### PR TITLE
GUAC-1043: Do not rely on fixed positioning for client viewport.

### DIFF
--- a/guacamole/src/main/webapp/app/client/styles/menu.css
+++ b/guacamole/src/main/webapp/app/client/styles/menu.css
@@ -22,7 +22,7 @@
 
 #menu {
     overflow: auto;
-    position: fixed;
+    position: absolute;
     top: 0;
     bottom: 0;
     max-width: 100%;

--- a/guacamole/src/main/webapp/app/client/styles/viewport.css
+++ b/guacamole/src/main/webapp/app/client/styles/viewport.css
@@ -21,7 +21,7 @@
  */
 
 .viewport {
-    position: fixed;
+    position: absolute;
     bottom: 0;
     left: 0;
     width: 100%;


### PR DESCRIPTION
iOS 7 has some major issues with rendering ```position: fixed``` elements, particularly when the native on-screen keyboard has been shown. The entire page shifts almost completely out of view when the device is rotated, and touch events register the wrong coordinates.

Since there are no elements in the content of the client view that affect document flow, it's safe to use a combination of ```position: absolute``` and the ```guacViewport``` directive instead.