### PR TITLE
GUAC-981: Fix handling of errors. Fix handling of auto-reconnect.

### DIFF
--- a/guacamole/src/main/webapp/app/client/controllers/clientController.js
+++ b/guacamole/src/main/webapp/app/client/controllers/clientController.js
@@ -381,11 +381,12 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
     // Show status dialog when connection status changes
     $scope.$watch('client.clientState.connectionState', function clientStateChanged(connectionState) {
 
-        // Hide status if no known state
-        if (!connectionState) {
-            $scope.showStatus(false);
+        // Hide any existing status
+        $scope.showStatus(false);
+
+        // Do not display status if status not known
+        if (!connectionState)
             return;
-        }
 
         // Get any associated status code
         var status = $scope.client.clientState.statusCode;

--- a/guacamole/src/main/webapp/app/notification/directives/guacNotification.js
+++ b/guacamole/src/main/webapp/app/notification/directives/guacNotification.js
@@ -66,8 +66,8 @@ angular.module('notification').directive('guacNotification', [function guacNotif
                         $scope.timeRemaining--;
 
                         // Call countdown callback when time remaining expires
-                        if ($scope.timeRemaining === 0)
-                            countdown.performAction();
+                        if ($scope.timeRemaining === 0 && countdown.callback)
+                            countdown.callback();
 
                     }, 1000, $scope.timeRemaining);
 

--- a/guacamole/src/main/webapp/app/notification/types/NotificationAction.js
+++ b/guacamole/src/main/webapp/app/notification/types/NotificationAction.js
@@ -69,16 +69,6 @@ angular.module('notification').factory('NotificationAction', [function defineNot
          */
         this.callback = callback;
 
-        /**
-         * Calls the callback associated with this NotificationAction, if any.
-         * If no callback is associated with this NotificationAction, this
-         * function has no effect.
-         */
-        this.performAction = function performAction() {
-            if (action.callback)
-                action.callback();
-        };
-
     };
 
     return NotificationAction;

--- a/guacamole/src/main/webapp/app/notification/types/NotificationCountdown.js
+++ b/guacamole/src/main/webapp/app/notification/types/NotificationCountdown.js
@@ -72,16 +72,6 @@ angular.module('notification').factory('NotificationCountdown', [function define
          */
         this.callback = callback;
 
-        /**
-         * Calls the callback associated with this NotificationCountdown, if any.
-         * If no callback is associated with this NotificationCountdown, this
-         * function has no effect.
-         */
-        this.performAction = function performAction() {
-            if (countdown.callback)
-                countdown.callback();
-        };
-
     };
 
     return NotificationCountdown;


### PR DESCRIPTION
Errors during connect were not being shown because ```showStatus()``` will only have an effect if no status is currently visible. Automatic reconnect was failing because the countdown object provided was defined via a JavaScript object, not an instance of ```NotificationCountdown```, and thus lacked the ```performAction()``` function.