### PR TITLE
GUAC-1126: Add user menu to Guacamole menu

### DIFF
--- a/guacamole/src/main/webapp/app/client/styles/menu.css
+++ b/guacamole/src/main/webapp/app/client/styles/menu.css
@@ -69,7 +69,7 @@
 
 }
 
-.menu-header {
+.menu-content .header {
 
     -ms-flex: 0 0 auto;
     -moz-box-flex: 0;
@@ -77,61 +77,8 @@
     -webkit-flex: 0 0 auto;
     flex: 0 0 auto;
 
-    /* IE10 */
-    display: -ms-flexbox;
-    -ms-flex-align: center;
-    -ms-flex-direction: row;
-
-    /* Ancient Mozilla */
-    display: -moz-box;
-    -moz-box-align: center;
-    -moz-box-orient: horizontal;
+    margin-bottom: 0;
     
-    /* Ancient WebKit */
-    display: -webkit-box;
-    -webkit-box-align: center;
-    -webkit-box-orient: horizontal;
-
-    /* Old WebKit */
-    display: -webkit-flex;
-    -webkit-align-items: center;
-    -webkit-flex-direction: row;
-
-    /* W3C */
-    display: flex;
-    align-items: center;
-    flex-direction: row;
-
-    padding: 0.75em 0.5em;
-
-    border-bottom: 1px solid rgba(0, 0, 0, 0.125);
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.125);
-    background: rgba(0, 0, 0, 0.04);
-
-}
-
-.menu-header > * {
-    -ms-flex: 0 0 auto;
-    -moz-box-flex: 0;
-    -webkit-box-flex: 0;
-    -webkit-flex: 0 0 auto;
-    flex: 0 0 auto;
-}
-
-.menu-header > h2 {
-
-    -ms-flex: 1 1 auto;
-    -moz-box-flex: 1;
-    -webkit-box-flex: 1;
-    -webkit-flex: 1 1 auto;
-    flex: 1 1 auto;
-
-    border: none;
-    padding: 0;
-    box-shadow: none;
-    background: none;
-    margin: 0;
-
 }
 
 .menu-body {

--- a/guacamole/src/main/webapp/app/client/templates/client.html
+++ b/guacamole/src/main/webapp/app/client/templates/client.html
@@ -59,7 +59,7 @@
             <!-- Stationary header -->
             <div class="header">
                 <h2>{{client.name}}</h2>
-                <guac-user-menu permissions="permissions" root-group="rootConnectionGroup"></guac-user-menu>
+                <guac-user-menu></guac-user-menu>
             </div>
 
             <!-- Scrollable body -->

--- a/guacamole/src/main/webapp/app/client/templates/client.html
+++ b/guacamole/src/main/webapp/app/client/templates/client.html
@@ -57,10 +57,9 @@
         <div class="menu-content">
 
             <!-- Stationary header -->
-            <div class="menu-header">
+            <div class="header">
                 <h2>{{client.name}}</h2>
-                <a class="home button" href="#/">{{'CLIENT.ACTION_NAVIGATE_HOME' | translate}}</a>
-                <a class="disconnect danger button" ng-click="disconnect()">{{'CLIENT.ACTION_DISCONNECT' | translate}}</a>
+                <guac-user-menu permissions="permissions" root-group="rootConnectionGroup"></guac-user-menu>
             </div>
 
             <!-- Scrollable body -->

--- a/guacamole/src/main/webapp/app/home/controllers/homeController.js
+++ b/guacamole/src/main/webapp/app/home/controllers/homeController.js
@@ -32,7 +32,6 @@ angular.module('home').controller('homeController', ['$scope', '$injector',
     // Get required services
     var authenticationService  = $injector.get("authenticationService");
     var connectionGroupService = $injector.get("connectionGroupService");
-    var userPageService        = $injector.get("userPageService");
     
     /**
      * The root connection group, or null if the connection group hierarchy has
@@ -59,12 +58,6 @@ angular.module('home').controller('homeController', ['$scope', '$injector',
     connectionGroupService.getConnectionGroupTree(ConnectionGroup.ROOT_IDENTIFIER)
     .success(function rootGroupRetrieved(rootConnectionGroup) {
         $scope.rootConnectionGroup = rootConnectionGroup;
-    });
-
-    // Navigate to home page, if not already there
-    userPageService.getHomePage()
-    .then(function homePageRetrieved(homePage) {
-        $location.url(homePage.url);
     });
 
 }]);

--- a/guacamole/src/main/webapp/app/home/controllers/homeController.js
+++ b/guacamole/src/main/webapp/app/home/controllers/homeController.js
@@ -30,10 +30,8 @@ angular.module('home').controller('homeController', ['$scope', '$injector',
     var ConnectionGroup = $injector.get("ConnectionGroup");
             
     // Get required services
-    var $location              = $injector.get("$location");
     var authenticationService  = $injector.get("authenticationService");
     var connectionGroupService = $injector.get("connectionGroupService");
-    var permissionService      = $injector.get("permissionService");
     var userPageService        = $injector.get("userPageService");
     
     /**
@@ -45,14 +43,6 @@ angular.module('home').controller('homeController', ['$scope', '$injector',
     $scope.rootConnectionGroup = null;
 
     /**
-     * All permissions associated with the current user, or null if the user's
-     * permissions have not yet been loaded.
-     *
-     * @type PermissionSet
-     */
-    $scope.permissions = null;
-
-    /**
      * Returns whether critical data has completed being loaded.
      *
      * @returns {Boolean}
@@ -61,27 +51,20 @@ angular.module('home').controller('homeController', ['$scope', '$injector',
      */
     $scope.isLoaded = function isLoaded() {
 
-        return $scope.rootConnectionGroup !== null
-            && $scope.permissions         !== null;
+        return $scope.rootConnectionGroup !== null;
 
     };
 
     // Retrieve root group and all descendants
     connectionGroupService.getConnectionGroupTree(ConnectionGroup.ROOT_IDENTIFIER)
     .success(function rootGroupRetrieved(rootConnectionGroup) {
-        
         $scope.rootConnectionGroup = rootConnectionGroup;
+    });
 
-        // Navigate to home page, if not already there
-        var homePage = userPageService.getHomePage(rootConnectionGroup);
+    // Navigate to home page, if not already there
+    userPageService.getHomePage()
+    .then(function homePageRetrieved(homePage) {
         $location.url(homePage.url);
-        
     });
-    
-    // Retrieve current permissions
-    permissionService.getPermissions(authenticationService.getCurrentUserID())
-    .success(function permissionsRetrieved(permissions) {
-        $scope.permissions = permissions;
-    });
-    
+
 }]);

