### PR TITLE
GUAC-1108: Use retrieval service for retrieving connection groups. Avoid possible NPE.

### DIFF
--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/connectiongroup/ConnectionGroupRESTService.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/connectiongroup/ConnectionGroupRESTService.java
@@ -247,7 +247,7 @@ public class ConnectionGroupRESTService {
         Directory<ConnectionGroup> connectionGroupDirectory = userContext.getConnectionGroupDirectory();
 
         // Retrieve connection group to update
-        ConnectionGroup existingConnectionGroup = connectionGroupDirectory.get(connectionGroupID);
+        ConnectionGroup existingConnectionGroup = retrievalService.retrieveConnectionGroup(userContext, connectionGroupID);
         
         // Update the connection group
         existingConnectionGroup.setName(connectionGroup.getName());


### PR DESCRIPTION
```connectionGroupDirectory.get()``` might return null. The retrieval service should be used so that an exception containing a reasonable error code is thrown instead.