### PR TITLE
GUAC-956: Fix display and text input rendering on iOS 7.

### DIFF
--- a/guacamole/src/main/webapp/app/client/directives/guacViewport.js
+++ b/guacamole/src/main/webapp/app/client/directives/guacViewport.js
@@ -31,8 +31,8 @@ angular.module('client').directive('guacViewport', [function guacViewport() {
         scope: {},
         transclude: true,
         templateUrl: 'app/client/templates/guacViewport.html',
-        controller: ['$scope', '$window', '$document', '$element',
-            function guacViewportController($scope, $window, $document, $element) {
+        controller: ['$scope', '$interval', '$window', '$document', '$element',
+            function guacViewportController($scope, $interval, $window, $document, $element) {
 
             /**
              * The fullscreen container element.
@@ -69,7 +69,7 @@ angular.module('client').directive('guacViewport', [function guacViewport() {
                 var scrollHeight = document.body.scrollHeight;
 
                 // Calculate new height
-                var adjustedHeight = $window.innerHeight - scrollTop;
+                var adjustedHeight = scrollHeight - scrollTop;
 
                 // Only update if not in response to our own call to scrollTo()
                 if (scrollLeft !== scrollWidth && scrollTop !== scrollHeight
@@ -84,14 +84,22 @@ angular.module('client').directive('guacViewport', [function guacViewport() {
 
                 }
 
+                // Manually attempt scroll if height has not been adjusted
+                else if (adjustedHeight === 0)
+                    $window.scrollTo(scrollWidth, scrollHeight);
+
             };
 
             // Fit container within visible region when window scrolls
             $window.addEventListener('scroll', fitVisibleArea);
 
-            // Clean up event listener on destroy
+            // Poll every 10ms, in case scroll event does not fire
+            var pollArea = $interval(fitVisibleArea, 10);
+
+            // Clean up on destruction
             $scope.$on('$destroy', function destroyViewport() {
                 $window.removeEventListener('scroll', fitVisibleArea);
+                $interval.cancel(pollArea);
             });
 
         }]

--- a/guacamole/src/main/webapp/app/client/templates/guacClient.html
+++ b/guacamole/src/main/webapp/app/client/templates/guacClient.html
@@ -21,15 +21,17 @@
        THE SOFTWARE.
     -->
 
-    <!-- Resize sensor -->
-    <iframe class="resize-sensor" src="app/client/templates/blank.html"></iframe>
-    
     <!-- Display -->
     <div class="displayOuter">
+
+        <!-- Resize sensor -->
+        <iframe class="resize-sensor" src="app/client/templates/blank.html"></iframe>
+        
         <div class="displayMiddle">
             <div class="display software-cursor">
             </div>
         </div>
+
     </div>
 
 </div>


### PR DESCRIPTION
This change alters the scroll compensation algorithm used by the ```guacViewport``` directive such that it works with both iOS 7 and iOS 8.

Since scroll events are not always sent by iOS, a low-load polling timer has been added, too.

After much fiddling, I've managed to determine that the text input UI was invisible on iOS 7 because Safari erroneously determines that the ```iframe``` resize sensor obscures it. This change works around that by rearranging the DOM of the ```guacClient``` directive such that the resize sensor is somewhat deeper.

The strange miscalculations seem to be related to ```display: table```.

:bug: :beetle: :bee: :ant: