### PR TITLE
GUAC-1106: Create generalized form module and directives

### DIFF
--- a/guacamole/src/main/webapp/app/form/directives/form.js
+++ b/guacamole/src/main/webapp/app/form/directives/form.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2015 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+/**
+ * A directive that allows editing of a collection of fields.
+ */
+angular.module('form').directive('guacForm', [function form() {
+
+    return {
+        // Element only
+        restrict: 'E',
+        replace: true,
+        scope: {
+
+            /**
+             * The fields to display.
+             *
+             * @type Field[]
+             */
+            fields : '=',
+
+            /**
+             * The object which will receive all field values. Each field value
+             * will be assigned to the property of this object having the same
+             * name.
+             *
+             * @type Object.<String, String>
+             */
+            model : '='
+
+        },
+        templateUrl: 'app/form/templates/form.html',
+        controller: ['$scope', function formController($scope) {
+
+            /**
+             * The object which will receive all field values. Normally, this
+             * will be the object provided within the "model" attribute. If
+             * no such object has been provided, a blank model will be used
+             * instead as a placeholder, such that the fields of this form
+             * will have something to bind to.
+             *
+             * @type Object.<String, String>
+             */
+            $scope.values = {};
+
+            // Update string value and re-assign to model when field is changed
+            $scope.$watch('model', function setModel(model) {
+
+                // Assign new model only if provided
+                if (model)
+                    $scope.values = model;
+
+                // Otherwise, use blank model
+                else
+                    $scope.values = {};
+
+            });
+
+        }] // end controller
+    };
+
+}]);

