### PR TITLE
GUAC-930: Add Swedish keymap to known parameter values.

### DIFF
--- a/guacamole-ext/src/main/resources/org/glyptodon/guacamole/protocols/rdp.xml
+++ b/guacamole-ext/src/main/resources/org/glyptodon/guacamole/protocols/rdp.xml
@@ -23,6 +23,7 @@
         <option value="en-us-qwerty">US English (Qwerty)</option>
         <option value="fr-fr-azerty">French (Azerty)</option>
         <option value="de-de-qwertz">German (Qwertz)</option>
+        <option value="sv-se-qwerty">Swedish (Qwerty)</option>
         <option value="failsafe">Unicode</option>
     </param>
 


### PR DESCRIPTION
Simply adds a new parameter value to RDP, such that users can select the new Swedish keyboard layout within the admin UI.
