### PR TITLE
GUAC-971: Restore secondary authentication

### DIFF
--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/GuacamoleSession.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/GuacamoleSession.java
@@ -53,12 +53,12 @@ public class GuacamoleSession {
     /**
      * The credentials provided when the user logged in.
      */
-    private final Credentials credentials;
+    private Credentials credentials;
     
     /**
      * The user context associated with this session.
      */
-    private final UserContext userContext;
+    private UserContext userContext;
 
     /**
      * Collection of all event listeners configured in guacamole.properties.
@@ -149,6 +149,17 @@ public class GuacamoleSession {
     }
 
     /**
+     * Replaces the credentials associated with this session with the given
+     * credentials.
+     *
+     * @param credentials
+     *     The credentials to associate with this session.
+     */
+    public void setCredentials(Credentials credentials) {
+        this.credentials = credentials;
+    }
+    
+    /**
      * Returns the UserContext associated with this session.
      *
      * @return The UserContext associated with this session.
@@ -157,6 +168,17 @@ public class GuacamoleSession {
         return userContext;
     }
 
+    /**
+     * Replaces the user context associated with this session with the given
+     * user context.
+     *
+     * @param userContext
+     *     The user context to associate with this session.
+     */
+    public void setUserContext(UserContext userContext) {
+        this.userContext = userContext;
+    }
+    
     /**
      * Returns the ClipboardState associated with this session.
      *

--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/GuacamoleSession.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/GuacamoleSession.java
@@ -51,7 +51,7 @@ public class GuacamoleSession {
     private static final Logger logger = LoggerFactory.getLogger(GuacamoleSession.class);
 
     /**
-     * The credentials provided when the user logged in.
+     * The credentials provided when the user authenticated.
      */
     private Credentials credentials;
     
@@ -139,10 +139,11 @@ public class GuacamoleSession {
 
     /**
      * Returns the credentials used when the user associated with this session
-     * logged in.
+     * authenticated.
      *
-     * @return The credentials used when the user associated with this session
-     *         logged in.
+     * @return
+     *     The credentials used when the user associated with this session
+     *     authenticated.
      */
     public Credentials getCredentials() {
         return credentials;

--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/properties/BasicGuacamoleProperties.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/properties/BasicGuacamoleProperties.java
@@ -50,18 +50,6 @@ public class BasicGuacamoleProperties {
     };
 
     /**
-     * Whether HTTP "Authorization" headers should be taken into account when
-     * authenticating the user. By default, "Authorization" headers are
-     * ignored.
-     */
-    public static final BooleanGuacamoleProperty ENABLE_HTTP_AUTH = new BooleanGuacamoleProperty() {
-
-        @Override
-        public String getName() { return "enable-http-auth"; }
-
-    };
-
-    /**
      * The directory to search for authentication provider classes.
      */
     public static final FileGuacamoleProperty LIB_DIRECTORY = new FileGuacamoleProperty() {

--- a/guacamole/src/main/webapp/app/index/config/indexRouteConfig.js
+++ b/guacamole/src/main/webapp/app/index/config/indexRouteConfig.js
@@ -115,8 +115,8 @@ angular.module('index').config(['$routeProvider', '$locationProvider',
             title         : 'APP.NAME',
             bodyClassName : 'login',
             templateUrl   : 'app/login/templates/login.html',
-            controller    : 'loginController',
-            resolve       : { updateCurrentToken: updateCurrentToken }
+            controller    : 'loginController'
+            // No need to update token here - the login screen ignores all auth
         })
 
         // Client view

--- a/guacamole/src/main/webapp/app/index/config/indexRouteConfig.js
+++ b/guacamole/src/main/webapp/app/index/config/indexRouteConfig.js
@@ -25,55 +25,113 @@
  */
 angular.module('index').config(['$routeProvider', '$locationProvider', 
         function indexRouteConfig($routeProvider, $locationProvider) {
-            
+
     // Disable HTML5 mode (use # for routing)
     $locationProvider.html5Mode(false);
-    
-    $routeProvider
-        .when('/', {
-            title: 'APP.NAME',
-            bodyClassName: 'home',
-            templateUrl: 'app/home/templates/home.html',
-            controller: 'homeController'
-        })
-        .when('/manage/', {
-            title: 'APP.NAME',
-            bodyClassName: 'manage',
-            templateUrl: 'app/manage/templates/manage.html',
-            controller: 'manageController'
-        })
-        .when('/manage/connections/:id?', {
-            title: 'APP.NAME',
-            bodyClassName: 'manage',
-            templateUrl: 'app/manage/templates/manageConnection.html',
-            controller: 'manageConnectionController'
-        })
-        .when('/manage/connectionGroups/:id?', {
-            title: 'APP.NAME',
-            bodyClassName: 'manage',
-            templateUrl: 'app/manage/templates/manageConnectionGroup.html',
-            controller: 'manageConnectionGroupController'
-        })
-        .when('/manage/users/:id', {
-            title: 'APP.NAME',
-            bodyClassName: 'manage',
-            templateUrl: 'app/manage/templates/manageUser.html',
-            controller: 'manageUserController'
-        })
-        .when('/login/', {
-            title: 'APP.NAME',
-            bodyClassName: 'login',
-            templateUrl: 'app/login/templates/login.html',
-            controller: 'loginController'
-        })
-        .when('/client/:type/:id/:params?', {
-            bodyClassName: 'client',
-            templateUrl: 'app/client/templates/client.html',
-            controller: 'clientController'
-        })
-        .otherwise({
-            redirectTo: '/'
+
+    /**
+     * Attempts to re-authenticate with the Guacamole server, sending any
+     * query parameters in the URL, along with the current auth token, and
+     * updating locally stored token if necessary.
+     *
+     * @param {Service} $injector
+     *     The Angular $injector service.
+     * 
+     * @returns {Promise}
+     *     A promise which resolves successfully only after an attempt to
+     *     re-authenticate has been made.
+     */
+    var updateCurrentToken = ['$injector', function updateCurrentToken($injector) {
+
+        // Required services
+        var $location             = $injector.get('$location');
+        var $q                    = $injector.get('$q');
+        var authenticationService = $injector.get('authenticationService');
+
+        // Promise for authentication attempt
+        var authAttempt = $q.defer();
+
+        // Re-authenticate including any parameters in URL
+        authenticationService.updateCurrentToken($location.search())
+        ['finally'](function authenticationAttemptComplete() {
+            authAttempt.resolve();
         });
+
+        // Return promise that will resolve regardless of success/failure
+        return authAttempt.promise;
+
+    }];
+
+    // Configure each possible route
+    $routeProvider
+
+        // Home screen
+        .when('/', {
+            title         : 'APP.NAME',
+            bodyClassName : 'home',
+            templateUrl   : 'app/home/templates/home.html',
+            controller    : 'homeController',
+            resolve       : { updateCurrentToken: updateCurrentToken }
+        })
+
+        // Management screen
+        .when('/manage/', {
+            title         : 'APP.NAME',
+            bodyClassName : 'manage',
+            templateUrl   : 'app/manage/templates/manage.html',
+            controller    : 'manageController',
+            resolve       : { updateCurrentToken: updateCurrentToken }
+        })
+
+        // Connection editor
+        .when('/manage/connections/:id?', {
+            title         : 'APP.NAME',
+            bodyClassName : 'manage',
+            templateUrl   : 'app/manage/templates/manageConnection.html',
+            controller    : 'manageConnectionController',
+            resolve       : { updateCurrentToken: updateCurrentToken }
+        })
+
+        // Connection group editor
+        .when('/manage/connectionGroups/:id?', {
+            title         : 'APP.NAME',
+            bodyClassName : 'manage',
+            templateUrl   : 'app/manage/templates/manageConnectionGroup.html',
+            controller    : 'manageConnectionGroupController',
+            resolve       : { updateCurrentToken: updateCurrentToken }
+        })
+
+        // User editor
+        .when('/manage/users/:id', {
+            title         : 'APP.NAME',
+            bodyClassName : 'manage',
+            templateUrl   : 'app/manage/templates/manageUser.html',
+            controller    : 'manageUserController',
+            resolve       : { updateCurrentToken: updateCurrentToken }
+        })
+
+        // Login screen
+        .when('/login/', {
+            title         : 'APP.NAME',
+            bodyClassName : 'login',
+            templateUrl   : 'app/login/templates/login.html',
+            controller    : 'loginController',
+            resolve       : { updateCurrentToken: updateCurrentToken }
+        })
+
+        // Client view
+        .when('/client/:type/:id/:params?', {
+            bodyClassName : 'client',
+            templateUrl   : 'app/client/templates/client.html',
+            controller    : 'clientController',
+            resolve       : { updateCurrentToken: updateCurrentToken }
+        })
+
+        // Redirect to home screen if page not found
+        .otherwise({
+            redirectTo : '/'
+        });
+
 }]);
 
 


### PR DESCRIPTION
This change restores a feature present in all past Guacamole releases:

URL parameters and any available request data (cookies, SSL certs, etc.) are made available to the auth provider with each request, and the user's session may be created or updated based on the validity of that data.