--- a/guacamole/src/main/webapp/app/home/templates/home.html
+++ b/guacamole/src/main/webapp/app/home/templates/home.html
@@ -27,7 +27,7 @@
         <!-- The recent connections for this user -->
         <div class="header">
             <h2>{{'HOME.SECTION_HEADER_RECENT_CONNECTIONS' | translate}}</h2>
-            <guac-user-menu permissions="permissions" root-group="rootConnectionGroup"></guac-user-menu>
+            <guac-user-menu></guac-user-menu>
         </div>
         <div class="recent-connections">
             <guac-recent-connections root-group="rootConnectionGroup"></guac-recent-connections>

--- a/guacamole/src/main/webapp/app/index/indexModule.js
+++ b/guacamole/src/main/webapp/app/index/indexModule.js
@@ -29,6 +29,7 @@ angular.module('index', [
     'home',
     'login',
     'manage',
+    'navigation',
     'ngRoute',
     'ngTouch',
     'notification',

--- a/guacamole/src/main/webapp/app/login/controllers/loginController.js
+++ b/guacamole/src/main/webapp/app/login/controllers/loginController.js
@@ -26,6 +26,7 @@ angular.module('login').controller('loginController', ['$scope', '$injector',
     // Required services
     var $location             = $injector.get("$location");
     var authenticationService = $injector.get("authenticationService");
+    var userPageService       = $injector.get('userPageService');
 
     /**
      * Whether an error occurred during login.
@@ -52,7 +53,10 @@ angular.module('login').controller('loginController', ['$scope', '$injector',
 
         // Redirect to main view upon success
         .success(function success(data, status, headers, config) {
-            $location.path('/');
+            userPageService.getHomePage()
+            .then(function homePageRetrieved(homePage) {
+                $location.url(homePage.url);
+            });
         })
 
         // Reset and focus password upon failure

--- a/guacamole/src/main/webapp/app/login/loginModule.js
+++ b/guacamole/src/main/webapp/app/login/loginModule.js
@@ -23,4 +23,4 @@
 /**
  * The module for the login functionality.
  */
-angular.module('login', ['element']);
+angular.module('login', ['element', 'navigation']);

--- a/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
@@ -25,7 +25,7 @@ THE SOFTWARE.
     <!-- Main property editor -->
     <div class="header">
         <h2>{{'MANAGE_CONNECTION.SECTION_HEADER_EDIT_CONNECTION' | translate}}</h2>
-        <guac-user-menu permissions="permissions"></guac-user-menu>
+        <guac-user-menu></guac-user-menu>
     </div>
     <div class="section">
         <table class="properties">

--- a/guacamole/src/main/webapp/app/manage/templates/manageConnectionGroup.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageConnectionGroup.html
@@ -25,7 +25,7 @@ THE SOFTWARE.
     <!-- Main property editor -->
     <div class="header">
         <h2>{{'MANAGE_CONNECTION_GROUP.SECTION_HEADER_EDIT_CONNECTION_GROUP' | translate}}</h2>
-        <guac-user-menu permissions="permissions"></guac-user-menu>
+        <guac-user-menu></guac-user-menu>
     </div>
     <div class="section">
         <table class="properties">

--- a/guacamole/src/main/webapp/app/manage/templates/manageConnections.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageConnections.html
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
     <div class="header">
         <h2>{{'MANAGE_CONNECTION.SECTION_HEADER_CONNECTIONS' | translate}}</h2>
-        <guac-user-menu permissions="permissions"></guac-user-menu>
+        <guac-user-menu></guac-user-menu>
     </div>
 
     <!-- Connection management -->

--- a/guacamole/src/main/webapp/app/manage/templates/manageSessions.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageSessions.html
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
     <div class="header">
         <h2>{{'MANAGE_SESSION.SECTION_HEADER_SESSIONS' | translate}}</h2>
-        <guac-user-menu permissions="permissions"></guac-user-menu>
+        <guac-user-menu></guac-user-menu>
     </div>
 
     <!-- User Session management -->

--- a/guacamole/src/main/webapp/app/manage/templates/manageUser.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageUser.html
@@ -25,7 +25,7 @@ THE SOFTWARE.
     <!-- Main property editor -->
     <div class="header">
         <h2>{{'MANAGE_USER.SECTION_HEADER_EDIT_USER' | translate}}</h2>
-        <guac-user-menu permissions="permissions"></guac-user-menu>
+        <guac-user-menu></guac-user-menu>
     </div>
     <div class="section">
         <table class="properties">

--- a/guacamole/src/main/webapp/app/manage/templates/manageUsers.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageUsers.html
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
     <div class="header">
         <h2>{{'MANAGE_USER.SECTION_HEADER_USERS' | translate}}</h2>
-        <guac-user-menu permissions="permissions"></guac-user-menu>
+        <guac-user-menu></guac-user-menu>
     </div>
 
     <!-- User management -->

--- a/guacamole/src/main/webapp/app/navigation/navigationModule.js
+++ b/guacamole/src/main/webapp/app/navigation/navigationModule.js
@@ -23,4 +23,4 @@
 /**
  * Module for generating and implementing user navigation options.
  */
-angular.module('navigation', ['notification']);
+angular.module('navigation', ['notification', 'rest']);


### PR DESCRIPTION
This change adds the user menu to the Guacamole menu. As the user menu is always determined by the current user, the technically-unnecessary ```rootGroup``` and ```permissions``` attributes/parameters are removed from both the user menu and the page service.

Given some future caching of REST results, I believe this makes sense. Our existing services rely on dependency injection to avoid such parameter passing. Why not then rely on some similar sort of "data injection" via service calls?