### PR TITLE
GUAC-1160: Add support for form sections

### DIFF
--- a/guacamole/src/main/webapp/app/form/styles/form.css
+++ b/guacamole/src/main/webapp/app/form/styles/form.css
@@ -20,7 +20,7 @@
  * THE SOFTWARE.
  */
 
-table.form th {
+.form table.fields th {
     text-align: left;
     font-weight: normal;
     padding-right: 1em;

--- a/guacamole/src/main/webapp/app/form/templates/form.html
+++ b/guacamole/src/main/webapp/app/form/templates/form.html
@@ -1,4 +1,4 @@
-<table class="form">
+<div ng-repeat="form in forms" class="form">
     <!--
         Copyright 2015 Glyptodon LLC.
 
@@ -21,12 +21,17 @@
         THE SOFTWARE.
     -->
 
-    <!-- All fields in form -->
-    <tr ng-repeat="field in fields">
-        <th>{{getFieldHeader(field) | translate}}</th>
-        <td>
-            <guac-form-field namespace="namespace" field="field" model="values[field.name]"></guac-form-field>
-        </td>
-    </tr>
+    <!-- Form name -->
+    <h3 ng-show="form.name">{{getSectionHeader(form) | translate}}</h3>
 
-</table>
+    <!-- All fields in form -->
+    <table class="fields">
+        <tr ng-repeat="field in form.fields">
+            <th>{{getFieldHeader(field) | translate}}</th>
+            <td>
+                <guac-form-field namespace="namespace" field="field" model="values[field.name]"></guac-form-field>
+            </td>
+        </tr>
+    </table>
+
+</div>

--- a/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
@@ -61,7 +61,7 @@ THE SOFTWARE.
     <h2 class="header">{{'MANAGE_CONNECTION.SECTION_HEADER_PARAMETERS' | translate}}</h2>
     <div class="section connection-parameters" ng-class="{loading: !parameters}">
         <guac-form namespace="getNamespace(connection.protocol)"
-                   fields="protocols[connection.protocol].parameters"
+                   content="protocols[connection.protocol].parameters"
                    model="parameters"></guac-form>
     </div>
 

--- a/guacamole/src/main/webapp/app/rest/types/Field.js
+++ b/guacamole/src/main/webapp/app/rest/types/Field.js
@@ -82,7 +82,7 @@ angular.module('rest').factory('Field', [function defineField() {
     };
 
     /**
-     * All valid protocol parameter types.
+     * All valid field types.
      */
     Field.Type = {
 

--- a/guacamole/src/main/webapp/app/rest/types/Form.js
+++ b/guacamole/src/main/webapp/app/rest/types/Form.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2014 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * Service which defines the Form class.
+ */
+angular.module('rest').factory('Form', [function defineForm() {
+
+    /**
+     * The object returned by REST API calls when representing the data
+     * associated with a form or set of configuration parameters.
+     *
+     * @constructor
+     * @param {Form|Object} [template={}]
+     *     The object whose properties should be copied within the new
+     *     Form.
+     */
+    var Form = function Form(template) {
+
+        // Use empty object by default
+        template = template || {};
+
+        /**
+         * The name which uniquely identifies this parameter, or null if this
+         * field has no name.
+         *
+         * @type String
+         */
+        this.name = template.name;
+
+        /**
+         * A human-readable name for this form, or null if this form has no
+         * name.
+         *
+         * @type String
+         */
+        this.title = template.title;
+
+        /**
+         * All fields contained within this form.
+         *
+         * @type Field[]
+         */
+        this.fields = template.fields || [];
+
+    };
+
+    return Form;
+
+}]);


### PR DESCRIPTION
This change allows the ```guacForm``` directive to accept not only an array of ```Field``` objects, but also a ```Form``` or ```Form[]```. The ```Form``` object is newly-defined, and simply pairs a set of fields with a name and title. Accepting ```Form[]``` allows for splitting forms into sub-forms, each with corresponding headers.

The logic which handles converting all these types to a common ```Form[]``` for the sake of the template is generic enough that it will actually also accept a single ```Field```, and the directive documentation has been updated to reflect this. Doing so is almost equivalent to simply using ```guacFormField```, except that the field will be encased in the various elements that make up a form.