### PR TITLE
GUAC-1018: Bump version in Version.js of guacamole-common-js (incorrect since 0.9.4).

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Version.js
+++ b/guacamole-common-js/src/main/webapp/modules/Version.js
@@ -30,4 +30,4 @@ var Guacamole = Guacamole || {};
  *
  * @type String
  */
-Guacamole.API_VERSION = "0.9.3";
+Guacamole.API_VERSION = "0.9.5";


### PR DESCRIPTION
Oops.