### PR TITLE
GUAC-1170: Fix all Maven warnings

### DIFF
--- a/doc/guacamole-example/pom.xml
+++ b/doc/guacamole-example/pom.xml
@@ -36,6 +36,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
+                <version>2.6</version>
                 <configuration>
                     <overlays>
                         <overlay>

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/pom.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/pom.xml
@@ -38,25 +38,22 @@
                 </configuration>
             </plugin>
 
-            <!-- Assembly plugin - for easy distribution -->
+            <!-- Copy dependencies prior to packaging -->
             <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.5.3</version>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.10</version>
                 <executions>
                     <execution>
-                        <id>jar-with-dependencies</id>
-                        <phase>package</phase>
+                        <id>unpack-dependencies</id>
+                        <phase>prepare-package</phase>
                         <goals>
-                            <goal>single</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <finalName>extension/${project.artifactId}-${project.version}</finalName>
-                            <appendAssemblyId>false</appendAssemblyId>
-                            <descriptorRefs>
-                                <descriptorRef>jar-with-dependencies</descriptorRef>
-                            </descriptorRefs>
+                            <outputDirectory>${project.build.directory}/classes</outputDirectory>
                         </configuration>
-                    </execution>                    
+                    </execution>
                 </executions>
             </plugin>
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/pom.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/pom.xml
@@ -41,7 +41,7 @@
             <!-- Assembly plugin - for easy distribution -->
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2-beta-5</version>
+                <version>2.5.3</version>
                 <executions>
                     <execution>
                         <id>jar-with-dependencies</id>

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/pom.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/pom.xml
@@ -38,25 +38,22 @@
                 </configuration>
             </plugin>
 
-            <!-- Assembly plugin - for easy distribution -->
+            <!-- Copy dependencies prior to packaging -->
             <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.5.3</version>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.10</version>
                 <executions>
                     <execution>
-                        <id>jar-with-dependencies</id>
-                        <phase>package</phase>
+                        <id>unpack-dependencies</id>
+                        <phase>prepare-package</phase>
                         <goals>
-                            <goal>single</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <finalName>extension/${project.artifactId}-${project.version}</finalName>
-                            <appendAssemblyId>false</appendAssemblyId>
-                            <descriptorRefs>
-                                <descriptorRef>jar-with-dependencies</descriptorRef>
-                            </descriptorRefs>
+                            <outputDirectory>${project.build.directory}/classes</outputDirectory>
                         </configuration>
-                    </execution>                    
+                    </execution>
                 </executions>
             </plugin>
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/pom.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/pom.xml
@@ -41,7 +41,7 @@
             <!-- Assembly plugin - for easy distribution -->
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2-beta-5</version>
+                <version>2.5.3</version>
                 <executions>
                     <execution>
                         <id>jar-with-dependencies</id>

--- a/extensions/guacamole-auth-jdbc/pom.xml
+++ b/extensions/guacamole-auth-jdbc/pom.xml
@@ -32,7 +32,7 @@
             <!-- Assembly plugin - for easy distribution -->
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2-beta-5</version>
+                <version>2.5.3</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/extensions/guacamole-auth-jdbc/src/main/assembly/dist.xml
+++ b/extensions/guacamole-auth-jdbc/src/main/assembly/dist.xml
@@ -20,7 +20,7 @@
                 <directory>modules/guacamole-auth-jdbc-mysql/schema</directory>
             </fileSet>
             <fileSet>
-                <directory>modules/guacamole-auth-jdbc-mysql/target/extension</directory>
+                <directory>modules/guacamole-auth-jdbc-mysql/target</directory>
                 <outputDirectory>mysql</outputDirectory>
                 <includes>
                     <include>*.jar</include>
@@ -33,7 +33,7 @@
                 <directory>modules/guacamole-auth-jdbc-postgresql/schema</directory>
             </fileSet>
             <fileSet>
-                <directory>modules/guacamole-auth-jdbc-postgresql/target/extension</directory>
+                <directory>modules/guacamole-auth-jdbc-postgresql/target</directory>
                 <outputDirectory>postgresql</outputDirectory>
                 <includes>
                     <include>*.jar</include>

--- a/extensions/guacamole-auth-jdbc/src/main/assembly/dist.xml
+++ b/extensions/guacamole-auth-jdbc/src/main/assembly/dist.xml
@@ -16,12 +16,12 @@
 
             <!-- MySQL implementation -->
             <fileSet>
-                <outputDirectory>/mysql/schema</outputDirectory>
+                <outputDirectory>mysql/schema</outputDirectory>
                 <directory>modules/guacamole-auth-jdbc-mysql/schema</directory>
             </fileSet>
             <fileSet>
                 <directory>modules/guacamole-auth-jdbc-mysql/target/extension</directory>
-                <outputDirectory>/mysql</outputDirectory>
+                <outputDirectory>mysql</outputDirectory>
                 <includes>
                     <include>*.jar</include>
                 </includes>
@@ -29,12 +29,12 @@
 
             <!-- PostgreSQL implementation -->
             <fileSet>
-                <outputDirectory>/postgresql/schema</outputDirectory>
+                <outputDirectory>postgresql/schema</outputDirectory>
                 <directory>modules/guacamole-auth-jdbc-postgresql/schema</directory>
             </fileSet>
             <fileSet>
                 <directory>modules/guacamole-auth-jdbc-postgresql/target/extension</directory>
