### PR TITLE
Fixes for IE: Handling JS exceptions when browser is locked down

### DIFF
--- a/guacamole/src/main/webapp/scripts/guac-ui.js
+++ b/guacamole/src/main/webapp/scripts/guac-ui.js
@@ -187,20 +187,23 @@ GuacUI.Audio = new (function() {
     // Build array of supported audio formats
     codecs.forEach(function(mimetype) {
 
-        var audio = new Audio();
-        var support_level = audio.canPlayType(mimetype);
+        try {
+            var audio = new Audio();
+            var support_level = audio.canPlayType(mimetype);
 
-        // Trim semicolon and trailer
-        var semicolon = mimetype.indexOf(";");
-        if (semicolon != -1)
-            mimetype = mimetype.substring(0, semicolon);
+            // Trim semicolon and trailer
+            var semicolon = mimetype.indexOf(";");
+            if (semicolon != -1)
+                mimetype = mimetype.substring(0, semicolon);
 
-        // Partition by probably/maybe
-        if (support_level == "probably")
-            probably_supported.push(mimetype);
-        else if (support_level == "maybe")
-            maybe_supported.push(mimetype);
-
+            // Partition by probably/maybe
+            if (support_level == "probably")
+                probably_supported.push(mimetype);
+            else if (support_level == "maybe")
+                maybe_supported.push(mimetype);
+        } catch (ignore) {
+            // This happens on IE with Windows Server when audio is disabled.
+        }
     });
 
     // Add probably supported types first

--- a/guacamole/src/main/webapp/scripts/session.js
+++ b/guacamole/src/main/webapp/scripts/session.js
@@ -23,7 +23,12 @@
 /**
  * Global storage for Guacamole pages. 
  */
-GuacamoleSessionStorage = (opener && opener.GuacamoleSessionStorage) || new (function() {
+var existingGuacamoleSessionStorage;
+try {
+    existingGuacamoleSessionStorage = (opener && opener.GuacamoleSessionStorage);
+} catch (e) {
+}
+GuacamoleSessionStorage = (existingGuacamoleSessionStorage) || new (function() {
 
     /**
      * The contents of storage, as a JSON string containing name/value pairs as


### PR DESCRIPTION
- session storage using opener property works differently in IE, as it actually has "opener"
  but gets an exception accessing anything inside it (Not Permitted).
- on Windows Server, the Audio() constructor throws Not Available.

These changes fix issues running Guacamole client on a locked down IE browser, which is commonly found on Windows 2K8 server.  On such a configuration, Guacamole displays a blank screen and no error message.  I found and resolved these issues on a local build.
