### PR TITLE
GUAC-1109: Do not rely on SHA2(). Handle password hashing in Java.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/UserMapper.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/UserMapper.java
@@ -33,23 +33,6 @@ import org.apache.ibatis.annotations.Param;
 public interface UserMapper extends DirectoryObjectMapper<UserModel> {
 
     /**
-     * Returns the user having the given username and password, if any. If no
-     * such user exists, null is returned.
-     *
-     * @param username
-     *     The username of the user to return.
-     *
-     * @param password
-     *     The password of the user to return.
-     *
-     * @return
-     *     The user having the given username and password, or null if no such
-     *     user exists.
-     */
-    UserModel selectOneByCredentials(@Param("username") String username,
-            @Param("password") String password);
-
-    /**
      * Returns the user having the given username, if any. If no such user
      * exists, null is returned.
      *

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/glyptodon/guacamole/auth/jdbc/user/UserMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/glyptodon/guacamole/auth/jdbc/user/UserMapper.xml
@@ -87,19 +87,6 @@
 
     </select>
 
-    <!-- Select single user by credentials -->
-    <select id="selectOneByCredentials" resultMap="UserResultMap">
-        SELECT
-            user_id,
-            username,
-            password_hash,
-            password_salt
-        FROM guacamole_user
-        WHERE
-                username      = #{username,jdbcType=VARCHAR}
-            AND password_hash = UNHEX(SHA2(CONCAT(#{password,jdbcType=VARCHAR}, HEX(password_salt)), 256))
-    </select>
-
     <!-- Select single user by username -->
     <select id="selectOne" resultMap="UserResultMap">
 


### PR DESCRIPTION
From [GUAC-1109](https://glyptodon.org/jira/browse/GUAC-1109):

> Unfortunately, MySQL versions older than 5.5.5 do not have the ```SHA2()```
> function that we now depend on for testing user credentials. This includes the
> version of MySQL currently installed on deployments of CentOS 6.
>
> Using the latest JDBC auth code on an older MySQL will result in the following
> error:
>
> ``` FUNCTION guacamole.SHA2 does not exist ```
>
> We need to migrate back to handling hashing and salting purely within Java.