--- a/guacamole/src/main/webapp/app/form/directives/form.js
+++ b/guacamole/src/main/webapp/app/form/directives/form.js
@@ -33,6 +33,17 @@ angular.module('form').directive('guacForm', [function form() {
         scope: {
 
             /**
+             * The translation namespace of the translation strings that will
+             * be generated for all fields. This namespace is absolutely
+             * required. If this namespace is omitted, all generated
+             * translation strings will be placed within the MISSING_NAMESPACE
+             * namespace, as a warning.
+             *
+             * @type String
+             */
+            namespace : '=',
+
+            /**
              * The fields to display.
              *
              * @type Field[]
@@ -50,7 +61,10 @@ angular.module('form').directive('guacForm', [function form() {
 
         },
         templateUrl: 'app/form/templates/form.html',
-        controller: ['$scope', function formController($scope) {
+        controller: ['$scope', '$injector', function formController($scope, $injector) {
+
+            // Required services
+            var translationStringService = $injector.get('translationStringService');
 
             /**
              * The object which will receive all field values. Normally, this
@@ -62,6 +76,30 @@ angular.module('form').directive('guacForm', [function form() {
              * @type Object.<String, String>
              */
             $scope.values = {};
+
+            /**
+             * Produces the translation string for the header of the given
+             * field. The translation string will be of the form:
+             *
+             * <code>NAMESPACE.FIELD_HEADER_NAME<code>
+             *
+             * where <code>NAMESPACE</code> is the namespace provided to the
+             * directive and <code>NAME</code> is the field name transformed
+             * via translationStringService.canonicalize().
+             *
+             * @param {Field} field
+             *     The field for which to produce the translation string.
+             *
+             * @returns {String}
+             *     The translation string which produces the translated header
+             *     of the field.
+             */
+            $scope.getFieldHeader = function getFieldHeader(field) {
+
+                return translationStringService.canonicalize($scope.namespace || 'MISSING_NAMESPACE')
+                        + '.FIELD_HEADER_' + translationStringService.canonicalize(field.name);
+
+            };
 
             // Update string value and re-assign to model when field is changed
             $scope.$watch('model', function setModel(model) {

--- a/guacamole/src/main/webapp/app/form/directives/formField.js
+++ b/guacamole/src/main/webapp/app/form/directives/formField.js
@@ -22,9 +22,9 @@
 
 
 /**
- * A directive that allows editing of a connection parameter.
+ * A directive that allows editing of a field.
  */
-angular.module('manage').directive('guacConnectionParameter', [function connectionParameter() {
+angular.module('form').directive('guacFormField', [function formField() {
     
     return {
         // Element only
@@ -48,8 +48,8 @@ angular.module('manage').directive('guacConnectionParameter', [function connecti
             model : '='
 
         },
-        templateUrl: 'app/manage/templates/connectionParameter.html',
-        controller: ['$scope', '$injector', function connectionParameterController($scope, $injector) {
+        templateUrl: 'app/form/templates/formField.html',
+        controller: ['$scope', '$injector', function formFieldController($scope, $injector) {
 
             /**
              * The type to use for password input fields. By default, password
@@ -80,9 +80,9 @@ angular.module('manage').directive('guacConnectionParameter', [function connecti
             };
 
             /**
-             * Toggles visibility of the parameter contents, if this parameter
-             * is a password parameter. Initially, password contents are
-             * masked (invisible).
+             * Toggles visibility of the field contents, if this field is a 
+             * password field. Initially, password contents are masked
+             * (invisible).
              */
             $scope.togglePassword = function togglePassword() {
 
@@ -119,7 +119,7 @@ angular.module('manage').directive('guacConnectionParameter', [function connecti
                 else if ($scope.field.type === 'BOOLEAN')
                     $scope.typedValue = (modelValue === $scope.field.value);
 
-                // All other parameter types are represented internally as strings
+                // All other field types are represented internally as strings
                 else
                     $scope.typedValue = modelValue || '';
 
@@ -152,7 +152,7 @@ angular.module('manage').directive('guacConnectionParameter', [function connecti
                 else if ($scope.field.type === 'BOOLEAN')
                     $scope.model = (typedValue ? $scope.field.value : '');
 
-                // All other parameter types are already strings
+                // All other field types are already strings
                 else
                     $scope.model = typedValue || '';
 
@@ -164,12 +164,12 @@ angular.module('manage').directive('guacConnectionParameter', [function connecti
                 setModelValue($scope.typedValue);
             });
 
-            // Update typed value when parameter set is changed
+            // Update typed value when model is changed
             $scope.$watch('model', function setModel(model) {
                 setTypedValue(model);
             });
 
-            // Update string value in parameter set when typed value is changed
+            // Update string value in model when typed value is changed
             $scope.$watch('typedValue', function typedValueChanged(typedValue) {
                 setModelValue(typedValue);
             });

--- a/guacamole/src/main/webapp/app/form/directives/formField.js
+++ b/guacamole/src/main/webapp/app/form/directives/formField.js
@@ -33,6 +33,17 @@ angular.module('form').directive('guacFormField', [function formField() {
         scope: {
 
             /**
+             * The translation namespace of the translation strings that will
+             * be generated for this field. This namespace is absolutely
+             * required. If this namespace is omitted, all generated
+             * translation strings will be placed within the MISSING_NAMESPACE
+             * namespace, as a warning.
+             *
+             * @type String
+             */
+            namespace : '=',
+
+            /**
              * The field to display.
              *
              * @type Field
@@ -50,6 +61,9 @@ angular.module('form').directive('guacFormField', [function formField() {
         },
         templateUrl: 'app/form/templates/formField.html',
         controller: ['$scope', '$injector', function formFieldController($scope, $injector) {
+
+            // Required services
+            var translationStringService = $injector.get('translationStringService');
 
             /**
              * The type to use for password input fields. By default, password
@@ -72,10 +86,10 @@ angular.module('form').directive('guacFormField', [function formField() {
 
                 // If password is hidden, togglePassword() will show the password
                 if ($scope.passwordInputType === 'password')
-                    return 'MANAGE.HELP_SHOW_PASSWORD';
+                    return 'FORM.HELP_SHOW_PASSWORD';
 
                 // If password is shown, togglePassword() will hide the password
-                return 'MANAGE.HELP_HIDE_PASSWORD';
+                return 'FORM.HELP_HIDE_PASSWORD';
 
             };
 
@@ -97,6 +111,37 @@ angular.module('form').directive('guacFormField', [function formField() {
             };
 
             /**
+             * Produces the translation string for the given field option
+             * value. The translation string will be of the form:
+             *
+             * <code>NAMESPACE.FIELD_OPTION_NAME_VALUE<code>
+             *
+             * where <code>NAMESPACE</code> is the namespace provided to the
+             * directive, <code>NAME</code> is the field name transformed
+             * via translationStringService.canonicalize(), and
+             * <code>VALUE</code> is the option value transformed via
+             * translationStringService.canonicalize()
+             *
+             * @param {String} value
+             *     The name of the option value.
+             *
+             * @returns {String}
+             *     The translation string which produces the translated name of the
+             *     value specified.
+             */
+            $scope.getFieldOption = function getFieldOption(value) {
+
+                // Don't bother if the model is not yet defined
+                if (!$scope.field)
+                    return '';
+
+                return translationStringService.canonicalize($scope.namespace || 'MISSING_NAMESPACE')
+                        + '.FIELD_OPTION_' + translationStringService.canonicalize($scope.field.name)
+                        + '_'              + translationStringService.canonicalize(value || 'EMPTY');
+
+            };
+
+            /**
              * Translates the given string field value into an appropriately-
              * typed value as dictated by the attributes of the field,
              * exposing that typed value within the scope as
@@ -107,7 +152,7 @@ angular.module('form').directive('guacFormField', [function formField() {
              */
             var setTypedValue = function setTypedValue(modelValue) {
 
-                // Don't bother if the modelValue is not yet defined
+                // Don't bother if the model is not yet defined
                 if (!$scope.field)
                     return;
 
@@ -148,7 +193,7 @@ angular.module('form').directive('guacFormField', [function formField() {
                         $scope.model = typedValue.toString();
                 }
 
-                // Convert boolean values back into strings based on protocol description
+                // Convert boolean values back into strings based on field description
                 else if ($scope.field.type === 'BOOLEAN')
                     $scope.model = (typedValue ? $scope.field.value : '');
 

--- a/guacamole/src/main/webapp/app/form/formModule.js
+++ b/guacamole/src/main/webapp/app/form/formModule.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Glyptodon LLC
+ * Copyright (C) 2015 Glyptodon LLC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,14 +21,6 @@
  */
 
 /**
- * The module for the administration functionality.
+ * Module for displaying dynamic forms.
  */
-angular.module('manage', [
-    'form',
-    'groupList',
-    'list',
-    'locale',
-    'navigation',
-    'notification',
-    'rest'
-]);
+angular.module('form', []);

--- a/guacamole/src/main/webapp/app/form/formModule.js
+++ b/guacamole/src/main/webapp/app/form/formModule.js
@@ -23,4 +23,4 @@
 /**
  * Module for displaying dynamic forms.
  */
-angular.module('form', []);
+angular.module('form', ['locale']);

--- a/guacamole/src/main/webapp/app/form/styles/form-field.css
+++ b/guacamole/src/main/webapp/app/form/styles/form-field.css
@@ -20,8 +20,31 @@
  * THE SOFTWARE.
  */
 
-table.form th {
-    text-align: left;
-    font-weight: normal;
-    padding-right: 1em;
+/* Keep toggle-password icon on same line */
+.form-field .password-field {
+    white-space: nowrap;
+}
+
+/* Generic 1x1em icon/button */
+.form-field .password-field .icon.toggle-password {
+
+    display: inline-block;
+    opacity: 0.5;
+    cursor: default;
+
+    background-repeat: no-repeat;
+    background-size: 1em;
+    width: 1em;
+    height: 1em;
+
+}
+
+/* Icon for unmasking passwords */
+.form-field .password-field input[type=password] ~ .icon.toggle-password {
+    background-image: url('images/action-icons/guac-show-pass.png');
+}
+
+/* Icon for masking passwords */
+.form-field .password-field input[type=text] ~ .icon.toggle-password {
+    background-image: url('images/action-icons/guac-hide-pass.png');
 }

--- a/guacamole/src/main/webapp/app/form/styles/form.css
+++ b/guacamole/src/main/webapp/app/form/styles/form.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Glyptodon LLC
+ * Copyright (C) 2015 Glyptodon LLC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,15 +20,31 @@
  * THE SOFTWARE.
  */
 
-/**
- * The module for the administration functionality.
- */
-angular.module('manage', [
-    'form',
-    'groupList',
-    'list',
-    'locale',
-    'navigation',
-    'notification',
-    'rest'
-]);
+/* Keep toggle-password icon on same line */
+.form-field .password-field {
+    white-space: nowrap;
+}
+
+/* Generic 1x1em icon/button */
+.form-field .password-field .icon.toggle-password {
+
+    display: inline-block;
+    opacity: 0.5;
+    cursor: default;
+
+    background-repeat: no-repeat;
+    background-size: 1em;
+    width: 1em;
+    height: 1em;
+
+}
+
+/* Icon for unmasking passwords */
+.form-field .password-field input[type=password] ~ .icon.toggle-password {
+    background-image: url('images/action-icons/guac-show-pass.png');
+}
+
+/* Icon for masking passwords */
+.form-field .password-field input[type=text] ~ .icon.toggle-password {
+    background-image: url('images/action-icons/guac-hide-pass.png');
+}

--- a/guacamole/src/main/webapp/app/form/templates/form.html
+++ b/guacamole/src/main/webapp/app/form/templates/form.html
@@ -23,9 +23,9 @@
 
     <!-- All fields in form -->
     <tr ng-repeat="field in fields">
-        <th>{{field.title | translate}}</th>
+        <th>{{getFieldHeader(field) | translate}}</th>
         <td>
-            <guac-form-field field="field" model="values[field.name]"></guac-form-field>
+            <guac-form-field namespace="namespace" field="field" model="values[field.name]"></guac-form-field>
         </td>
     </tr>
 

--- a/guacamole/src/main/webapp/app/form/templates/form.html
+++ b/guacamole/src/main/webapp/app/form/templates/form.html
@@ -1,0 +1,32 @@
+<table class="form">
+    <!--
+        Copyright 2015 Glyptodon LLC.
+
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in
+        all copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+        THE SOFTWARE.
+    -->
+
+    <!-- All fields in form -->
+    <tr ng-repeat="field in fields">
+        <th>{{field.title | translate}}</th>
+        <td>
+            <guac-form-field field="field" model="values[field.name]"></guac-form-field>
+        </td>
+    </tr>
+
+</table>

--- a/guacamole/src/main/webapp/app/form/templates/formField.html
+++ b/guacamole/src/main/webapp/app/form/templates/formField.html
@@ -37,6 +37,6 @@
     <textarea ng-show="field.type === 'MULTILINE'" ng-model="typedValue" autocorrect="off" autocapitalize="off"></textarea>
 
     <!-- Enumerated field -->
-    <select ng-show="field.type === 'ENUM'" ng-model="typedValue" ng-options="option.value as option.title | translate for option in field.options | orderBy: value"></select>
+    <select ng-show="field.type === 'ENUM'" ng-model="typedValue" ng-options="option.value as getFieldOption(option.value) | translate for option in field.options | orderBy: value"></select>
 
 </div>

--- a/guacamole/src/main/webapp/app/form/templates/formField.html
+++ b/guacamole/src/main/webapp/app/form/templates/formField.html
@@ -1,4 +1,4 @@
-<div class="connection-parameter">
+<div class="form-field">
     <!--
         Copyright 2014 Glyptodon LLC.
 

--- a/guacamole/src/main/webapp/app/manage/controllers/manageConnectionController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageConnectionController.js
@@ -282,26 +282,6 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
     };
 
     /**
-     * Given the internal name of a protocol and the internal name of a
-     * parameter for that protocol, produces the translation string
-     * for the localized, human-readable name of that protocol parameter.
-     *
-     * @param {String} protocolName
-     *     The name of the protocol.
-     * 
-     * @param {String} parameterName
-     *     The name of the protocol parameter.
-     * 
-     * @returns {String}
-     *     The translation string which produces the translated name of the
-     *     protocol parameter specified.
-     */
-    $scope.getProtocolParameterName = function getProtocolParameterName(protocolName, parameterName) {
-        return 'PROTOCOL_'      + translationStringService.canonicalize(protocolName)
-             + '.FIELD_HEADER_' + translationStringService.canonicalize(parameterName);
-    };
-
-    /**
      * Cancels all pending edits, returning to the management page.
      */
     $scope.cancel = function cancel() {

--- a/guacamole/src/main/webapp/app/manage/controllers/manageConnectionController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageConnectionController.js
@@ -267,8 +267,40 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
     }
 
     /**
+     * Returns the translation string namespace for the protocol having the
+     * given name. The namespace will be of the form:
+     *
+     * <code>PROTOCOL_NAME</code>
+     *
+     * where <code>NAME</code> is the protocol name transformed via
+     * translationStringService.canonicalize().
+     *
+     * @param {String} protocolName
+     *     The name of the protocol.
+     *
+     * @returns {String}
+     *     The translation namespace for the protocol specified, or null if no
+     *     namespace could be generated.
+     */
+    $scope.getNamespace = function getNamespace(protocolName) {
+
+        // Do not generate a namespace if no protocol is selected
+        if (!protocolName)
+            return null;
+
+        return 'PROTOCOL_' + translationStringService.canonicalize(protocolName);
+
+    };
+
+    /**
      * Given the internal name of a protocol, produces the translation string
-     * for the localized version of that protocol's name.
+     * for the localized version of that protocol's name. The translation
+     * string will be of the form:
+     *
+     * <code>NAMESPACE.NAME<code>
+     *
+     * where <code>NAMESPACE</code> is the namespace generated from
+     * $scope.getNamespace().
      *
      * @param {String} protocolName
      *     The name of the protocol.
@@ -278,7 +310,7 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
      *     protocol specified.
      */
     $scope.getProtocolName = function getProtocolName(protocolName) {
-        return 'PROTOCOL_' + translationStringService.canonicalize(protocolName) + '.NAME';
+        return $scope.getNamespace(protocolName) + '.NAME';
     };
 
     /**

--- a/guacamole/src/main/webapp/app/manage/styles/connection-parameter.css
+++ b/guacamole/src/main/webapp/app/manage/styles/connection-parameter.css
@@ -21,37 +21,8 @@
  */
 
 /* Do not stretch connection parameters to fit available area */
-.connection-parameter input[type=text],
-.connection-parameter input[type=password],
-.connection-parameter input[type=number] {
+.connection-parameters input[type=text],
+.connection-parameters input[type=password],
+.connection-parameters input[type=number] {
     width: auto;
-}
-
-/* Keep toggle-password icon on same line */
-.connection-parameter .password-field {
-    white-space: nowrap;
-}
-
-/* Generic 1x1em icon/button */
-.connection-parameter .password-field .icon.toggle-password {
-
-    display: inline-block;
-    opacity: 0.5;
-    cursor: default;
-
-    background-repeat: no-repeat;
-    background-size: 1em;
-    width: 1em;
-    height: 1em;
-
-}
-
-/* Icon for unmasking passwords */
-.connection-parameter .password-field input[type=password] ~ .icon.toggle-password {
-    background-image: url('images/action-icons/guac-show-pass.png');
-}
-
-/* Icon for masking passwords */
-.connection-parameter .password-field input[type=text] ~ .icon.toggle-password {
-    background-image: url('images/action-icons/guac-hide-pass.png');
 }

--- a/guacamole/src/main/webapp/app/manage/templates/connectionParameter.html
+++ b/guacamole/src/main/webapp/app/manage/templates/connectionParameter.html
@@ -22,21 +22,21 @@
     -->
 
     <!-- Generic input types -->
-    <input    ng-show="parameter.type === 'TEXT'"     type="text"     ng-model="typedValue" autocorrect="off" autocapitalize="off"/>
-    <input    ng-show="parameter.type === 'NUMERIC'"  type="number"   ng-model="typedValue" autocorrect="off" autocapitalize="off"/>
-    <input    ng-show="parameter.type === 'USERNAME'" type="text"     ng-model="typedValue" autocorrect="off" autocapitalize="off"/>
-    <input    ng-show="parameter.type === 'BOOLEAN'"  type="checkbox" ng-model="typedValue" autocorrect="off" autocapitalize="off"/>
+    <input ng-show="field.type === 'TEXT'"     type="text"     ng-model="typedValue" autocorrect="off" autocapitalize="off"/>
+    <input ng-show="field.type === 'NUMERIC'"  type="number"   ng-model="typedValue" autocorrect="off" autocapitalize="off"/>
+    <input ng-show="field.type === 'USERNAME'" type="text"     ng-model="typedValue" autocorrect="off" autocapitalize="off"/>
+    <input ng-show="field.type === 'BOOLEAN'"  type="checkbox" ng-model="typedValue" autocorrect="off" autocapitalize="off"/>
 
-    <!-- Password parameter -->
-    <div ng-show="parameter.type === 'PASSWORD'" class="password-field">
+    <!-- Password field -->
+    <div ng-show="field.type === 'PASSWORD'" class="password-field">
         <input type="{{passwordInputType}}" ng-model="typedValue" autocorrect="off" autocapitalize="off"/>
         <div class="icon toggle-password" ng-click="togglePassword()" title="{{getTogglePasswordHelpText() | translate}}"></div>
     </div>
 
-    <!-- Multiline parameter -->
-    <textarea ng-show="parameter.type === 'MULTILINE'" ng-model="typedValue" autocorrect="off" autocapitalize="off"></textarea>
+    <!-- Multiline field -->
+    <textarea ng-show="field.type === 'MULTILINE'" ng-model="typedValue" autocorrect="off" autocapitalize="off"></textarea>
 
-    <!-- Enumerated parameter -->
-    <select   ng-show="parameter.type === 'ENUM'" ng-model="typedValue" ng-options="option.value as getProtocolParameterOption(protocol.name, parameter.name, option.value) | translate for option in parameter.options | orderBy: value"></select>
+    <!-- Enumerated field -->
+    <select ng-show="field.type === 'ENUM'" ng-model="typedValue" ng-options="option.value as option.title | translate for option in field.options | orderBy: value"></select>
 
 </div>

--- a/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
@@ -59,17 +59,8 @@ THE SOFTWARE.
 
     <!-- Connection parameters -->
     <h2 class="header">{{'MANAGE_CONNECTION.SECTION_HEADER_PARAMETERS' | translate}}</h2>
-    <div class="section" ng-class="{loading: !parameters}">
-        <table class="properties connection-parameters">
-            
-            <!-- All the different possible editable field types -->
-            <tr ng-repeat="parameter in protocols[connection.protocol].parameters">
-                <th>{{parameter.title | translate}}</th>
-                <td>
-                    <guac-form-field field="parameter" model="parameters[parameter.name]"></guac-form-field>
-                </td>
-            </tr>
-        </table>
+    <div class="section connection-parameters" ng-class="{loading: !parameters}">
+        <guac-form fields="protocols[connection.protocol].parameters" model="parameters"></guac-form>
     </div>
 
     <!-- Form action buttons -->

--- a/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
@@ -60,13 +60,13 @@ THE SOFTWARE.
     <!-- Connection parameters -->
     <h2 class="header">{{'MANAGE_CONNECTION.SECTION_HEADER_PARAMETERS' | translate}}</h2>
     <div class="section" ng-class="{loading: !parameters}">
-        <table class="properties">
+        <table class="properties connection-parameters">
             
             <!-- All the different possible editable field types -->
             <tr ng-repeat="parameter in protocols[connection.protocol].parameters">
                 <th>{{parameter.title | translate}}</th>
                 <td>
-                    <guac-connection-parameter field="parameter" model="parameters[parameter.name]"></guac-connection-parameter>
+                    <guac-form-field field="parameter" model="parameters[parameter.name]"></guac-form-field>
                 </td>
             </tr>
         </table>

--- a/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
@@ -60,7 +60,9 @@ THE SOFTWARE.
     <!-- Connection parameters -->
     <h2 class="header">{{'MANAGE_CONNECTION.SECTION_HEADER_PARAMETERS' | translate}}</h2>
     <div class="section connection-parameters" ng-class="{loading: !parameters}">
-        <guac-form fields="protocols[connection.protocol].parameters" model="parameters"></guac-form>
+        <guac-form namespace="getNamespace(connection.protocol)"
+                   fields="protocols[connection.protocol].parameters"
+                   model="parameters"></guac-form>
     </div>
 
     <!-- Form action buttons -->

--- a/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
@@ -64,9 +64,9 @@ THE SOFTWARE.
             
             <!-- All the different possible editable field types -->
             <tr ng-repeat="parameter in protocols[connection.protocol].parameters">
-                <th>{{getProtocolParameterName(connection.protocol, parameter.name) | translate}}</th>
+                <th>{{parameter.title | translate}}</th>
                 <td>
-                    <guac-connection-parameter protocol="protocols[connection.protocol]" name="parameter.name" parameters="parameters"></guac-connection-parameter>
+                    <guac-connection-parameter field="parameter" model="parameters[parameter.name]"></guac-connection-parameter>
                 </td>
             </tr>
         </table>

--- a/guacamole/src/main/webapp/app/rest/types/Field.js
+++ b/guacamole/src/main/webapp/app/rest/types/Field.js
@@ -27,7 +27,7 @@ angular.module('rest').factory('Field', [function defineField() {
             
     /**
      * The object returned by REST API calls when representing the data
-     * associated with a configuration parameter of a remote desktop protocol.
+     * associated with a field or configuration parameter.
      * 
      * @constructor
      * @param {Field|Object} [template={}]

--- a/guacamole/src/main/webapp/app/rest/types/Field.js
+++ b/guacamole/src/main/webapp/app/rest/types/Field.js
@@ -21,20 +21,20 @@
  */
 
 /**
- * Service which defines the ProtocolParameter class.
+ * Service which defines the Field class.
  */
-angular.module('rest').factory('ProtocolParameter', [function defineProtocolParameter() {
+angular.module('rest').factory('Field', [function defineField() {
             
     /**
      * The object returned by REST API calls when representing the data
      * associated with a configuration parameter of a remote desktop protocol.
      * 
      * @constructor
-     * @param {ProtocolParameter|Object} [template={}]
+     * @param {Field|Object} [template={}]
      *     The object whose properties should be copied within the new
-     *     ProtocolParameter.
+     *     Field.
      */
-    var ProtocolParameter = function ProtocolParameter(template) {
+    var Field = function Field(template) {
 
         // Use empty object by default
         template = template || {};
@@ -56,12 +56,12 @@ angular.module('rest').factory('ProtocolParameter', [function defineProtocolPara
         /**
          * The type string defining which values this parameter may contain,
          * as well as what properties are applicable. Valid types are listed
-         * within ProtocolParameter.Type.
+         * within Field.Type.
          *
          * @type String
-         * @default ProtocolParameter.Type.TEXT
+         * @default Field.Type.TEXT
          */
-        this.type = template.type || ProtocolParameter.Type.TEXT;
+        this.type = template.type || Field.Type.TEXT;
 
         /**
          * The value to set the parameter to, in the case of a BOOLEAN
@@ -75,7 +75,7 @@ angular.module('rest').factory('ProtocolParameter', [function defineProtocolPara
          * All possible legal values for this parameter. This property is only
          * applicable to ENUM type parameters.
          *
-         * @type ProtocolParameterOption[]
+         * @type FieldOption[]
          */
         this.options = template.options;
 
@@ -84,7 +84,7 @@ angular.module('rest').factory('ProtocolParameter', [function defineProtocolPara
     /**
      * All valid protocol parameter types.
      */
-    ProtocolParameter.Type = {
+    Field.Type = {
 
         /**
          * The type string associated with parameters that may contain a single
@@ -147,6 +147,6 @@ angular.module('rest').factory('ProtocolParameter', [function defineProtocolPara
 
     };
 
-    return ProtocolParameter;
+    return Field;
 
 }]);

--- a/guacamole/src/main/webapp/app/rest/types/FieldOption.js
+++ b/guacamole/src/main/webapp/app/rest/types/FieldOption.js
@@ -27,7 +27,7 @@ angular.module('rest').factory('FieldOption', [function defineFieldOption() {
             
     /**
      * The object returned by REST API calls when representing a single possible
-     * legal value of a configuration parameter of a remote desktop protocol.
+     * legal value of a field.
      * 
      * @constructor
      * @param {FieldOption|Object} [template={}]

--- a/guacamole/src/main/webapp/app/rest/types/FieldOption.js
+++ b/guacamole/src/main/webapp/app/rest/types/FieldOption.js
@@ -21,20 +21,20 @@
  */
 
 /**
- * Service which defines the ProtocolParameterOption class.
+ * Service which defines the FieldOption class.
  */
-angular.module('rest').factory('ProtocolParameterOption', [function defineProtocolParameterOption() {
+angular.module('rest').factory('FieldOption', [function defineFieldOption() {
             
     /**
      * The object returned by REST API calls when representing a single possible
      * legal value of a configuration parameter of a remote desktop protocol.
      * 
      * @constructor
-     * @param {ProtocolParameterOption|Object} [template={}]
+     * @param {FieldOption|Object} [template={}]
      *     The object whose properties should be copied within the new
-     *     ProtocolParameterOption.
+     *     FieldOption.
      */
-    var ProtocolParameterOption = function ProtocolParameterOption(template) {
+    var FieldOption = function FieldOption(template) {
 
         // Use empty object by default
         template = template || {};
@@ -56,6 +56,6 @@ angular.module('rest').factory('ProtocolParameterOption', [function defineProtoc
 
     };
 
-    return ProtocolParameterOption;
+    return FieldOption;
 
 }]);

--- a/guacamole/src/main/webapp/app/rest/types/Protocol.js
+++ b/guacamole/src/main/webapp/app/rest/types/Protocol.js
@@ -57,7 +57,7 @@ angular.module('rest').factory('Protocol', [function defineProtocol() {
          * An array of all known parameters for this protocol, their types,
          * and other information.
          *
-         * @type ProtocolParameter[]
+         * @type Field[]
          * @default []
          */
         this.parameters = template.parameters || [];

--- a/guacamole/src/main/webapp/translations/en_US.json
+++ b/guacamole/src/main/webapp/translations/en_US.json
@@ -117,6 +117,13 @@
 
     },
 
+    "FORM" : {
+
+        "HELP_SHOW_PASSWORD" : "Click to show password",
+        "HELP_HIDE_PASSWORD" : "Click to hide password"
+
+    },
+
     "HOME" : {
 
         "INFO_ACTIVE_USER_COUNT" : "@:APP.INFO_ACTIVE_USER_COUNT",
@@ -161,8 +168,6 @@
         "FORMAT_HISTORY_START" : "@:APP.FORMAT_DATE_TIME_PRECISE",
 
         "HELP_CONNECTIONS"   : "Click or tap on a connection below to manage that connection. Depending on your access level, connections can be added and deleted, and their properties (protocol, hostname, port, etc.) can be changed.",
-        "HELP_SHOW_PASSWORD" : "Click to show password",
-        "HELP_HIDE_PASSWORD" : "Click to hide password",
         
         "INFO_ACTIVE_USER_COUNT" : "@:APP.INFO_ACTIVE_USER_COUNT",
         "INFO_CONNECTION_DURATION_UNKNOWN" : "--",


### PR DESCRIPTION
This change generalizes the protocol-specific ```ProtocolParameter``` and ```guacConnectionParameter``` into ```FormField``` and ```guacFormField```. An arbitrary array of ```FormField``` objects can be placed onto any page through the ```guacForm``` directive, which will retrieve and set field values into a provided model object.