### PR TITLE
GUAC-1126: Maintain session-local data through login/logout events

### DIFF
--- a/guacamole/src/main/webapp/app/auth/authModule.js
+++ b/guacamole/src/main/webapp/app/auth/authModule.js
@@ -23,4 +23,4 @@
 /**
  * The module for authentication and management of tokens.
  */
-angular.module('auth', ['ngCookies', 'rest']);
+angular.module('auth', ['ngCookies']);

--- a/guacamole/src/main/webapp/app/client/services/guacClientManager.js
+++ b/guacamole/src/main/webapp/app/client/services/guacClientManager.js
@@ -30,7 +30,8 @@ angular.module('client').factory('guacClientManager', ['$injector',
     var ManagedClient = $injector.get('ManagedClient');
 
     // Required services
-    var $window = $injector.get('$window');
+    var $window    = $injector.get('$window');
+    var $rootScope = $injector.get('$rootScope');
 
     var service = {};
 
@@ -143,6 +144,11 @@ angular.module('client').factory('guacClientManager', ['$injector',
 
     // Disconnect all clients when window is unloaded
     $window.addEventListener('unload', service.clear);
+
+    // Clear clients on logout
+    $rootScope.$on('guacLogout', function handleLogout() {
+        service.clear();
+    });
 
     return service;
 

--- a/guacamole/src/main/webapp/app/login/controllers/loginController.js
+++ b/guacamole/src/main/webapp/app/login/controllers/loginController.js
@@ -26,7 +26,6 @@ angular.module('login').controller('loginController', ['$scope', '$injector',
     // Required services
     var $location             = $injector.get('$location');
     var authenticationService = $injector.get('authenticationService');
-    var guacClientManager     = $injector.get('guacClientManager');
     var userPageService       = $injector.get('userPageService');
 
     /**
@@ -54,16 +53,10 @@ angular.module('login').controller('loginController', ['$scope', '$injector',
 
         // Redirect to main view upon success
         .then(function loginSuccessful() {
-
-            // Provide user with clean environment
-            guacClientManager.clear();
-
-            // Redirect to main view
             userPageService.getHomePage()
             .then(function homePageRetrieved(homePage) {
                 $location.url(homePage.url);
             });
-
         })
 
         // Reset and focus password upon failure

--- a/guacamole/src/main/webapp/app/login/loginModule.js
+++ b/guacamole/src/main/webapp/app/login/loginModule.js
@@ -23,4 +23,4 @@
 /**
  * The module for the login functionality.
  */
-angular.module('login', ['client', 'element', 'navigation']);
+angular.module('login', ['element', 'navigation']);

--- a/guacamole/src/main/webapp/app/rest/services/cacheService.js
+++ b/guacamole/src/main/webapp/app/rest/services/cacheService.js
@@ -28,7 +28,7 @@ angular.module('rest').factory('cacheService', ['$injector',
 
     // Required services
     var $cacheFactory = $injector.get('$cacheFactory');
-    
+    var $rootScope    = $injector.get('$rootScope');
 
     // Service containing all caches
     var service = {};
@@ -63,7 +63,12 @@ angular.module('rest').factory('cacheService', ['$injector',
         service.connections.removeAll();
         service.users.removeAll();
     };
-    
+
+    // Clear caches on logout
+    $rootScope.$on('guacLogout', function handleLogout() {
+        service.clearCaches();
+    });
+
     return service;
 
 }]);


### PR DESCRIPTION
A minor change for sake of separation of concerns, this removes the need for the authentication service to "know" what other services need to be updated/cleared when a user's session is ending. Instead, generic ```guacLogin``` and ```guacLogout``` events are broadcast on the root scope.

Services, etc. which need to ensure data is destroyed upon logout (or upon login) can listen for these events and act accordingly.