### PR TITLE
GUAC-1119: Redirect to login ONLY for requests to /api/tokens, and ONLY if not already at login.

### DIFF
--- a/guacamole/src/main/webapp/app/index/services/authenticationInterceptor.js
+++ b/guacamole/src/main/webapp/app/index/services/authenticationInterceptor.js
@@ -24,17 +24,24 @@ angular.module('index').factory('authenticationInterceptor', ['$location', '$q',
         function authenticationInterceptor($location, $q) {
             
     return {
-        'response': function(response) {
-            return response || $q.when(response);
-        },
 
-        'responseError': function(rejection) {
-            // Do not redirect failed api requests.
+        // Redirect users to login if authorization fails
+        responseError: function handleErrorResponse(rejection) {
+
+            // Only redirect failed authentication requests
             if ((rejection.status === 401 || rejection.status === 403)
-                    && rejection.config.url.search('api/') === -1) {
-                $location.path('/login');
+                    && rejection.config.url  === 'api/tokens') {
+
+                // Only redirect if not already on login page
+                if ($location.path() !== '/login/')
+                    $location.path('/login/');
+
             }
+
             return $q.reject(rejection);
+
         }
+
     };
+
 }]);


### PR DESCRIPTION
The modified logic was flawed because the only requests that reach the interceptor are REST API requests. If we explicitly exclude those, then we exclude everything and there is no redirect.

What we should have done is redirect **only** authentication requests (requests to ```/api/tokens```), and **only** if we aren't already on the login page.