### PR TITLE
GUAC-958: Yet another attempt at a workaround for the iOS 7 visibility issue.

### DIFF
--- a/guacamole/src/main/webapp/app/client/directives/guacClient.js
+++ b/guacamole/src/main/webapp/app/client/directives/guacClient.js
@@ -339,7 +339,7 @@ angular.module('client').directive('guacClient', [function guacClient() {
             });
             
             // If the element is resized, attempt to resize client
-            resizeSensor.contentWindow.addEventListener('resize', function mainElementResized() {
+            resizeSensor.contentDocument.defaultView.addEventListener('resize', function mainElementResized() {
 
                 // Send new display size, if changed
                 if (client && display) {

--- a/guacamole/src/main/webapp/app/client/directives/guacThumbnail.js
+++ b/guacamole/src/main/webapp/app/client/directives/guacThumbnail.js
@@ -164,7 +164,7 @@ angular.module('client').directive('guacThumbnail', [function guacThumbnail() {
             });
 
             // If the element is resized, attempt to resize client
-            resizeSensor.contentWindow.addEventListener('resize', function mainElementResized() {
+            resizeSensor.contentDocument.defaultView.addEventListener('resize', function mainElementResized() {
                 $scope.$apply(updateDisplayScale);
             });
 

--- a/guacamole/src/main/webapp/app/client/templates/guacClient.html
+++ b/guacamole/src/main/webapp/app/client/templates/guacClient.html
@@ -24,9 +24,6 @@
     <!-- Display -->
     <div class="displayOuter">
 
-        <!-- Resize sensor -->
-        <iframe class="resize-sensor" src="app/client/templates/blank.html"></iframe>
-        
         <div class="displayMiddle">
             <div class="display software-cursor">
             </div>
@@ -34,4 +31,7 @@
 
     </div>
 
+    <!-- Resize sensor -->
+    <object type="text/html" class="resize-sensor" data="app/client/templates/blank.html"></object>
+    
 </div>

--- a/guacamole/src/main/webapp/app/client/templates/guacThumbnail.html
+++ b/guacamole/src/main/webapp/app/client/templates/guacThumbnail.html
@@ -22,7 +22,7 @@
     -->
 
     <!-- Resize sensor -->
-    <iframe class="resize-sensor" src="app/client/templates/blank.html"></iframe>
+    <object type="text/html" class="resize-sensor" data="app/client/templates/blank.html"></object>
     
     <!-- Display -->
     <div class="display">

--- a/guacamole/src/main/webapp/app/osk/directives/guacOsk.js
+++ b/guacamole/src/main/webapp/app/osk/directives/guacOsk.js
@@ -106,7 +106,7 @@ angular.module('osk').directive('guacOsk', [function guacOsk() {
                     };
 
                     // Resize keyboard whenever element changes size
-                    resizeSensor.contentWindow.addEventListener('resize', resizeListener);
+                    resizeSensor.contentDocument.defaultView.addEventListener('resize', resizeListener);
 
                 }
 

--- a/guacamole/src/main/webapp/app/osk/templates/guacOsk.html
+++ b/guacamole/src/main/webapp/app/osk/templates/guacOsk.html
@@ -22,6 +22,6 @@
     -->
 
     <!-- Resize sensor -->
-    <iframe class="resize-sensor" src="app/osk/templates/blank.html"></iframe>
+    <object type="text/html" class="resize-sensor" data="app/osk/templates/blank.html"></object>
 
 </div>


### PR DESCRIPTION
The previous attempt worked, but caused a regression in window resize handling, as the resize sensor would not always be tied to window size at that position in the DOM.

The new attempt replaces each ```iframe``` resize sensor with an ```object``` resize sensor. iOS 7 seems to render these ones properly.