### PR TITLE
GUAC-898: Send new display size to Guacamole when window size changes.

### DIFF
--- a/guacamole/src/main/webapp/app/client/directives/guacClient.js
+++ b/guacamole/src/main/webapp/app/client/directives/guacClient.js
@@ -431,9 +431,9 @@ angular.module('client').directive('guacClient', [function guacClient() {
                 // Send new display size, if changed
                 if (client && display) {
 
-                    var pixel_density = $window.devicePixelRatio || 1;
-                    var width  = main.offsetWidth  * pixel_density;
-                    var height = main.offsetHeight * pixel_density;
+                    var pixelDensity = $window.devicePixelRatio || 1;
+                    var width  = main.offsetWidth  * pixelDensity;
+                    var height = main.offsetHeight * pixelDensity;
 
                     if (display.getWidth() !== width || display.getHeight() !== height)
                         client.sendSize(width, height);


### PR DESCRIPTION
This change modifies the handling of the browser "resize" event, sending the new display dimensions to the Guacamole server, in addition to updating the local display scale.