-                <outputDirectory>/postgresql</outputDirectory>
+                <outputDirectory>postgresql</outputDirectory>
                 <includes>
                     <include>*.jar</include>
                 </includes>

--- a/extensions/guacamole-auth-ldap/pom.xml
+++ b/extensions/guacamole-auth-ldap/pom.xml
@@ -35,7 +35,7 @@
             <!-- Assembly plugin - for easy distribution -->
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2-beta-5</version>
+                <version>2.5.3</version>
                 <configuration>
                     <finalName>${project.artifactId}-${project.version}</finalName>
                     <appendAssemblyId>false</appendAssemblyId>

--- a/extensions/guacamole-auth-ldap/src/main/assembly/dist.xml
+++ b/extensions/guacamole-auth-ldap/src/main/assembly/dist.xml
@@ -16,13 +16,12 @@
 
             <!-- Include docs -->
             <fileSet>
-                <outputDirectory>/</outputDirectory>
                 <directory>doc</directory>
             </fileSet>
 
             <!-- Include schema -->
             <fileSet>
-                <outputDirectory>/schema</outputDirectory>
+                <outputDirectory>schema</outputDirectory>
                 <directory>schema</directory>
             </fileSet>
 
@@ -33,7 +32,7 @@
     <dependencySets>
         <dependencySet>
 
-            <outputDirectory>/lib</outputDirectory>
+            <outputDirectory>lib</outputDirectory>
             <scope>runtime</scope>
             <unpack>false</unpack>
             <useProjectArtifact>true</useProjectArtifact>

--- a/extensions/guacamole-auth-noauth/pom.xml
+++ b/extensions/guacamole-auth-noauth/pom.xml
@@ -35,7 +35,7 @@
             <!-- Assembly plugin - for easy distribution -->
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2-beta-5</version>
+                <version>2.5.3</version>
                 <configuration>
                     <finalName>${project.artifactId}-${project.version}</finalName>
                     <appendAssemblyId>false</appendAssemblyId>

--- a/extensions/guacamole-auth-noauth/src/main/assembly/dist.xml
+++ b/extensions/guacamole-auth-noauth/src/main/assembly/dist.xml
@@ -14,11 +14,10 @@
     <!-- Include docs and schema -->
     <fileSets>
 
-            <!-- Include docs -->
-            <fileSet>
-                <outputDirectory>/</outputDirectory>
-                <directory>doc</directory>
-            </fileSet>
+        <!-- Include docs -->
+        <fileSet>
+            <directory>doc</directory>
+        </fileSet>
 
     </fileSets>
 
@@ -27,7 +26,7 @@
     <dependencySets>
         <dependencySet>
 
-            <outputDirectory>/lib</outputDirectory>
+            <outputDirectory>lib</outputDirectory>
             <scope>runtime</scope>
             <unpack>false</unpack>
             <useProjectArtifact>true</useProjectArtifact>

--- a/guacamole-common-js/pom.xml
+++ b/guacamole-common-js/pom.xml
@@ -54,7 +54,7 @@
             <!-- Assemble JS files into single .zip -->
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
+                <version>2.5.3</version>
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>

--- a/guacamole-common/pom.xml
+++ b/guacamole-common/pom.xml
@@ -70,6 +70,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>2.4</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -84,6 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.3</version>
                 <configuration>
                     <detectOfflineLinks>false</detectOfflineLinks>
                 </configuration>

--- a/guacamole-ext/pom.xml
+++ b/guacamole-ext/pom.xml
@@ -70,6 +70,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>2.4</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -84,6 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.3</version>
                 <configuration>
                     <detectOfflineLinks>false</detectOfflineLinks>
                 </configuration>

--- a/guacamole/pom.xml
+++ b/guacamole/pom.xml
@@ -69,6 +69,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
+                <version>2.6</version>
                 <configuration>
 
                     <!-- Filter translation strings -->

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
                 <configuration>
                     <finalName>${project.artifactId}-${project.version}</finalName>
                     <appendAssemblyId>false</appendAssemblyId>
+                    <tarLongFileMode>gnu</tarLongFileMode>
                     <descriptors>
                         <descriptor>project-assembly.xml</descriptor>
                     </descriptors>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
             <!-- Assembly plugin - for easy distribution -->
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
+                <version>2.5.3</version>
 
                 <!-- Build project archive -->
                 <configuration>

--- a/project-assembly.xml
+++ b/project-assembly.xml
@@ -12,7 +12,6 @@
     <fileSets>
         <fileSet>
             <directory>${project.basedir}</directory>
-            <outputDirectory>/</outputDirectory>
             <useDefaultExcludes>true</useDefaultExcludes>
             <excludes>
                 <exclude>**/*.log</exclude>


### PR DESCRIPTION
This change fixes all Maven warnings that occurred during the build, namely:

1. Missing plugin versions
2. Weird multiple .jar artifacts for the guacamole-auth-jdbc-* projects (for example: "Replacing pre-existing project main-artifact file: target/guacamole-auth-jdbc-postgresql-0.9.6.jar with assembly file: target/extension/guacamole-auth-jdbc-postgresql-0.9.6.jar")
3. Filename length warnings in the source .tar.gz (only extensions to .tar provide the long names we need)
