### PR TITLE
GUAC-980 Client does not properly size itself in Firefox

### DIFF
--- a/guacamole/src/main/webapp/app/client/styles/client.css
+++ b/guacamole/src/main/webapp/app/client/styles/client.css
@@ -48,6 +48,8 @@ body.client {
 
 .client-view .client-body {
     display: table-row;
+    width: 100%;
+    height: 100%;
 }
 
 .client-view .client-bottom {


### PR DESCRIPTION
Also need to set client-body to height 100% for it to work in Firefox