### PR TITLE
GUAC-964: Ensure connections and connection groups only refer to the root group as "ROOT"

### DIFF
--- a/extensions/guacamole-auth-mysql/src/main/java/net/sourceforge/guacamole/net/auth/mysql/MySQLConnection.java
+++ b/extensions/guacamole-auth-mysql/src/main/java/net/sourceforge/guacamole/net/auth/mysql/MySQLConnection.java
@@ -108,7 +108,7 @@ public class MySQLConnection extends AbstractConnection {
         if (parentID != null)
             this.setParentIdentifier(String.valueOf(parentID));
         else
-            this.setParentIdentifier(null);
+            this.setParentIdentifier(MySQLConstants.CONNECTION_GROUP_ROOT_IDENTIFIER);
 
     }
 

--- a/extensions/guacamole-auth-mysql/src/main/java/net/sourceforge/guacamole/net/auth/mysql/MySQLConnectionGroup.java
+++ b/extensions/guacamole-auth-mysql/src/main/java/net/sourceforge/guacamole/net/auth/mysql/MySQLConnectionGroup.java
@@ -129,7 +129,7 @@ public class MySQLConnectionGroup extends AbstractConnectionGroup {
         if (parentID != null)
             this.setParentIdentifier(String.valueOf(parentID));
         else
-            this.setParentIdentifier(null);
+            this.setParentIdentifier(MySQLConstants.CONNECTION_GROUP_ROOT_IDENTIFIER);
 
     }
 

--- a/guacamole/src/main/webapp/app/manage/controllers/manageController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageController.js
@@ -50,6 +50,20 @@ angular.module('manage').controller('manageController', ['$scope', '$injector',
     };
 
     /**
+     * All visible users.
+     *
+     * @type User[]
+     */
+    $scope.users = null;
+
+    /**
+     * The root connection group of the connection group hierarchy.
+     *
+     * @type ConnectionGroup
+     */
+    $scope.rootGroup = null;
+
+    /**
      * Whether the current user can manage users. If the current permissions
      * have not yet been loaded, this will be null.
      *


### PR DESCRIPTION
This change modifies the MySQL auth such that it consistently uses its own "ROOT" identifier to refer to the root connection group. It doesn't matter whether a particular auth provider uses "ROOT" to refer to the root group, but whatever identifier it uses must be consistent.

Prior to this change, the MySQL auth would return ```null``` as the parent identifier of connections in root, while also rejecting ```null``` when used to search for connection groups.

This change also fixes an issue in the initialization of ```$scope``` variables in the manage controller, noticed during testing.