### PR TITLE
GUAC-1053: Default to "none" input mode as before.

### DIFF
--- a/guacamole/src/main/webapp/app/settings/services/preferenceService.js
+++ b/guacamole/src/main/webapp/app/settings/services/preferenceService.js
@@ -58,7 +58,7 @@ angular.module('settings').factory('preferenceService', ['$injector',
          *
          * @type String
          */
-        inputMethod : null
+        inputMethod : 'none'
 
     };
 
@@ -87,17 +87,6 @@ angular.module('settings').factory('preferenceService', ['$injector',
 
     }
     catch (ignore) {}
-
-    // Choose reasonable default input method based on best-guess at platform
-    if (service.preferences.inputMethod === null) {
-
-        // Use text input by default if platform likely lacks physical keyboard
-        if (/android|ipad|iphone/i.test(navigator.userAgent))
-            service.preferences.inputMethod = 'text';
-        else
-            service.preferences.inputMethod = 'none';
-
-    }
 
     // Persist settings when window is unloaded
     $window.addEventListener('unload', service.save);


### PR DESCRIPTION
This reverts commit 21d3e45. Having the keyboard pop open automatically proved disruptive.