### PR TITLE
GUAC-1126: Calculate active connections using the active connection service

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/activeconnection/ActiveConnectionPermissionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/activeconnection/ActiveConnectionPermissionService.java
@@ -88,20 +88,22 @@ public class ActiveConnectionPermissionService
         if (canReadPermissions(user, targetUser)) {
 
             // Only administrators may access active connections
-            if (!targetUser.isAdministrator())
-                return Collections.EMPTY_SET;
+            boolean isAdmin = targetUser.isAdministrator();
 
             // Get all active connections
             Collection<ActiveConnectionRecord> records = tunnelService.getActiveConnections(user);
 
-            // We have READ and DELETE on all active connections
+            // We have READ, and possibly DELETE, on all active connections
             Set<ObjectPermission> permissions = new HashSet<ObjectPermission>();
             for (ActiveConnectionRecord record : records) {
 
-                // Add implicit READ and DELETE
+                // Add implicit READ
                 String identifier = record.getUUID().toString();
-                permissions.add(new ObjectPermission(ObjectPermission.Type.READ,   identifier));
-                permissions.add(new ObjectPermission(ObjectPermission.Type.DELETE, identifier));
+                permissions.add(new ObjectPermission(ObjectPermission.Type.READ, identifier));
+
+                // If we're and admin, then we also have DELETE
+                if (isAdmin)
+                    permissions.add(new ObjectPermission(ObjectPermission.Type.DELETE, identifier));
 
             }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/activeconnection/ActiveConnectionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/activeconnection/ActiveConnectionService.java
@@ -26,6 +26,7 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import org.glyptodon.guacamole.auth.jdbc.user.AuthenticatedUser;
@@ -62,35 +63,42 @@ public class ActiveConnectionService
     public TrackedActiveConnection retrieveObject(AuthenticatedUser user,
             String identifier) throws GuacamoleException {
 
-        // Only administrators may retrieve active connections
-        if (!user.getUser().isAdministrator())
-            throw new GuacamoleSecurityException("Permission denied.");
+        // Pull objects having given identifier
+        Collection<TrackedActiveConnection> objects = retrieveObjects(user, Collections.singleton(identifier));
 
-        // Retrieve record associated with requested connection
-        ActiveConnectionRecord record = tunnelService.getActiveConnection(user, identifier);
-        if (record == null)
+        // If no such object, return null
+        if (objects.isEmpty())
             return null;
 
-        // Return tracked active connection using retrieved record
-        TrackedActiveConnection activeConnection = trackedActiveConnectionProvider.get();
-        activeConnection.init(user, record);
-        return activeConnection;
-        
+        // The object collection will have exactly one element unless the
+        // database has seriously lost integrity
+        assert(objects.size() == 1);
+
+        // Return first and only object
+        return objects.iterator().next();
+
     }
     
     @Override
     public Collection<TrackedActiveConnection> retrieveObjects(AuthenticatedUser user,
             Collection<String> identifiers) throws GuacamoleException {
 
-        // Build list of all active connections with given identifiers
-        Collection<TrackedActiveConnection> activeConnections = new ArrayList<TrackedActiveConnection>(identifiers.size());
-        for (String identifier : identifiers) {
+        Set<String> identifierSet = new HashSet<String>(identifiers);
 
-            // Add connection to list if it exists
-            TrackedActiveConnection activeConnection = retrieveObject(user, identifier);
-            if (activeConnection != null)
+        // Retrieve all visible connections (permissions enforced by tunnel service)
+        Collection<ActiveConnectionRecord> records = tunnelService.getActiveConnections(user);
+
+        // Restrict to subset of records which match given identifiers
+        Collection<TrackedActiveConnection> activeConnections = new ArrayList<TrackedActiveConnection>(identifiers.size());
+        for (ActiveConnectionRecord record : records) {
+
+            // Add connection if within requested identifiers
+            if (identifierSet.contains(record.getUUID().toString())) {
+                TrackedActiveConnection activeConnection = trackedActiveConnectionProvider.get();
+                activeConnection.init(user, record);
                 activeConnections.add(activeConnection);
-            
+            }
+
         }
 
         return activeConnections;
@@ -100,6 +108,10 @@ public class ActiveConnectionService
     @Override
     public void deleteObject(AuthenticatedUser user, String identifier)
         throws GuacamoleException {
+
+        // Only administrators may delete active connections
+        if (!user.getUser().isAdministrator())
+            throw new GuacamoleSecurityException("Permission denied.");
 
         // Close connection, if it exists (and we have permission)
         ActiveConnection activeConnection = retrieveObject(user, identifier);

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/activeconnection/ActiveConnectionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/activeconnection/ActiveConnectionService.java
@@ -83,6 +83,7 @@ public class ActiveConnectionService
     public Collection<TrackedActiveConnection> retrieveObjects(AuthenticatedUser user,
             Collection<String> identifiers) throws GuacamoleException {
 
+        boolean isAdmin = user.getUser().isAdministrator();
         Set<String> identifierSet = new HashSet<String>(identifiers);
 
         // Retrieve all visible connections (permissions enforced by tunnel service)
@@ -95,7 +96,7 @@ public class ActiveConnectionService
             // Add connection if within requested identifiers
             if (identifierSet.contains(record.getUUID().toString())) {
                 TrackedActiveConnection activeConnection = trackedActiveConnectionProvider.get();
-                activeConnection.init(user, record);
+                activeConnection.init(user, record, isAdmin);
                 activeConnections.add(activeConnection);
             }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/activeconnection/TrackedActiveConnection.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/activeconnection/TrackedActiveConnection.java
@@ -69,26 +69,40 @@ public class TrackedActiveConnection extends RestrictedObject implements ActiveC
 
     /**
      * Initializes this TrackedActiveConnection, copying the data associated
-     * with the given active connection record.
+     * with the given active connection record. At a minimum, the identifier
+     * of this active connection will be set, the start date, and the
+     * identifier of the associated connection will be copied. If requested,
+     * sensitive information like the associated username will be copied, as
+     * well.
      *
      * @param currentUser
      *     The user that created or retrieved this object.
      *
      * @param activeConnectionRecord
      *     The active connection record to copy.
+     *
+     * @param includeSensitiveInformation
+     *     Whether sensitive data should be copied from the connection record
+     *     as well. This includes the remote host, associated tunnel, and
+     *     username.
      */
     public void init(AuthenticatedUser currentUser,
-            ActiveConnectionRecord activeConnectionRecord) {
+            ActiveConnectionRecord activeConnectionRecord,
+            boolean includeSensitiveInformation) {
 
         super.init(currentUser);
         
-        // Copy all data from given record
+        // Copy all non-sensitive data from given record
         this.connectionIdentifier = activeConnectionRecord.getConnection().getIdentifier();
         this.identifier           = activeConnectionRecord.getUUID().toString();
-        this.remoteHost           = activeConnectionRecord.getRemoteHost();
         this.startDate            = activeConnectionRecord.getStartDate();
-        this.tunnel               = activeConnectionRecord.getTunnel();
-        this.username             = activeConnectionRecord.getUsername();
+
+        // Include sensitive data, too, if requested
+        if (includeSensitiveInformation) {
+            this.remoteHost = activeConnectionRecord.getRemoteHost();
+            this.tunnel     = activeConnectionRecord.getTunnel();
+            this.username   = activeConnectionRecord.getUsername();
+        }
 
     }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/tunnel/GuacamoleTunnelService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/tunnel/GuacamoleTunnelService.java
@@ -60,30 +60,6 @@ public interface GuacamoleTunnelService {
             throws GuacamoleException;
 
     /**
-     * Returns the connection records representing the connection associated
-     * with the tunnel having the given UUID, if that connection is visible to
-     * the given user.
-     *
-     * @param user
-     *     The user retrieving the active connection.
-     * 
-     * @param tunnelUUID
-     *     The UUID of the tunnel associated with the active connection being
-     *     retrieved.
-     *
-     * @return
-     *     The active connection associated with the tunnel having the given
-     *     UUID, or null if no such connection exists.
-     *
-     * @throws GuacamoleException
-     *     If an error occurs while retrieving all active connections, or if
-     *     permission is denied.
-     */
-    public ActiveConnectionRecord getActiveConnection(AuthenticatedUser user,
-            String tunnelUUID)
-            throws GuacamoleException;
-
-    /**
      * Creates a socket for the given user which connects to the given
      * connection. The given client information will be passed to guacd when
      * the connection is established. This function will apply any concurrent

--- a/guacamole-ext/src/main/java/org/glyptodon/guacamole/net/auth/ActiveConnection.java
+++ b/guacamole-ext/src/main/java/org/glyptodon/guacamole/net/auth/ActiveConnection.java
@@ -34,7 +34,9 @@ import org.glyptodon.guacamole.net.GuacamoleTunnel;
 public interface ActiveConnection extends Identifiable {
 
     /**
-     * Returns the identifier of the connection being actively used.
+     * Returns the identifier of the connection being actively used. Unlike the
+     * other information stored in this object, the connection identifier must
+     * be present and MAY NOT be null.
      *
      * @return
      *     The identifier of the connection being actively used.
@@ -53,7 +55,8 @@ public interface ActiveConnection extends Identifiable {
      * Returns the date and time the connection began.
      *
      * @return
-     *     The date and time the connection began.
+     *     The date and time the connection began, or null if this
+     *     information is not available.
      */
     Date getStartDate();
 
@@ -61,7 +64,8 @@ public interface ActiveConnection extends Identifiable {
      * Sets the date and time the connection began.
      *
      * @param startDate 
-     *     The date and time the connection began.
+     *     The date and time the connection began, or null if this
+     *     information is not available.
      */
     void setStartDate(Date startDate);
 
@@ -90,7 +94,8 @@ public interface ActiveConnection extends Identifiable {
      * Returns the name of the user who is using this connection.
      *
      * @return
-     *     The name of the user who is using this connection.
+     *     The name of the user who is using this connection, or null if this
+     *     information is not available.
      */
     String getUsername();
 
@@ -98,7 +103,8 @@ public interface ActiveConnection extends Identifiable {
      * Sets the name of the user who is using this connection.
      *
      * @param username 
-     *     The name of the user who is using this connection.
+     *     The name of the user who is using this connection, or null if this
+     *     information is not available.
      */
     void setUsername(String username);
 

--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/activeconnection/ActiveConnectionRESTService.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/activeconnection/ActiveConnectionRESTService.java
@@ -106,14 +106,14 @@ public class ActiveConnectionRESTService {
         if (permissions != null && permissions.isEmpty())
             permissions = null;
 
-        // An admin user has access to any user
+        // An admin user has access to any connection
         SystemPermissionSet systemPermissions = self.getSystemPermissions();
         boolean isAdmin = systemPermissions.hasPermission(SystemPermission.Type.ADMINISTER);
 
         // Get the directory
         Directory<ActiveConnection> activeConnectionDirectory = userContext.getActiveConnectionDirectory();
 
-        // Filter users, if requested
+        // Filter connections, if requested
         Collection<String> activeConnectionIdentifiers = activeConnectionDirectory.getIdentifiers();
         if (!isAdmin && permissions != null) {
             ObjectPermissionSet activeConnectionPermissions = self.getActiveConnectionPermissions();

--- a/guacamole/src/main/webapp/app/home/templates/connection.html
+++ b/guacamole/src/main/webapp/app/home/templates/connection.html
@@ -21,7 +21,7 @@
        THE SOFTWARE.
     -->
 
-    <div class="caption" ng-class="{active: item.activeConnections}">
+    <div class="caption" ng-class="{active: item.getActiveConnections()}">
 
         <!-- Connection icon -->
         <div class="protocol">
@@ -32,8 +32,8 @@
         <span class="name">{{item.name}}</span>
         
         <!-- Active user count -->
-        <span class="activeUserCount" ng-show="item.activeConnections">
-            {{'HOME.INFO_ACTIVE_USER_COUNT' | translate:'{USERS: item.activeConnections}'}}
+        <span class="activeUserCount" ng-show="item.getActiveConnections()">
+            {{'HOME.INFO_ACTIVE_USER_COUNT' | translate:'{USERS: item.getActiveConnections()}'}}
         </span>
 
     </div>

--- a/guacamole/src/main/webapp/app/manage/templates/connection.html
+++ b/guacamole/src/main/webapp/app/manage/templates/connection.html
@@ -21,7 +21,7 @@
        THE SOFTWARE.
     -->
 
-    <div class="caption" ng-class="{active: item.activeConnections}">
+    <div class="caption" ng-class="{active: item.getActiveConnections()}">
 
         <!-- Connection icon -->
         <div class="protocol">
@@ -32,8 +32,8 @@
         <span class="name">{{item.name}}</span>
 
         <!-- Active user count -->
-        <span class="activeUserCount" ng-show="item.activeConnections">
-            {{'MANAGE_CONNECTION.INFO_ACTIVE_USER_COUNT' | translate:'{USERS: item.activeConnections}'}}
+        <span class="activeUserCount" ng-show="item.getActiveConnections()">
+            {{'MANAGE_CONNECTION.INFO_ACTIVE_USER_COUNT' | translate:'{USERS: item.getActiveConnections()}'}}
         </span>
         
     </div>

--- a/guacamole/src/main/webapp/app/rest/types/ActiveConnection.js
+++ b/guacamole/src/main/webapp/app/rest/types/ActiveConnection.js
@@ -59,7 +59,7 @@ angular.module('rest').factory('ActiveConnection', [function defineActiveConnect
 
         /**
          * The time that the connection began, in seconds since
-         * 1970-01-01 00:00:00 UTC.
+         * 1970-01-01 00:00:00 UTC, if known.
          *
          * @type Number 
          */
@@ -73,7 +73,7 @@ angular.module('rest').factory('ActiveConnection', [function defineActiveConnect
         this.remoteHost = template.remoteHost;
 
         /**
-         * The username of the user associated with the connection.
+         * The username of the user associated with the connection, if known.
          * 
          * @type String
          */


### PR DESCRIPTION
Rather than use the ```activeConnections``` property of connections and groups from ```/api/connectionGroups/*/tree```, which may be cached, instead query ```/api/activeConnections``` within the ```guacGroupList``` directive.

This requires:

1. Modifying the permissions checks of the database auth to display provide active connection info about connections you can ```READ```
2. Updating documentation to describe most properties of active connections as optional / ```null``` if unknown
3. Modifying the UI code to pull all this new information from the active connection service, and map it into place via a dynamically-set getter

