### PR TITLE
GUAC-1082: HTTP tunnel fails to reconnect

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Tunnel.js
+++ b/guacamole-common-js/src/main/webapp/modules/Tunnel.js
@@ -214,6 +214,10 @@ Guacamole.HTTPTunnel = function(tunnelURL) {
 
         // Mark as closed
         tunnel.state = Guacamole.Tunnel.State.CLOSED;
+        
+        sendingMessages = false;
+        outputMessageBuffer = "";
+
         if (tunnel.onstatechange)
             tunnel.onstatechange(tunnel.state);
 

--- a/guacamole-common-js/src/main/webapp/modules/Tunnel.js
+++ b/guacamole-common-js/src/main/webapp/modules/Tunnel.js
@@ -215,7 +215,7 @@ Guacamole.HTTPTunnel = function(tunnelURL) {
         // Mark as closed
         tunnel.state = Guacamole.Tunnel.State.CLOSED;
 
-        // Reset the flag indicates this tunnel is in progress of sending messages
+        // Reset output message buffer
         sendingMessages = false;
 
         if (tunnel.onstatechange)

--- a/guacamole-common-js/src/main/webapp/modules/Tunnel.js
+++ b/guacamole-common-js/src/main/webapp/modules/Tunnel.js
@@ -215,7 +215,7 @@ Guacamole.HTTPTunnel = function(tunnelURL) {
         // Mark as closed
         tunnel.state = Guacamole.Tunnel.State.CLOSED;
 
-        // Reset output message buffer
+        // Reset output message buffer 
         sendingMessages = false;
 
         if (tunnel.onstatechange)

--- a/guacamole-common-js/src/main/webapp/modules/Tunnel.js
+++ b/guacamole-common-js/src/main/webapp/modules/Tunnel.js
@@ -215,7 +215,7 @@ Guacamole.HTTPTunnel = function(tunnelURL) {
         // Mark as closed
         tunnel.state = Guacamole.Tunnel.State.CLOSED;
 
-        // Reset output message buffer 
+        // Reset output message buffer
         sendingMessages = false;
 
         if (tunnel.onstatechange)

--- a/guacamole-common-js/src/main/webapp/modules/Tunnel.js
+++ b/guacamole-common-js/src/main/webapp/modules/Tunnel.js
@@ -214,9 +214,9 @@ Guacamole.HTTPTunnel = function(tunnelURL) {
 
         // Mark as closed
         tunnel.state = Guacamole.Tunnel.State.CLOSED;
-        
+
+        // Reset the flag indicates this tunnel is in progress of sending messages
         sendingMessages = false;
-        outputMessageBuffer = "";
 
         if (tunnel.onstatechange)
             tunnel.onstatechange(tunnel.state);


### PR DESCRIPTION
I've found a bug (now using version 0.9.3) - When using HttpTunnel reconnect is not possible

How to reproduce:
1. Connect to remote vm using HttpTunnel
2. Execute 'Disconnect' on client
3. Execute 'Connect'

After debugging this I found out that the the cause is 'sendingMessages' variable is preventing 'sendPendingMessages' function to be called. When the client does not send any messages, server thinks it's not active and disconnects it

I think 'sendingMessages' variable should be reset side by side with channel close (this is working for me now, but might be implemented elsewhere in the tunnel)
'outputMessageBuffer' is also been cleared here just for cleanup sake. Clearing just 'outputMessageBuffer' it is not enough for the client to respond after reconnect