### PR TITLE
GUAC-1083: Add CORS support to Guacamole.HTTPTunnel

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/OnScreenKeyboard.js
+++ b/guacamole-common-js/src/main/webapp/modules/OnScreenKeyboard.js
@@ -214,7 +214,6 @@ Guacamole.OnScreenKeyboard = function(url) {
     // Retrieve keyboard XML
     var xmlhttprequest = new XMLHttpRequest();
     xmlhttprequest.open("GET", url, false);
-    xmlhttprequest.withCredentials = true;
     xmlhttprequest.send(null);
 
     var xml = xmlhttprequest.responseXML;

--- a/guacamole-common-js/src/main/webapp/modules/OnScreenKeyboard.js
+++ b/guacamole-common-js/src/main/webapp/modules/OnScreenKeyboard.js
@@ -214,6 +214,7 @@ Guacamole.OnScreenKeyboard = function(url) {
     // Retrieve keyboard XML
     var xmlhttprequest = new XMLHttpRequest();
     xmlhttprequest.open("GET", url, false);
+    xmlhttprequest.withCredentials = true;
     xmlhttprequest.send(null);
 
     var xml = xmlhttprequest.responseXML;

--- a/guacamole-common-js/src/main/webapp/modules/Tunnel.js
+++ b/guacamole-common-js/src/main/webapp/modules/Tunnel.js
@@ -274,7 +274,6 @@ Guacamole.HTTPTunnel = function(tunnelURL) {
 
             var message_xmlhttprequest = new XMLHttpRequest();
             message_xmlhttprequest.open("POST", TUNNEL_WRITE + tunnel_uuid);
-            message_xmlhttprequest.withCredentials = true;
             message_xmlhttprequest.setRequestHeader("Content-type", "application/x-www-form-urlencoded; charset=UTF-8");
 
             // Once response received, send next queued event.
@@ -505,7 +504,6 @@ Guacamole.HTTPTunnel = function(tunnelURL) {
         // Make request, increment request ID
         var xmlhttprequest = new XMLHttpRequest();
         xmlhttprequest.open("GET", TUNNEL_READ + tunnel_uuid + ":" + (request_id++));
-        xmlhttprequest.withCredentials = true;
         xmlhttprequest.send(null);
 
         return xmlhttprequest;
@@ -545,7 +543,6 @@ Guacamole.HTTPTunnel = function(tunnelURL) {
         };
 
         connect_xmlhttprequest.open("POST", TUNNEL_CONNECT, true);
-        connect_xmlhttprequest.withCredentials = true;
         connect_xmlhttprequest.setRequestHeader("Content-type", "application/x-www-form-urlencoded; charset=UTF-8");
         connect_xmlhttprequest.send(data);
 

--- a/guacamole-common-js/src/main/webapp/modules/Tunnel.js
+++ b/guacamole-common-js/src/main/webapp/modules/Tunnel.js
@@ -138,6 +138,7 @@ Guacamole.Tunnel.State = {
  * @constructor
  * @augments Guacamole.Tunnel
  * @param {String} tunnelURL The URL of the HTTP tunneling service.
+ * @param {Boolean} withCredentials HTTP requests 'withCredentials' header value.
  */
 Guacamole.HTTPTunnel = function(tunnelURL, withCredentials) {
 

--- a/guacamole-common-js/src/main/webapp/modules/Tunnel.js
+++ b/guacamole-common-js/src/main/webapp/modules/Tunnel.js
@@ -274,6 +274,7 @@ Guacamole.HTTPTunnel = function(tunnelURL) {
 
             var message_xmlhttprequest = new XMLHttpRequest();
             message_xmlhttprequest.open("POST", TUNNEL_WRITE + tunnel_uuid);
+            message_xmlhttprequest.withCredentials = true;
             message_xmlhttprequest.setRequestHeader("Content-type", "application/x-www-form-urlencoded; charset=UTF-8");
 
             // Once response received, send next queued event.
@@ -504,6 +505,7 @@ Guacamole.HTTPTunnel = function(tunnelURL) {
         // Make request, increment request ID
         var xmlhttprequest = new XMLHttpRequest();
         xmlhttprequest.open("GET", TUNNEL_READ + tunnel_uuid + ":" + (request_id++));
+        xmlhttprequest.withCredentials = true;
         xmlhttprequest.send(null);
 
         return xmlhttprequest;
@@ -543,6 +545,7 @@ Guacamole.HTTPTunnel = function(tunnelURL) {
         };
 
         connect_xmlhttprequest.open("POST", TUNNEL_CONNECT, true);
+        connect_xmlhttprequest.withCredentials = true;
         connect_xmlhttprequest.setRequestHeader("Content-type", "application/x-www-form-urlencoded; charset=UTF-8");
         connect_xmlhttprequest.send(data);
 

--- a/guacamole-common-js/src/main/webapp/modules/Tunnel.js
+++ b/guacamole-common-js/src/main/webapp/modules/Tunnel.js
@@ -139,7 +139,7 @@ Guacamole.Tunnel.State = {
  * @augments Guacamole.Tunnel
  * @param {String} tunnelURL The URL of the HTTP tunneling service.
  */
-Guacamole.HTTPTunnel = function(tunnelURL) {
+Guacamole.HTTPTunnel = function(tunnelURL, withCredentials) {
 
     /**
      * Reference to this HTTP tunnel.
@@ -161,6 +161,8 @@ Guacamole.HTTPTunnel = function(tunnelURL) {
 
     var sendingMessages = false;
     var outputMessageBuffer = "";
+
+    withCredentials = !!withCredentials;
 
     /**
      * The current receive timeout ID, if any.
@@ -274,6 +276,7 @@ Guacamole.HTTPTunnel = function(tunnelURL) {
 
             var message_xmlhttprequest = new XMLHttpRequest();
             message_xmlhttprequest.open("POST", TUNNEL_WRITE + tunnel_uuid);
+            message_xmlhttprequest.withCredentials = withCredentials;
             message_xmlhttprequest.setRequestHeader("Content-type", "application/x-www-form-urlencoded; charset=UTF-8");
 
             // Once response received, send next queued event.
@@ -504,6 +507,7 @@ Guacamole.HTTPTunnel = function(tunnelURL) {
         // Make request, increment request ID
         var xmlhttprequest = new XMLHttpRequest();
         xmlhttprequest.open("GET", TUNNEL_READ + tunnel_uuid + ":" + (request_id++));
+        xmlhttprequest.withCredentials = withCredentials;
         xmlhttprequest.send(null);
 
         return xmlhttprequest;
@@ -543,6 +547,7 @@ Guacamole.HTTPTunnel = function(tunnelURL) {
         };
 
         connect_xmlhttprequest.open("POST", TUNNEL_CONNECT, true);
+        connect_xmlhttprequest.withCredentials = withCredentials;
         connect_xmlhttprequest.setRequestHeader("Content-type", "application/x-www-form-urlencoded; charset=UTF-8");
         connect_xmlhttprequest.send(data);
 


### PR DESCRIPTION
I've wanted to add support for HTTPTunnel across domains, but configuring the Gucamole server (tomcat/web.xml) isn't enough
I found out that that problem is the server does not get back the JSESSION cookie from client, because 'withCredentials' header is not set to true on the HTTP calls
After setting this header it worked