### PR TITLE
GUAC-978 Digest in progress error when loading connection in FF/Win7

### DIFF
--- a/guacamole/src/main/webapp/app/client/directives/guacClient.js
+++ b/guacamole/src/main/webapp/app/client/directives/guacClient.js
@@ -353,7 +353,7 @@ angular.module('client').directive('guacClient', [function guacClient() {
 
                 }
 
-                $scope.$apply(updateDisplayScale);
+                $scope.$evalAsync(updateDisplayScale);
 
             });
 


### PR DESCRIPTION
Use $evalAsync instead of $apply to avoid digest in progress error.