### PR TITLE
GUAC-1096: Properly close() and cleanup HTTP tunnel when end-of-stream is encountered.

### DIFF
--- a/guacamole-common/src/main/java/org/glyptodon/guacamole/servlet/GuacamoleHTTPTunnelServlet.java
+++ b/guacamole-common/src/main/java/org/glyptodon/guacamole/servlet/GuacamoleHTTPTunnelServlet.java
@@ -305,8 +305,10 @@ public abstract class GuacamoleHTTPTunnelServlet extends HttpServlet {
                 } while (tunnel.isOpen() && (message = reader.read()) != null);
 
                 // Close tunnel immediately upon EOF
-                if (message == null)
+                if (message == null) {
+                    session.detachTunnel(tunnel);
                     tunnel.close();
+                }
 
                 // End-of-instructions marker
                 out.write("0.;");
@@ -314,11 +316,18 @@ public abstract class GuacamoleHTTPTunnelServlet extends HttpServlet {
                 response.flushBuffer();
             }
 
-            // Send end-of-stream marker if connection is closed
+            // Send end-of-stream marker and close tunnel if connection is closed
             catch (GuacamoleConnectionClosedException e) {
+
+                // Detach and close
+                session.detachTunnel(tunnel);
+                tunnel.close();
+
+                // End-of-instructions marker
                 out.write("0.;");
                 out.flush();
                 response.flushBuffer();
+
             }
 
             catch (GuacamoleException e) {


### PR DESCRIPTION
The tunnel is currently not explicitly closed in all cases when end-of-stream is encountered. If the connection closes between requests, the tunnel may never be explicitly closed, and the client will never detect the end-of-stream condition, even though the underlying socket is not open.