### PR TITLE
GUAC-1126: Automatically clear connections and auth tokens upon login (fixes GUAC-1066).

### DIFF
--- a/guacamole/src/main/webapp/app/client/services/guacClientManager.js
+++ b/guacamole/src/main/webapp/app/client/services/guacClientManager.js
@@ -127,14 +127,22 @@ angular.module('client').factory('guacClientManager', ['$injector',
 
     };
 
-    // Disconnect all clients when window is unloaded
-    $window.addEventListener('unload', function disconnectAllClients() {
+    /**
+     * Disconnects and removes all currently-connected clients.
+     */
+    service.clear = function clear() {
 
         // Disconnect each managed client
         for (var id in service.managedClients)
             service.managedClients[id].client.disconnect();
 
-    });
+        // Clear managed clients
+        service.managedClients = {};
+
+    };
+
+    // Disconnect all clients when window is unloaded
+    $window.addEventListener('unload', service.clear);
 
     return service;
 

--- a/guacamole/src/main/webapp/app/login/controllers/loginController.js
+++ b/guacamole/src/main/webapp/app/login/controllers/loginController.js
@@ -24,8 +24,9 @@ angular.module('login').controller('loginController', ['$scope', '$injector',
         function loginController($scope, $injector) {
             
     // Required services
-    var $location             = $injector.get("$location");
-    var authenticationService = $injector.get("authenticationService");
+    var $location             = $injector.get('$location');
+    var authenticationService = $injector.get('authenticationService');
+    var guacClientManager     = $injector.get('guacClientManager');
     var userPageService       = $injector.get('userPageService');
 
     /**
@@ -53,10 +54,16 @@ angular.module('login').controller('loginController', ['$scope', '$injector',
 
         // Redirect to main view upon success
         .success(function success(data, status, headers, config) {
+
+            // Provide user with clean environment
+            guacClientManager.clear();
+
+            // Redirect to main view
             userPageService.getHomePage()
             .then(function homePageRetrieved(homePage) {
                 $location.url(homePage.url);
             });
+
         })
 
         // Reset and focus password upon failure

--- a/guacamole/src/main/webapp/app/login/controllers/loginController.js
+++ b/guacamole/src/main/webapp/app/login/controllers/loginController.js
@@ -49,11 +49,11 @@ angular.module('login').controller('loginController', ['$scope', '$injector',
      */
     $scope.login = function login() {
 
-        // Attempt login
+        // Attempt login once existing session is destroyed
         authenticationService.login($scope.username, $scope.password)
 
         // Redirect to main view upon success
-        .success(function success(data, status, headers, config) {
+        .then(function loginSuccessful() {
 
             // Provide user with clean environment
             guacClientManager.clear();
@@ -67,7 +67,7 @@ angular.module('login').controller('loginController', ['$scope', '$injector',
         })
 
         // Reset and focus password upon failure
-        .error(function error(data, status, headers, config) {
+        ['catch'](function loginFailed() {
             $scope.loginError = true;
             $scope.passwordFocused = true;
             $scope.password = '';

--- a/guacamole/src/main/webapp/app/login/loginModule.js
+++ b/guacamole/src/main/webapp/app/login/loginModule.js
@@ -23,4 +23,4 @@
 /**
  * The module for the login functionality.
  */
-angular.module('login', ['element', 'navigation']);
+angular.module('login', ['client', 'element', 'navigation']);


### PR DESCRIPTION
To avoid unexpected behavior due to in-memory active clients and multiple valid auth tokens, Guacamole should perform the following upon login:

1. Clear any managed clients, such that no connections remain active in memory
2. Invalidate the existing auth token, if any
