### PR TITLE
GUAC-1099: Do not attempt to display connections in guacGroupList if no connection template is provided.

### DIFF
--- a/guacamole/src/main/webapp/app/groupList/directives/guacGroupList.js
+++ b/guacamole/src/main/webapp/app/groupList/directives/guacGroupList.js
@@ -130,8 +130,8 @@ angular.module('groupList').directive('guacGroupList', [function guacGroupList()
 
                 if (connectionGroup) {
 
-                    // Create item hierarchy
-                    var rootItem = GroupListItem.fromConnectionGroup(connectionGroup);
+                    // Create item hierarchy, including connections only if they will be visible
+                    var rootItem = GroupListItem.fromConnectionGroup(connectionGroup, !!$scope.connectionTemplate);
 
                     // If root group is to be shown, wrap that group as the child of a fake root group
                     if ($scope.showRootGroup)

--- a/guacamole/src/main/webapp/app/groupList/types/GroupListItem.js
+++ b/guacamole/src/main/webapp/app/groupList/types/GroupListItem.js
@@ -160,17 +160,22 @@ angular.module('groupList').factory('GroupListItem', ['ConnectionGroup', functio
      * @param {ConnectionGroup} connectionGroup
      *     The connection group whose contents and descendants should be
      *     represented by the new GroupListItem and its descendants.
+     *     
+     * @param {Boolean} [includeConnections=true]
+     *     Whether connections should be included in the contents of the
+     *     resulting GroupListItem. By default, connections are included.
      *
      * @returns {GroupListItem}
      *     A new GroupListItem which represents the given connection group,
      *     including all descendants.
      */
-    GroupListItem.fromConnectionGroup = function fromConnectionGroup(connectionGroup) {
+    GroupListItem.fromConnectionGroup = function fromConnectionGroup(connectionGroup,
+        includeConnections) {
 
         var children = [];
 
         // Add any child connections
-        if (connectionGroup.childConnections) {
+        if (connectionGroup.childConnections && includeConnections !== false) {
             connectionGroup.childConnections.forEach(function addChildConnection(child) {
                 children.push(GroupListItem.fromConnection(child));
             });
@@ -179,7 +184,7 @@ angular.module('groupList').factory('GroupListItem', ['ConnectionGroup', functio
         // Add any child groups 
         if (connectionGroup.childConnectionGroups) {
             connectionGroup.childConnectionGroups.forEach(function addChildGroup(child) {
-                children.push(GroupListItem.fromConnectionGroup(child));
+                children.push(GroupListItem.fromConnectionGroup(child, includeConnections));
             });
         }
 


### PR DESCRIPTION
The location chooser is still slow despite pagination, as it always has exactly one item in the root level, and thus is never paginated.

As nearly all of its contents are connections that will not be shown anyway, this change omits connections from the group list hierarchy entirely if no connection template is provided to the ```guacGroupList``` directive.