### PR TITLE
GUAC-982: Containing div of the OSK resize-sensor must have relative positioning.

### DIFF
--- a/guacamole/src/main/webapp/app/osk/styles/osk.css
+++ b/guacamole/src/main/webapp/app/osk/styles/osk.css
@@ -20,6 +20,10 @@
  * THE SOFTWARE.
  */
 
+.osk {
+    position: relative;
+}
+
 .osk .resize-sensor {
     height: 100%;
     width: 100%;


### PR DESCRIPTION
Without relative positioning, the resize sensor inside the div fills the entire screen, intercepting all mouse and touch events, possibly preventing the OSK from ever being hidden.