### PR TITLE
Plug from the 404. The most frequently seen in IE

### DIFF
--- a/guacamole/src/main/webapp/null
+++ b/guacamole/src/main/webapp/null
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<HTML>
+    <HEAD>
+	<TITLE>Guacamole</TITLE>
+    </HEAD>
+<BODY>
+<p>Waiting for redirect...</p>
+</BODY>
+</HTML>


### PR DESCRIPTION
When you open a connection to the IE often seen this error. This fix is not only cosmetic, it allows the web server to unload logs from 404.

![screen](https://cloud.githubusercontent.com/assets/9342585/4726982/c9b252d0-5967-11e4-9c30-1d620542121b.png)
