### PR TITLE
GUAC-1046: Fix of doc/guacamole-example

### DIFF
--- a/doc/guacamole-example/pom.xml
+++ b/doc/guacamole-example/pom.xml
@@ -72,6 +72,13 @@
             <scope>runtime</scope>
         </dependency>
 
+	<dependency>
+		<groupId>org.slf4j</groupId>
+		<artifactId>slf4j-simple</artifactId>
+		<version>1.7.7</version>
+	</dependency>
+
+
     </dependencies>
 
 </project>

--- a/doc/guacamole-example/src/main/webapp/index.html
+++ b/doc/guacamole-example/src/main/webapp/index.html
@@ -49,7 +49,7 @@
             );
 
             // Add client to display div
-            display.appendChild(guac.getDisplay());
+            display.appendChild(guac.getDisplay().getElement());
             
             // Error handler
             guac.onerror = function(error) {
@@ -65,7 +65,7 @@
             }
 
             // Mouse
-            var mouse = new Guacamole.Mouse(guac.getDisplay());
+            var mouse = new Guacamole.Mouse(guac.getDisplay().getElement());
 
             mouse.onmousedown = 
             mouse.onmouseup   =


### PR DESCRIPTION
Hello!

The provided example was not working, so I've added some fixes. After that I was able to successfully run the example on jetty9 for 'ssh' protocol.

Best regards,
 Vasily