### PR TITLE
GUAC-1001: Do not use null identifiers

### DIFF
--- a/guacamole-ext/src/main/java/org/glyptodon/guacamole/net/auth/Connection.java
+++ b/guacamole-ext/src/main/java/org/glyptodon/guacamole/net/auth/Connection.java
@@ -52,8 +52,13 @@ public interface Connection {
     public void setName(String name);
 
     /**
-     * Returns the unique identifier assigned to this Connection.
-     * @return The unique identifier assigned to this Connection.
+     * Returns the unique identifier assigned to this Connection. All
+     * connections must have a deterministic, unique identifier which may not
+     * be null.
+     *
+     * @return
+     *     The unique identifier assigned to this Connection, which may not be
+     *     null.
      */
     public String getIdentifier();
 

--- a/guacamole-ext/src/main/java/org/glyptodon/guacamole/net/auth/ConnectionGroup.java
+++ b/guacamole-ext/src/main/java/org/glyptodon/guacamole/net/auth/ConnectionGroup.java
@@ -52,8 +52,13 @@ public interface ConnectionGroup {
     public void setName(String name);
 
     /**
-     * Returns the unique identifier assigned to this ConnectionGroup.
-     * @return The unique identifier assigned to this ConnectionGroup.
+     * Returns the unique identifier assigned to this ConnectionGroup. All
+     * connection groups must have a deterministic, unique identifier which may
+     * not be null.
+     *
+     * @return
+     *     The unique identifier assigned to this ConnectionGroup, which may
+     *     not be null.
      */
     public String getIdentifier();
 

--- a/guacamole-ext/src/main/java/org/glyptodon/guacamole/net/auth/User.java
+++ b/guacamole-ext/src/main/java/org/glyptodon/guacamole/net/auth/User.java
@@ -36,8 +36,11 @@ public interface User {
 
     /**
      * Returns the name of this user, which must be unique across all users.
+     * All users must have a deterministic, unique username which may not be
+     * null.
      *
-     * @return The name of this user.
+     * @return
+     *     The unique username of this user, which may not be null.
      */
     public String getUsername();
 

--- a/guacamole-ext/src/main/java/org/glyptodon/guacamole/net/auth/simple/SimpleAuthenticationProvider.java
+++ b/guacamole-ext/src/main/java/org/glyptodon/guacamole/net/auth/simple/SimpleAuthenticationProvider.java
@@ -66,6 +66,9 @@ public abstract class SimpleAuthenticationProvider
     public UserContext getUserContext(Credentials credentials)
             throws GuacamoleException {
 
+        // Get username, if any
+        String username = credentials.getUsername();
+
         // Get configurations
         Map<String, GuacamoleConfiguration> configs =
                 getAuthorizedConfigurations(credentials);
@@ -83,7 +86,12 @@ public abstract class SimpleAuthenticationProvider
             tokenFilter.filterValues(config.getParameters());
         
         // Return user context restricted to authorized configs
-        return new SimpleUserContext(credentials.getUsername(), configs);
+        if (username != null)
+            return new SimpleUserContext(username, configs);
+
+        // If there is no associated username, let SimpleUserContext generate one
+        else
+            return new SimpleUserContext(configs);
 
     }
 

--- a/guacamole-ext/src/main/java/org/glyptodon/guacamole/net/auth/simple/SimpleAuthenticationProvider.java
+++ b/guacamole-ext/src/main/java/org/glyptodon/guacamole/net/auth/simple/SimpleAuthenticationProvider.java
@@ -86,7 +86,7 @@ public abstract class SimpleAuthenticationProvider
             tokenFilter.filterValues(config.getParameters());
         
         // Return user context restricted to authorized configs
-        if (username != null)
+        if (username != null && !username.isEmpty())
             return new SimpleUserContext(username, configs);
 
         // If there is no associated username, let SimpleUserContext generate one

--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/connectiongroup/ConnectionGroupRESTService.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/connectiongroup/ConnectionGroupRESTService.java
@@ -297,10 +297,10 @@ public class ConnectionGroupRESTService {
      *     The ID of the connection group to retrieve.
      *
      * @param permissions
-     *     If specified, limit the returned list to only those connections for
-     *     which the current user has any of the given permissions. Otherwise, 
-     *     all visible connections are returned. Connection groups are 
-     *     unaffected by this parameter.
+     *     If specified and non-empty, limit the returned list to only those
+     *     connections for which the current user has any of the given
+     *     permissions. Otherwise, all visible connections are returned.
+     *     Connection groups are unaffected by this parameter.
      * 
      * @return
      *     The requested connection group, including all descendants.
@@ -319,6 +319,10 @@ public class ConnectionGroupRESTService {
 
         UserContext userContext = authenticationService.getUserContext(authToken);
 
+        // Do not filter on permissions if no permissions are specified
+        if (permissions != null && permissions.isEmpty())
+            permissions = null;
+        
         // Retrieve requested connection group and all descendants
         APIConnectionGroup connectionGroup = retrieveConnectionGroup(userContext, connectionGroupID, true, permissions);
         if (connectionGroup == null)

--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/user/UserRESTService.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/user/UserRESTService.java
@@ -176,6 +176,10 @@ public class UserRESTService {
         UserContext userContext = authenticationService.getUserContext(authToken);
         User self = userContext.self();
         
+        // Do not filter on permissions if no permissions are specified
+        if (permissions != null && permissions.isEmpty())
+            permissions = null;
+
         // An admin user has access to any user
         boolean isAdmin = self.hasPermission(new SystemPermission(SystemPermission.Type.ADMINISTER));
 


### PR DESCRIPTION
This change removes usage of null identifiers via ```SimpleAuthenticationProvider```, which ultimately affects NoAuth, adding documentation to guacamole-ext noting that identifiers/usernames cannot be null.

Permission filtering is also fixed here, having been partially re-broken via GUAC-1000. ```List``` query parameters are translated to an empty list when unspecified; they are not ```null```.