### PR TITLE
GUAC-1100: Update parent identifier within REST service calls.

### DIFF
--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/connection/ConnectionRESTService.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/connection/ConnectionRESTService.java
@@ -40,7 +40,6 @@ import org.glyptodon.guacamole.GuacamoleClientException;
 import org.glyptodon.guacamole.GuacamoleException;
 import org.glyptodon.guacamole.GuacamoleSecurityException;
 import org.glyptodon.guacamole.net.auth.Connection;
-import org.glyptodon.guacamole.net.auth.ConnectionGroup;
 import org.glyptodon.guacamole.net.auth.ConnectionRecord;
 import org.glyptodon.guacamole.net.auth.Directory;
 import org.glyptodon.guacamole.net.auth.User;
@@ -297,6 +296,7 @@ public class ConnectionRESTService {
 
         // Update the connection
         existingConnection.setConfiguration(config);
+        existingConnection.setParentIdentifier(connection.getParentIdentifier());
         existingConnection.setName(connection.getName());
         connectionDirectory.update(existingConnection);
 

--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/connectiongroup/ConnectionGroupRESTService.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/connectiongroup/ConnectionGroupRESTService.java
@@ -251,6 +251,7 @@ public class ConnectionGroupRESTService {
         
         // Update the connection group
         existingConnectionGroup.setName(connectionGroup.getName());
+        existingConnectionGroup.setParentIdentifier(connectionGroup.getParentIdentifier());
         existingConnectionGroup.setType(connectionGroup.getType());
         connectionGroupDirectory.update(existingConnectionGroup);
 


### PR DESCRIPTION
Moving connections or groups via REST was not working. Turns out I'm not setting the parent identifier on update for either of those objects.