### PR TITLE
GUAC-1018: Bump version to 0.9.5.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (C) 2013 Glyptodon LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/doc/guacamole-example/pom.xml
+++ b/doc/guacamole-example/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole-example</artifactId>
     <packaging>war</packaging>
-    <version>0.9.4</version>
+    <version>0.9.5</version>
     <name>guacamole-example</name>
     <url>http://guac-dev.org/</url>
 
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-common-js</artifactId>
-            <version>0.9.4</version>
+            <version>0.9.5</version>
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>

--- a/extensions/guacamole-auth-ldap/pom.xml
+++ b/extensions/guacamole-auth-ldap/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole-auth-ldap</artifactId>
     <packaging>jar</packaging>
-    <version>0.9.4</version>
+    <version>0.9.5</version>
     <name>guacamole-auth-ldap</name>
     <url>http://guac-dev.org/</url>
 
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>0.9.4</version>
+            <version>0.9.5</version>
         </dependency>
 
         <!-- JLDAP -->

--- a/extensions/guacamole-auth-mysql/pom.xml
+++ b/extensions/guacamole-auth-mysql/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole-auth-mysql</artifactId>
     <packaging>jar</packaging>
-    <version>0.9.4</version>
+    <version>0.9.5</version>
     <name>guacamole-auth-mysql</name>
     <url>http://guac-dev.org/</url>
 
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>0.9.4</version>
+            <version>0.9.5</version>
         </dependency>
 
         <!-- SLF4J - logging -->

--- a/extensions/guacamole-auth-noauth/pom.xml
+++ b/extensions/guacamole-auth-noauth/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole-auth-noauth</artifactId>
     <packaging>jar</packaging>
-    <version>0.9.4</version>
+    <version>0.9.5</version>
     <name>guacamole-auth-noauth</name>
     <url>http://guacamole.sourceforge.net/</url>
 
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>0.9.4</version>
+            <version>0.9.5</version>
         </dependency>
 
     </dependencies>

--- a/guacamole-common-js/pom.xml
+++ b/guacamole-common-js/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole-common-js</artifactId>
     <packaging>pom</packaging>
-    <version>0.9.4</version>
+    <version>0.9.5</version>
     <name>guacamole-common-js</name>
     <url>http://guac-dev.org/</url>
 

--- a/guacamole-ext/pom.xml
+++ b/guacamole-ext/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole-ext</artifactId>
     <packaging>jar</packaging>
-    <version>0.9.4</version>
+    <version>0.9.5</version>
     <name>guacamole-ext</name>
     <url>http://guac-dev.org/</url>
 

--- a/guacamole/pom.xml
+++ b/guacamole/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole</artifactId>
     <packaging>war</packaging>
-    <version>0.9.4</version>
+    <version>0.9.5</version>
     <name>guacamole</name>
     <url>http://guac-dev.org/</url>
 
@@ -207,14 +207,14 @@
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>0.9.4</version>
+            <version>0.9.5</version>
         </dependency>
 
         <!-- Guacamole JavaScript API -->
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-common-js</artifactId>
-            <version>0.9.4</version>
+            <version>0.9.5</version>
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole-client</artifactId>
     <packaging>pom</packaging>
-    <version>0.9.4</version>
+    <version>0.9.5</version>
     <name>guacamole-client</name>
     <url>http://guac-dev.org/</url>
 


### PR DESCRIPTION
In preparation for the 0.9.5 release, this change bumps the version numbers of all changed guacamole-client components.

The only completely unchanged component is guacamole-common.