### PR TITLE
GUAC-1179: Fix handling of numeric fields

### DIFF
--- a/guacamole/src/main/webapp/app/form/directives/formField.js
+++ b/guacamole/src/main/webapp/app/form/directives/formField.js
@@ -183,7 +183,7 @@ angular.module('form').directive('guacFormField', [function formField() {
 
                 // Coerce numeric strings to numbers
                 if ($scope.field.type === 'NUMERIC')
-                    $scope.typedValue = (modelValue ? Number($scope.field.value) : null);
+                    $scope.typedValue = (modelValue ? Number(modelValue) : null);
 
                 // Coerce boolean strings to boolean values
                 else if ($scope.field.type === 'BOOLEAN')


### PR DESCRIPTION
The typed value should be the coerced version of the model value ... not ```field.value```, which is specific to ```BOOLEAN``` fields and **does not contain the current value of a field**.