### PR TITLE
GUAC-998: Fix handling of Guacamole menu with respect to Meta

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Keyboard.js
+++ b/guacamole-common-js/src/main/webapp/modules/Keyboard.js
@@ -298,8 +298,8 @@ Guacamole.Keyboard = function(element) {
         this.location = location;
 
         // If key is known from keyCode or DOM3 alone, use that
-        this.keysym =  keysym_from_keycode(keyCode, location)
-                    || recentKeysym[keyCode]
+        this.keysym =  recentKeysym[keyCode]
+                    || keysym_from_keycode(keyCode, location)
                     || keysym_from_key_identifier(key, location); // keyCode is still more reliable for keyup when dead keys are in use
 
         // Keyup is as reliable as it will ever be

--- a/guacamole/src/main/webapp/app/client/controllers/clientController.js
+++ b/guacamole/src/main/webapp/app/client/controllers/clientController.js
@@ -62,9 +62,10 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
      * In order to open the guacamole menu, we need to hit ctrl-alt-shift. There are
      * several possible keysysms for each key.
      */
-    var SHIFT_KEYS  = {0xFFE1 : true, 0xFFE2: true},
-        ALT_KEYS    = {0xFFE9 : true, 0xFFEA : true, 0xFE03: true},
-        CTRL_KEYS   = {0xFFE3 : true, 0xFFE4: true},
+    var SHIFT_KEYS  = {0xFFE1 : true, 0xFFE2 : true},
+        ALT_KEYS    = {0xFFE9 : true, 0xFFEA : true, 0xFE03 : true,
+                       0xFFE7 : true, 0xFFE8 : true},
+        CTRL_KEYS   = {0xFFE3 : true, 0xFFE4 : true},
         MENU_KEYS   = angular.extend({}, SHIFT_KEYS, ALT_KEYS, CTRL_KEYS);
 
     /**


### PR DESCRIPTION
On Firefox, and probably other browser/system combinations, Shift+Alt is translated to Shift+Meta, and thus cannot be used when showing the Guacamole menu. This change allows Meta to be used in place of Alt when showing the menu, thus avoiding confusion.

The Guacamole keyboard also contained a bug which caused different keysyms to be returned depending on whether Meta was pressed or released, mainly due to Meta having the same JavaScript keycode as Alt. This change modifies the Guacamole keyboard event interpretation algorithm such that the keysym used for keydown is preferred when interpreting keyup.