### PR TITLE
GUAC-1121: Do not expose retrieved ConnectionRecord list directly.

### DIFF
--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/connection/APIConnectionRecord.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/connection/APIConnectionRecord.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2015 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.glyptodon.guacamole.net.basic.rest.connection;
+
+import java.util.Date;
+import org.glyptodon.guacamole.net.auth.ConnectionRecord;
+
+/**
+ * A connection record which may be exposed through the REST endpoints.
+ * 
+ * @author Michael Jumper
+ */
+public class APIConnectionRecord {
+
+    /**
+     * The date and time the connection began.
+     */
+    private final Date startDate;
+
+    /**
+     * The date and time the connection ended, or null if the connection is
+     * still running or if the end time is unknown.
+     */
+    private final Date endDate;
+
+    /**
+     * The name of the user who used or is using the connection.
+     */
+    private final String username;
+
+    /**
+     * Whether the connection is currently active.
+     */
+    private final boolean active;
+
+    /**
+     * Creates a new APIConnectionRecord, copying the data from the given
+     * record.
+     *
+     * @param record
+     *     The record to copy data from.
+     */
+    public APIConnectionRecord(ConnectionRecord record) {
+        this.startDate = record.getStartDate();
+        this.endDate   = record.getEndDate();
+        this.username  = record.getUsername();
+        this.active    = record.isActive();
+    }
+
+    /**
+     * Returns the date and time the connection began.
+     *
+     * @return
+     *     The date and time the connection began.
+     */
+    public Date getStartDate() {
+        return startDate;
+    }
+
+    /**
+     * Returns the date and time the connection ended, if applicable.
+     *
+     * @return
+     *     The date and time the connection ended, or null if the connection is
+     *     still running or if the end time is unknown.
+     */
+    public Date getEndDate() {
+        return endDate;
+    }
+
+    /**
+     * Returns the name of the user who used or is using the connection at the
+     * times given by this connection record.
+     *
+     * @return
+     *     The name of the user who used or is using the associated connection.
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * Returns whether the connection associated with this record is still
+     * active.
+     *
+     * @return
+     *     true if the connection associated with this record is still active,
+     *     false otherwise.
+     */
+    public boolean isActive() {
+        return active;
+    }
+    
+}

--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/connection/ConnectionRESTService.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/connection/ConnectionRESTService.java
@@ -23,7 +23,7 @@
 package org.glyptodon.guacamole.net.basic.rest.connection;
 
 import com.google.inject.Inject;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import javax.ws.rs.Consumes;
@@ -176,14 +176,21 @@ public class ConnectionRESTService {
     @GET
     @Path("/{connectionID}/history")
     @AuthProviderRESTExposure
-    public List<ConnectionRecord> getConnectionHistory(@QueryParam("token") String authToken, 
+    public List<APIConnectionRecord> getConnectionHistory(@QueryParam("token") String authToken, 
             @PathParam("connectionID") String connectionID) throws GuacamoleException {
 
         UserContext userContext = authenticationService.getUserContext(authToken);
         
-        // Retrieve the requested connection's history
+        // Retrieve the requested connection
         Connection connection = retrievalService.retrieveConnection(userContext, connectionID);
-        return Collections.<ConnectionRecord>unmodifiableList(connection.getHistory());
+
+        // Retrieve the requested connection's history
+        List<APIConnectionRecord> apiRecords = new ArrayList<APIConnectionRecord>();
+        for (ConnectionRecord record : connection.getHistory())
+            apiRecords.add(new APIConnectionRecord(record));
+
+        // Return the converted history
+        return apiRecords;
 
     }
 


### PR DESCRIPTION
The connection history REST endpoint was returning the ```ConnectionRecord``` list exactly as retrieved from the auth provider. As the JSON serializer determines the resulting JSON through reflection, this can result in the response containing internal data.

In the case of [GUAC-1121](https://glyptodon.org/jira/browse/GUAC-1121), this resulted in the response containing the ```user```/```currentUser``` cyclic references.

Thankfully, it looks like no other REST endpoints within Guacamole directly expose guacamole-ext objects. They all return API-specific objects instead.