### PR TITLE
GUAC-975: Fix permission handling

### DIFF
--- a/guacamole/src/main/webapp/app/client/controllers/clientController.js
+++ b/guacamole/src/main/webapp/app/client/controllers/clientController.js
@@ -517,9 +517,6 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
 
         }
 
-        // Hide any status dialog
-        $scope.showStatus(false);
-
     });
 
 }]);

--- a/guacamole/src/main/webapp/app/home/controllers/homeController.js
+++ b/guacamole/src/main/webapp/app/home/controllers/homeController.js
@@ -52,6 +52,20 @@ angular.module('home').controller('homeController', ['$scope', '$injector',
      */
     $scope.canManageGuacamole = null;
 
+    /**
+     * Returns whether critical data has completed being loaded.
+     *
+     * @returns {Boolean}
+     *     true if enough data has been loaded for the user interface to be
+     *     useful, false otherwise.
+     */
+    $scope.isLoaded = function isLoaded() {
+
+        return $scope.rootConnectionGroup !== null
+            && $scope.canManageGuacamole  !== null;
+
+    };
+
     // Retrieve root group and all descendants
     connectionGroupService.getConnectionGroupTree(ConnectionGroup.ROOT_IDENTIFIER)
     .success(function rootGroupRetrieved(rootConnectionGroup) {

--- a/guacamole/src/main/webapp/app/home/templates/home.html
+++ b/guacamole/src/main/webapp/app/home/templates/home.html
@@ -23,19 +23,19 @@
 <div class="connection-list-ui">
 
     <div class="logout-panel">
-        <a class="manage button" ng-show="currentUserHasUpdate" href="#/manage">{{'HOME.ACTION_MANAGE' | translate}}</a>
+        <a class="manage button" ng-show="canManageGuacamole" href="#/manage">{{'HOME.ACTION_MANAGE' | translate}}</a>
         <a class="logout button" ng-click="logout()">{{'HOME.ACTION_LOGOUT' | translate}}</a>
     </div>
 
     <!-- The recent connections for this user -->
     <h2>{{'HOME.SECTION_HEADER_RECENT_CONNECTIONS' | translate}}</h2>
-    <div class="recent-connections" ng-class="{loading: loading}">
+    <div class="recent-connections" ng-class="{loading: !rootConnectionGroup}">
         <guac-recent-connections root-group="rootConnectionGroup"/>
     </div>
 
     <!-- All connections for this user -->
     <h2>{{'HOME.SECTION_HEADER_ALL_CONNECTIONS' | translate}}</h2>
-    <div class="all-connections" ng-class="{loading: loading}">
+    <div class="all-connections" ng-class="{loading: !rootConnectionGroup}">
         <guac-group-list
             connection-group="rootConnectionGroup"
             connection-template="'app/home/templates/connection.html'"

--- a/guacamole/src/main/webapp/app/home/templates/home.html
+++ b/guacamole/src/main/webapp/app/home/templates/home.html
@@ -20,26 +20,30 @@
    THE SOFTWARE.
 -->
 
-<div class="connection-list-ui">
+<div class="view" ng-class="{loading: !isLoaded()}">
 
-    <div class="logout-panel">
-        <a class="manage button" ng-show="canManageGuacamole" href="#/manage">{{'HOME.ACTION_MANAGE' | translate}}</a>
-        <a class="logout button" ng-click="logout()">{{'HOME.ACTION_LOGOUT' | translate}}</a>
-    </div>
+    <div class="connection-list-ui">
 
-    <!-- The recent connections for this user -->
-    <h2>{{'HOME.SECTION_HEADER_RECENT_CONNECTIONS' | translate}}</h2>
-    <div class="recent-connections" ng-class="{loading: !rootConnectionGroup}">
-        <guac-recent-connections root-group="rootConnectionGroup"/>
-    </div>
+        <div class="logout-panel">
+            <a class="manage button" ng-show="canManageGuacamole" href="#/manage">{{'HOME.ACTION_MANAGE' | translate}}</a>
+            <a class="logout button" ng-click="logout()">{{'HOME.ACTION_LOGOUT' | translate}}</a>
+        </div>
 
-    <!-- All connections for this user -->
-    <h2>{{'HOME.SECTION_HEADER_ALL_CONNECTIONS' | translate}}</h2>
-    <div class="all-connections" ng-class="{loading: !rootConnectionGroup}">
-        <guac-group-list
-            connection-group="rootConnectionGroup"
-            connection-template="'app/home/templates/connection.html'"
-            connection-group-template="'app/home/templates/connectionGroup.html'"/>
+        <!-- The recent connections for this user -->
+        <h2>{{'HOME.SECTION_HEADER_RECENT_CONNECTIONS' | translate}}</h2>
+        <div class="recent-connections">
+            <guac-recent-connections root-group="rootConnectionGroup"/>
+        </div>
+
+        <!-- All connections for this user -->
+        <h2>{{'HOME.SECTION_HEADER_ALL_CONNECTIONS' | translate}}</h2>
+        <div class="all-connections">
+            <guac-group-list
+                connection-group="rootConnectionGroup"
+                connection-template="'app/home/templates/connection.html'"
+                connection-group-template="'app/home/templates/connectionGroup.html'"/>
+        </div>
+
     </div>
 
 </div>

--- a/guacamole/src/main/webapp/app/index/controllers/indexController.js
+++ b/guacamole/src/main/webapp/app/index/controllers/indexController.js
@@ -26,16 +26,11 @@
 angular.module('index').controller('indexController', ['$scope', '$injector',
         function indexController($scope, $injector) {
 
-    // Required types
-    var PermissionSet = $injector.get("PermissionSet");
-
     // Required services
-    var $document               = $injector.get("$document");
-    var $location               = $injector.get("$location");
-    var $q                      = $injector.get("$q");
-    var $window                 = $injector.get("$window");
-    var authenticationService   = $injector.get("authenticationService");
-    var permissionService       = $injector.get("permissionService");
+    var $document             = $injector.get("$document");
+    var $location             = $injector.get("$location");
+    var $window               = $injector.get("$window");
+    var authenticationService = $injector.get("authenticationService");
     
     /**
      * The current status notification, or false if no status is currently
@@ -52,27 +47,35 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
      */
     $scope.notifications = [];
 
-    // Put some useful variables in the top level scope
+    /**
+     * Basic page-level information.
+     */
     $scope.page = {
+
+        /**
+         * The title of the page.
+         * 
+         * @type String
+         */
         title: '',
+
+        /**
+         * The name of the CSS class to apply to the page body, if any.
+         *
+         * @type String
+         */
         bodyClassName: ''
+
     };
-    $scope.currentUserID = null;
-    $scope.currentUserIsAdmin = false;
-    $scope.currentUserHasUpdate = false;
-    $scope.currentUserPermissions = null;
+
+    /**
+     * The ID of the most recently shown notification, or 0 if no notifications
+     * have yet been shown.
+     *
+     * @type Number
+     */
     var notificationUniqueID = 0;
     
-    // A promise to be fulfilled when all basic user permissions are loaded.
-    var permissionsLoaded= $q.defer();
-    $scope.basicPermissionsLoaded = permissionsLoaded.promise;
-    
-    $scope.currentUserID = authenticationService.getCurrentUserID();
-    
-    // If the user is unknown, force a login
-    if(!$scope.currentUserID)
-        $location.path('/login');
-
     /**
      * Shows or hides the given notification as a modal status. If a status
      * notification is currently shown, no further statuses will be shown
@@ -150,25 +153,6 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
         }
     };
            
-    // Allow the permissions to be reloaded elsewhere if needed
-    $scope.loadBasicPermissions = function loadBasicPermissions() {
-        
-        permissionService.getPermissions($scope.currentUserID).success(function fetchCurrentUserPermissions(permissions) {
-            $scope.currentUserPermissions = permissions;
-
-            // Whether the user has system-wide admin permission
-            $scope.currentUserIsAdmin = PermissionSet.hasSystemPermission($scope.currentUserPermissions, PermissionSet.SystemPermissionType.ADMINISTER);
-
-            // Whether the user can update at least one object
-            $scope.currentUserHasUpdate = $scope.currentUserIsAdmin
-                                        || PermissionSet.hasConnectionPermission($scope.currentUserPermissions, "UPDATE")
-                                        || PermissionSet.hasConnectionGroupPermission($scope.currentUserPermissions, "UPDATE")
-                                        || PermissionSet.hasUserPermission($scope.currentUserPermissions, "UPDATE");
-
-            permissionsLoaded.resolve();
-        });
-    };
-
     // Provide simple mechanism for logging out the current user
     $scope.logout = function logout() {
         authenticationService.logout()['finally'](function logoutComplete() {
@@ -176,9 +160,6 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
         });
     };
     
-    // Try to load them now
-    $scope.loadBasicPermissions();
-
     // Create event listeners at the global level
     var keyboard = new Guacamole.Keyboard($document[0]);
 

--- a/guacamole/src/main/webapp/app/index/controllers/indexController.js
+++ b/guacamole/src/main/webapp/app/index/controllers/indexController.js
@@ -198,11 +198,16 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
     // Update title and CSS class upon navigation
     $scope.$on('$routeChangeSuccess', function(event, current, previous) {
 
+        // Set title
         var title = current.$$route.title;
         if (title)
             $scope.page.title = title;
 
+        // Set body CSS class
         $scope.page.bodyClassName = current.$$route.bodyClassName || '';
+
+        // Hide any status dialog
+        $scope.showStatus(false);
 
     });
 

--- a/guacamole/src/main/webapp/app/index/styles/loading.css
+++ b/guacamole/src/main/webapp/app/index/styles/loading.css
@@ -25,6 +25,14 @@
     min-height: 200px;
 }
 
+.view.loading {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
 .loading * {
     visibility: hidden;
 }

--- a/guacamole/src/main/webapp/app/login/controllers/loginController.js
+++ b/guacamole/src/main/webapp/app/login/controllers/loginController.js
@@ -52,8 +52,6 @@ angular.module('login').controller('loginController', ['$scope', '$injector',
 
         // Redirect to main view upon success
         .success(function success(data, status, headers, config) {
-            // Set up the basic permissions for the user
-            $scope.loadBasicPermissions();
             $location.path('/');
         })
 

--- a/guacamole/src/main/webapp/app/manage/controllers/manageConnectionController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageConnectionController.js
@@ -60,6 +60,59 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
      */
     var identifier = $routeParams.id;
 
+    /**
+     * All known protocols.
+     *
+     * @type Object.<String, Protocol>
+     */
+    $scope.protocols = null;
+
+    /**
+     * The root connection group of the connection group hierarchy.
+     *
+     * @type ConnectionGroup
+     */
+    $scope.rootGroup = null;
+
+    /**
+     * The connection being modified.
+     * 
+     * @type Connection
+     */
+    $scope.connection = null;
+
+    /**
+     * The parameter name/value pairs associated with the connection being
+     * modified.
+     *
+     * @type Object.<String, String>
+     */
+    $scope.parameters = null;
+
+    /**
+     * The usage history of the connection being modified.
+     *
+     * @type HistoryEntryWrapper[]
+     */
+    $scope.historyEntryWrappers = null;
+
+    /**
+     * Returns whether critical data has completed being loaded.
+     *
+     * @returns {Boolean}
+     *     true if enough data has been loaded for the user interface to be
+     *     useful, false otherwise.
+     */
+    $scope.isLoaded = function isLoaded() {
+
+        return $scope.protocols            !== null
+            && $scope.rootGroup            !== null
+            && $scope.connection           !== null
+            && $scope.parameters           !== null
+            && $scope.historyEntryWrappers !== null;
+
+    };
+
     // Pull connection group hierarchy
     connectionGroupService.getConnectionGroupTree(ConnectionGroup.ROOT_IDENTIFIER, PermissionSet.ObjectPermissionType.UPDATE)
     .success(function connectionGroupReceived(rootGroup) {

--- a/guacamole/src/main/webapp/app/manage/controllers/manageConnectionGroupController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageConnectionGroupController.js
@@ -55,6 +55,35 @@ angular.module('manage').controller('manageConnectionGroupController', ['$scope'
      */
     var identifier = $routeParams.id;
 
+    /**
+     * The root connection group of the connection group hierarchy.
+     *
+     * @type ConnectionGroup
+     */
+    $scope.rootGroup = null;
+
+    /**
+     * The connection group being modified.
+     * 
+     * @type ConnectionGroup
+     */
+    $scope.connectionGroup = null;
+
+    /**
+     * Returns whether critical data has completed being loaded.
+     *
+     * @returns {Boolean}
+     *     true if enough data has been loaded for the user interface to be
+     *     useful, false otherwise.
+     */
+    $scope.isLoaded = function isLoaded() {
+
+        return $scope.rootGroup       !== null
+            && $scope.connectionGroup !== null;
+
+    };
+
+
     // Pull connection group hierarchy
     connectionGroupService.getConnectionGroupTree(ConnectionGroup.ROOT_IDENTIFIER, PermissionSet.ObjectPermissionType.UPDATE)
     .success(function connectionGroupReceived(rootGroup) {

--- a/guacamole/src/main/webapp/app/manage/controllers/manageUserController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageUserController.js
@@ -57,6 +57,42 @@ angular.module('manage').controller('manageUserController', ['$scope', '$injecto
      */
     var username = $routeParams.id;
 
+    /**
+     * The user being modified.
+     *
+     * @type User
+     */
+    $scope.user = null;
+
+    /**
+     * All permissions associated with the user being modified.
+     * 
+     * @type PermissionFlagSet
+     */
+    $scope.permissionFlags = null;
+
+    /**
+     * The root connection group of the connection group hierarchy.
+     *
+     * @type ConnectionGroup
+     */
+    $scope.rootGroup = null;
+
+    /**
+     * Returns whether critical data has completed being loaded.
+     *
+     * @returns {Boolean}
+     *     true if enough data has been loaded for the user interface to be
+     *     useful, false otherwise.
+     */
+    $scope.isLoaded = function isLoaded() {
+
+        return $scope.user            !== null
+            && $scope.permissionFlags !== null
+            && $scope.rootGroup       !== null;
+
+    };
+
     // Pull user data
     userService.getUser(username).success(function userReceived(user) {
         $scope.user = user;

--- a/guacamole/src/main/webapp/app/manage/templates/manage.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manage.html
@@ -26,7 +26,7 @@ THE SOFTWARE.
 </div>
 
 <h2>{{'MANAGE.SECTION_HEADER_ADMINISTRATION' | translate}}</h2>
-<div ng-show="currentUserHasUpdate" class="settings section">
+<div class="settings section">
 
     <h3 class="require-manage-users">{{'MANAGE.SECTION_HEADER_USERS' | translate}}</h3>
     <div class="require-manage-users users">

--- a/guacamole/src/main/webapp/app/manage/templates/manage.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manage.html
@@ -20,53 +20,67 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
-<div class="logout-panel">
-    <a class="home button" href="#/">{{'MANAGE.ACTION_NAVIGATE_HOME' | translate}}</a>
-    <a class="logout button" ng-click="logout()">{{'MANAGE.ACTION_LOGOUT' | translate}}</a>
-</div>
+<div class="view" ng-class="{loading: !isLoaded()}">
 
-<h2>{{'MANAGE.SECTION_HEADER_ADMINISTRATION' | translate}}</h2>
-<div class="settings section">
+    <div class="logout-panel">
+        <a class="home button" href="#/">{{'MANAGE.ACTION_NAVIGATE_HOME' | translate}}</a>
+        <a class="logout button" ng-click="logout()">{{'MANAGE.ACTION_LOGOUT' | translate}}</a>
+    </div>
 
-    <h3 class="require-manage-users">{{'MANAGE.SECTION_HEADER_USERS' | translate}}</h3>
-    <div class="require-manage-users users">
+    <h2>{{'MANAGE.SECTION_HEADER_ADMINISTRATION' | translate}}</h2>
 
-        <p>{{'MANAGE.HELP_USERS' | translate}}</p>
+    <!-- User management -->
+    <div class="settings section" ng-show="canManageUsers">
+        <h3>{{'MANAGE.SECTION_HEADER_USERS' | translate}}</h3>
+        <div class="users">
 
-        <!-- Control to create a new user -->
-        <div class="user-add-form">
-            <input type="text" ng-model="newUsername" class="name username" autocorrect="off" autocapitalize="off"/>
-            <button class="add-user" ng-click="newUser()">{{'MANAGE.ACTION_NEW_USER' | translate}}</button>
-        </div>
+            <p>{{'MANAGE.HELP_USERS' | translate}}</p>
 
-        <!-- List of users this user has access to -->
-        <div class="user-list" ng-class="{loading: !users}">
-            <div ng-repeat="user in users | orderBy : 'username'" class="user list-item">
-                <div class="caption">
-                    <div class="icon user"></div>
-                    <a class="name" ng-href="#/manage/users/{{user.username}}">{{user.username}}</a>
+            <!-- User creation form -->
+            <div class="user-add-form" ng-show="canCreateUsers">
+                <input type="text" ng-model="newUsername" class="name username" autocorrect="off" autocapitalize="off"/>
+                <button class="add-user" ng-click="newUser()">{{'MANAGE.ACTION_NEW_USER' | translate}}</button>
+            </div>
+
+            <!-- List of users this user has access to -->
+            <div class="user-list">
+                <div ng-repeat="user in users | orderBy : 'username'" class="user list-item">
+                    <div class="caption">
+                        <div class="icon user"></div>
+                        <a class="name" ng-href="#/manage/users/{{user.username}}">{{user.username}}</a>
+                    </div>
                 </div>
             </div>
         </div>
     </div>
 
-    <h3 class="require-manage-connections">{{'MANAGE.SECTION_HEADER_CONNECTIONS' | translate}}</h3>
-    <div class="require-manage-connections connections">
+    <!-- Connection management -->
+    <div class="settings section" ng-show="canManageConnections">
+        <h3>{{'MANAGE.SECTION_HEADER_CONNECTIONS' | translate}}</h3>
+        <div class="connections">
 
-        <p>{{'MANAGE.HELP_CONNECTIONS' | translate}}</p>
+            <p>{{'MANAGE.HELP_CONNECTIONS' | translate}}</p>
 
-        <!-- Control to create a new connection or group -->
-        <div class="connection-add-form">
-            <a class="add-connection button" href="#/manage/connections/">{{'MANAGE.ACTION_NEW_CONNECTION' | translate}}</a>
-            <a class="add-connection-group button" href="#/manage/connectionGroups/">{{'MANAGE.ACTION_NEW_CONNECTION_GROUP' | translate}}</a>
-        </div>
+            <!-- Connection/group creation buttons -->
+            <div class="connection-add-form">
 
-        <!-- List of connections and groups this user has access to -->
-        <div class="connection-list" ng-class="{loading: !rootGroup}">
-            <guac-group-list
-                connection-group="rootGroup"
-                connection-template="'app/manage/templates/connection.html'"
-                connection-group-template="'app/manage/templates/connectionGroup.html'"/>
+                <a class="add-connection button"
+                   ng-show="canCreateConnections"
+                   href="#/manage/connections/">{{'MANAGE.ACTION_NEW_CONNECTION' | translate}}</a>
+
+                <a class="add-connection-group button"
+                   ng-show="canCreateConnectionGroups"
+                   href="#/manage/connectionGroups/">{{'MANAGE.ACTION_NEW_CONNECTION_GROUP' | translate}}</a>
+
+            </div>
+
+            <!-- List of accessible connections and groups -->
+            <div class="connection-list">
+                <guac-group-list
+                    connection-group="rootGroup"
+                    connection-template="'app/manage/templates/connection.html'"
+                    connection-group-template="'app/manage/templates/connectionGroup.html'"/>
+            </div>
         </div>
     </div>
 

--- a/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
@@ -20,83 +20,87 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
-<div class="logout-panel">
-    <a class="back button" href="#/manage/">{{'MANAGE_CONNECTION.ACTION_NAVIGATE_BACK' | translate}}</a>
-    <a class="logout button" ng-click="logout()">{{'MANAGE_CONNECTION.ACTION_LOGOUT' | translate}}</a>
-</div>
+<div class="view" ng-class="{loading: !isLoaded()}">
 
-<!-- Main property editor -->
-<h2>{{'MANAGE_CONNECTION.SECTION_HEADER_EDIT_CONNECTION' | translate}}</h2>
-<div class="section">
-    <table class="properties">
-        
-        <!-- Edit connection name -->
-        <tr>
-            <th>{{'MANAGE_CONNECTION.FIELD_HEADER_NAME' | translate}}</th>
-          
-            <td><input type="text" ng-model="connection.name" autocorrect="off" autocapitalize="off"/></td>
-        </tr>
-        
-        <!-- Edit connection location -->
-        <tr>
-            <th>{{'MANAGE_CONNECTION.FIELD_HEADER_LOCATION' | translate}}</th>
-          
-            <td>
-                <location-chooser value="connection.parentIdentifier" root-group="rootGroup"></location-chooser>
-            </td>
-        </tr>
-        
-        
-        <!-- Edit connection protocol -->
-        <tr>
-            <th>{{'MANAGE_CONNECTION.FIELD_HEADER_PROTOCOL' | translate}}</th>
-            <td>
-                <select ng-model="connection.protocol" ng-options="name as getProtocolName(protocol.name) | translate for (name, protocol) in protocols | orderBy: name"></select>
-            </td>
-        </tr>
-    </table>
-</div>
+    <div class="logout-panel">
+        <a class="back button" href="#/manage/">{{'MANAGE_CONNECTION.ACTION_NAVIGATE_BACK' | translate}}</a>
+        <a class="logout button" ng-click="logout()">{{'MANAGE_CONNECTION.ACTION_LOGOUT' | translate}}</a>
+    </div>
 
-<!-- Connection parameters -->
-<h2>{{'MANAGE_CONNECTION.SECTION_HEADER_PARAMETERS' | translate}}</h2>
-<div class="section" ng-class="{loading: !parameters}">
-    <table class="properties">
-        
-        <!-- All the different possible editable field types -->
-        <tr ng-repeat="parameter in protocols[connection.protocol].parameters">
-            <th>{{getProtocolParameterName(connection.protocol, parameter.name) | translate}}</th>
-            <td>
-                <guac-connection-parameter protocol="protocols[connection.protocol]" name="parameter.name" parameters="parameters"/>
-            </td>
-        </tr>
-    </table>
-</div>
-
-<!-- Form action buttons -->
-<div class="action-buttons">
-    <button ng-click="saveConnection()">{{'MANAGE_CONNECTION.ACTION_SAVE' | translate}}</button>
-    <button ng-click="cancel()">{{'MANAGE_CONNECTION.ACTION_CANCEL' | translate}}</button>
-    <button ng-click="deleteConnection()" class="danger">{{'MANAGE_CONNECTION.ACTION_DELETE' | translate}}</button>
-</div>
-
-<!-- Connection history -->
-<h2>{{'MANAGE_CONNECTION.SECTION_HEADER_HISTORY' | translate}}</h2>
-<div class="history section" ng-class="{loading: !historyEntryWrappers}">
-    <p ng-hide="historyEntryWrappers.length">{{'MANAGE_CONNECTION.INFO_CONNECTION_NOT_USED' | translate}}</p>
-    <table ng-show="historyEntryWrappers.length">
-        <thead>
+    <!-- Main property editor -->
+    <h2>{{'MANAGE_CONNECTION.SECTION_HEADER_EDIT_CONNECTION' | translate}}</h2>
+    <div class="section">
+        <table class="properties">
+            
+            <!-- Edit connection name -->
             <tr>
-                <th>{{'MANAGE_CONNECTION.TABLE_HEADER_HISTORY_USERNAME' | translate}}</th>
-                <th>{{'MANAGE_CONNECTION.TABLE_HEADER_HISTORY_START' | translate}}</th>
-                <th>{{'MANAGE_CONNECTION.TABLE_HEADER_HISTORY_DURATION' | translate}}</th>
+                <th>{{'MANAGE_CONNECTION.FIELD_HEADER_NAME' | translate}}</th>
+              
+                <td><input type="text" ng-model="connection.name" autocorrect="off" autocapitalize="off"/></td>
             </tr>
-        </thead>
-        <tbody>
-            <tr ng-repeat="wrapper in historyEntryWrappers">
-                <td class="username">{{wrapper.entry.username}}</td>
-                <td class="start">{{wrapper.entry.startDate | date:'short'}}</td>
-                <td class="duration">{{wrapper.durationText | translate:"{VALUE: wrapper.duration.value, UNIT: wrapper.duration.unit}"}}</td>
+            
+            <!-- Edit connection location -->
+            <tr>
+                <th>{{'MANAGE_CONNECTION.FIELD_HEADER_LOCATION' | translate}}</th>
+              
+                <td>
+                    <location-chooser value="connection.parentIdentifier" root-group="rootGroup"></location-chooser>
+                </td>
             </tr>
-        </tbody>
-    </table>
+            
+            
+            <!-- Edit connection protocol -->
+            <tr>
+                <th>{{'MANAGE_CONNECTION.FIELD_HEADER_PROTOCOL' | translate}}</th>
+                <td>
+                    <select ng-model="connection.protocol" ng-options="name as getProtocolName(protocol.name) | translate for (name, protocol) in protocols | orderBy: name"></select>
+                </td>
+            </tr>
+        </table>
+    </div>
+
+    <!-- Connection parameters -->
+    <h2>{{'MANAGE_CONNECTION.SECTION_HEADER_PARAMETERS' | translate}}</h2>
+    <div class="section" ng-class="{loading: !parameters}">
+        <table class="properties">
+            
+            <!-- All the different possible editable field types -->
+            <tr ng-repeat="parameter in protocols[connection.protocol].parameters">
+                <th>{{getProtocolParameterName(connection.protocol, parameter.name) | translate}}</th>
+                <td>
+                    <guac-connection-parameter protocol="protocols[connection.protocol]" name="parameter.name" parameters="parameters"/>
+                </td>
+            </tr>
+        </table>
+    </div>
+
+    <!-- Form action buttons -->
+    <div class="action-buttons">
+        <button ng-click="saveConnection()">{{'MANAGE_CONNECTION.ACTION_SAVE' | translate}}</button>
+        <button ng-click="cancel()">{{'MANAGE_CONNECTION.ACTION_CANCEL' | translate}}</button>
+        <button ng-click="deleteConnection()" class="danger">{{'MANAGE_CONNECTION.ACTION_DELETE' | translate}}</button>
+    </div>
+
+    <!-- Connection history -->
+    <h2>{{'MANAGE_CONNECTION.SECTION_HEADER_HISTORY' | translate}}</h2>
+    <div class="history section" ng-class="{loading: !historyEntryWrappers}">
+        <p ng-hide="historyEntryWrappers.length">{{'MANAGE_CONNECTION.INFO_CONNECTION_NOT_USED' | translate}}</p>
+        <table ng-show="historyEntryWrappers.length">
+            <thead>
+                <tr>
+                    <th>{{'MANAGE_CONNECTION.TABLE_HEADER_HISTORY_USERNAME' | translate}}</th>
+                    <th>{{'MANAGE_CONNECTION.TABLE_HEADER_HISTORY_START' | translate}}</th>
+                    <th>{{'MANAGE_CONNECTION.TABLE_HEADER_HISTORY_DURATION' | translate}}</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr ng-repeat="wrapper in historyEntryWrappers">
+                    <td class="username">{{wrapper.entry.username}}</td>
+                    <td class="start">{{wrapper.entry.startDate | date:'short'}}</td>
+                    <td class="duration">{{wrapper.durationText | translate:"{VALUE: wrapper.duration.value, UNIT: wrapper.duration.unit}"}}</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
 </div>

--- a/guacamole/src/main/webapp/app/manage/templates/manageConnectionGroup.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageConnectionGroup.html
@@ -20,46 +20,50 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
-<div class="logout-panel">
-    <a class="back button" href="#/manage/">{{'MANAGE_CONNECTION_GROUP.ACTION_NAVIGATE_BACK' | translate}}</a>
-    <a class="logout button" ng-click="logout()">{{'MANAGE_CONNECTION_GROUP.ACTION_LOGOUT' | translate}}</a>
-</div>
+<div class="view" ng-class="{loading: !isLoaded()}">
 
-<!-- Main property editor -->
-<h2>{{'MANAGE_CONNECTION_GROUP.SECTION_HEADER_EDIT_CONNECTION_GROUP' | translate}}</h2>
-<div class="section">
-    <table class="properties">
-                    
-        <!-- Edit connection group name -->
-        <tr>
-            <th>{{'MANAGE_CONNECTION_GROUP.FIELD_HEADER_NAME' | translate}}</th>
-                      
-            <td><input type="text" ng-model="connectionGroup.name" autocorrect="off" autocapitalize="off"/></td>
-        </tr>
-                    
-        <!-- Edit connection group location -->
-        <tr>
-            <th>{{'MANAGE_CONNECTION_GROUP.FIELD_HEADER_LOCATION' | translate}}</th>
-                      
-            <td>
-                <location-chooser value="connectionGroup.parentIdentifier" root-group="rootGroup"/>
-            </td>
-        </tr>
-                    
-                    
-        <!-- Edit connection group type -->
-        <tr>
-            <th>{{'MANAGE_CONNECTION_GROUP.FIELD_HEADER_TYPE' | translate}}</th>
-            <td>
-                <select ng-model="connectionGroup.type" ng-options="type.value as type.label | translate for type in types | orderBy: name"></select>
-            </td>
-        </tr>
-    </table>
-</div>
+    <div class="logout-panel">
+        <a class="back button" href="#/manage/">{{'MANAGE_CONNECTION_GROUP.ACTION_NAVIGATE_BACK' | translate}}</a>
+        <a class="logout button" ng-click="logout()">{{'MANAGE_CONNECTION_GROUP.ACTION_LOGOUT' | translate}}</a>
+    </div>
 
-<!-- Form action buttons -->
-<div class="action-buttons">
-    <button ng-click="saveConnectionGroup()">{{'MANAGE_CONNECTION_GROUP.ACTION_SAVE' | translate}}</button>
-    <button ng-click="cancel()">{{'MANAGE_CONNECTION_GROUP.ACTION_CANCEL' | translate}}</button>
-    <button ng-click="deleteConnectionGroup()" class="danger">{{'MANAGE_CONNECTION_GROUP.ACTION_DELETE' | translate}}</button>
+    <!-- Main property editor -->
+    <h2>{{'MANAGE_CONNECTION_GROUP.SECTION_HEADER_EDIT_CONNECTION_GROUP' | translate}}</h2>
+    <div class="section">
+        <table class="properties">
+                        
+            <!-- Edit connection group name -->
+            <tr>
+                <th>{{'MANAGE_CONNECTION_GROUP.FIELD_HEADER_NAME' | translate}}</th>
+                          
+                <td><input type="text" ng-model="connectionGroup.name" autocorrect="off" autocapitalize="off"/></td>
+            </tr>
+                        
+            <!-- Edit connection group location -->
+            <tr>
+                <th>{{'MANAGE_CONNECTION_GROUP.FIELD_HEADER_LOCATION' | translate}}</th>
+                          
+                <td>
+                    <location-chooser value="connectionGroup.parentIdentifier" root-group="rootGroup"/>
+                </td>
+            </tr>
+                        
+                        
+            <!-- Edit connection group type -->
+            <tr>
+                <th>{{'MANAGE_CONNECTION_GROUP.FIELD_HEADER_TYPE' | translate}}</th>
+                <td>
+                    <select ng-model="connectionGroup.type" ng-options="type.value as type.label | translate for type in types | orderBy: name"></select>
+                </td>
+            </tr>
+        </table>
+    </div>
+
+    <!-- Form action buttons -->
+    <div class="action-buttons">
+        <button ng-click="saveConnectionGroup()">{{'MANAGE_CONNECTION_GROUP.ACTION_SAVE' | translate}}</button>
+        <button ng-click="cancel()">{{'MANAGE_CONNECTION_GROUP.ACTION_CANCEL' | translate}}</button>
+        <button ng-click="deleteConnectionGroup()" class="danger">{{'MANAGE_CONNECTION_GROUP.ACTION_DELETE' | translate}}</button>
+    </div>
+
 </div>

--- a/guacamole/src/main/webapp/app/manage/templates/manageUser.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageUser.html
@@ -20,58 +20,62 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
-<div class="logout-panel">
-    <a class="back button" href="#/manage/">{{'MANAGE_USER.ACTION_NAVIGATE_BACK' | translate}}</a>
-    <a class="logout button" ng-click="logout()">{{'MANAGE_USER.ACTION_LOGOUT' | translate}}</a>
-</div>
+<div class="view" ng-class="{loading: !isLoaded()}">
 
-<!-- Main property editor -->
-<h2>{{'MANAGE_USER.SECTION_HEADER_EDIT_USER' | translate}}</h2>
-<div class="section">
-    <table class="properties">
-        <tr>
-            <th>{{'MANAGE_USER.FIELD_HEADER_USERNAME' | translate}}</th>
-                      
-            <td>{{user.username}}</td>
-        </tr>
-        <tr>
-            <th>{{'MANAGE_USER.FIELD_HEADER_PASSWORD' | translate}}</th>
-                        
-            <td><input ng-model="user.password" type="password" /></td>
-        </tr>
-        <tr>
-            <th>{{'MANAGE_USER.FIELD_HEADER_PASSWORD_AGAIN' | translate}}</th>
-                        
-            <td><input ng-model="passwordMatch" type="password" /></td>
-        </tr>
-    </table>
-</div>
+    <div class="logout-panel">
+        <a class="back button" href="#/manage/">{{'MANAGE_USER.ACTION_NAVIGATE_BACK' | translate}}</a>
+        <a class="logout button" ng-click="logout()">{{'MANAGE_USER.ACTION_LOGOUT' | translate}}</a>
+    </div>
 
-<!-- System permissions section -->
-<h2>{{'MANAGE_USER.SECTION_HEADER_PERMISSIONS' | translate}}</h2>
-<div class="section">
-    <table class="properties">
-        <tr ng-repeat="systemPermissionType in systemPermissionTypes">
-            <th>{{systemPermissionType.label | translate}}</th>
-            <td><input type="checkbox" ng-model="permissionFlags.systemPermissions[systemPermissionType.value]"
-                                       ng-change="systemPermissionChanged(systemPermissionType.value)"/></td>
-        </tr>
-    </table>
-</div>
-    
-<!-- Connection and connection group permission section -->
-<h2>{{'MANAGE_USER.SECTION_HEADER_CONNECTIONS' | translate}}</h2>
-<div class="section" ng-class="{loading: !rootGroup}">
-    <guac-group-list
-        context="groupListContext"
-        connection-group="rootGroup"
-        connection-template="'app/manage/templates/connectionPermission.html'"
-        connection-group-template="'app/manage/templates/connectionGroupPermission.html'"/>
-</div>
+    <!-- Main property editor -->
+    <h2>{{'MANAGE_USER.SECTION_HEADER_EDIT_USER' | translate}}</h2>
+    <div class="section">
+        <table class="properties">
+            <tr>
+                <th>{{'MANAGE_USER.FIELD_HEADER_USERNAME' | translate}}</th>
+                          
+                <td>{{user.username}}</td>
+            </tr>
+            <tr>
+                <th>{{'MANAGE_USER.FIELD_HEADER_PASSWORD' | translate}}</th>
+                            
+                <td><input ng-model="user.password" type="password" /></td>
+            </tr>
+            <tr>
+                <th>{{'MANAGE_USER.FIELD_HEADER_PASSWORD_AGAIN' | translate}}</th>
+                            
+                <td><input ng-model="passwordMatch" type="password" /></td>
+            </tr>
+        </table>
+    </div>
 
-<!-- Form action buttons -->
-<div class="action-buttons">
-    <button ng-click="saveUser()">{{'MANAGE_USER.ACTION_SAVE' | translate}}</button>
-    <button ng-click="cancel()">{{'MANAGE_USER.ACTION_CANCEL' | translate}}</button>
-    <button ng-click="deleteUser()" class="danger">{{'MANAGE_USER.ACTION_DELETE' | translate}}</button>
+    <!-- System permissions section -->
+    <h2>{{'MANAGE_USER.SECTION_HEADER_PERMISSIONS' | translate}}</h2>
+    <div class="section">
+        <table class="properties">
+            <tr ng-repeat="systemPermissionType in systemPermissionTypes">
+                <th>{{systemPermissionType.label | translate}}</th>
+                <td><input type="checkbox" ng-model="permissionFlags.systemPermissions[systemPermissionType.value]"
+                                           ng-change="systemPermissionChanged(systemPermissionType.value)"/></td>
+            </tr>
+        </table>
+    </div>
+        
+    <!-- Connection and connection group permission section -->
+    <h2>{{'MANAGE_USER.SECTION_HEADER_CONNECTIONS' | translate}}</h2>
+    <div class="section" ng-class="{loading: !rootGroup}">
+        <guac-group-list
+            context="groupListContext"
+            connection-group="rootGroup"
+            connection-template="'app/manage/templates/connectionPermission.html'"
+            connection-group-template="'app/manage/templates/connectionGroupPermission.html'"/>
+    </div>
+
+    <!-- Form action buttons -->
+    <div class="action-buttons">
+        <button ng-click="saveUser()">{{'MANAGE_USER.ACTION_SAVE' | translate}}</button>
+        <button ng-click="cancel()">{{'MANAGE_USER.ACTION_CANCEL' | translate}}</button>
+        <button ng-click="deleteUser()" class="danger">{{'MANAGE_USER.ACTION_DELETE' | translate}}</button>
+    </div>
+
 </div>


### PR DESCRIPTION
This change removes the caching of permissions from the index controller, explicitly loads permissions wherever needed, and delays display of UI components until most data is loaded (the "manage" button may appear after a delay otherwise).

As it became a nuisance while fixing this, I've also modified the handling of routing events such that status dialogs are *always* hidden upon navigation.