### PR TITLE
GUAC-1170: Fix basic JavaScript warnings.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/AudioChannel.js
+++ b/guacamole-common-js/src/main/webapp/modules/AudioChannel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Glyptodon LLC
+ * Copyright (C) 2015 Glyptodon LLC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -70,7 +70,12 @@ Guacamole.AudioChannel = function() {
 };
 
 // Define context if available
-if (window.webkitAudioContext) {
+if (window.AudioContext) {
+    Guacamole.AudioChannel.context = new AudioContext();
+}
+
+// Fallback to Webkit-specific AudioContext implementation
+else if (window.webkitAudioContext) {
     Guacamole.AudioChannel.context = new webkitAudioContext();
 }
 

--- a/guacamole-common-js/src/main/webapp/modules/Keyboard.js
+++ b/guacamole-common-js/src/main/webapp/modules/Keyboard.js
@@ -954,6 +954,34 @@ Guacamole.Keyboard = function(element) {
 
     }
 
+    /**
+     * Returns the keyboard location of the key associated with the given
+     * keyboard event. The location differentiates key events which otherwise
+     * have the same keycode, such as left shift vs. right shift.
+     *
+     * @param {KeyboardEvent} e
+     *     A JavaScript keyboard event, as received through the DOM via a
+     *     "keydown", "keyup", or "keypress" handler.
+     *
+     * @returns {Number}
+     *     The location of the key event on the keyboard, as defined at:
+     *     http://www.w3.org/TR/DOM-Level-3-Events/#events-KeyboardEvent
+     */
+    var getEventLocation = function getEventLocation(e) {
+
+        // Use standard location, if possible
+        if ('location' in e)
+            return e.location;
+
+        // Failing that, attempt to use deprecated keyLocation
+        if ('keyLocation' in e)
+            return e.keyLocation;
+
+        // If no location is available, assume left side
+        return 0;
+
+    };
+
     // When key pressed
     element.addEventListener("keydown", function(e) {
 
@@ -973,7 +1001,7 @@ Guacamole.Keyboard = function(element) {
             return;
 
         // Log event
-        var keydownEvent = new KeydownEvent(keyCode, e.keyIdentifier, e.key, e.location || e.keyLocation);
+        var keydownEvent = new KeydownEvent(keyCode, e.keyIdentifier, e.key, getEventLocation(e));
         eventLog.push(keydownEvent);
 
         // Interpret as many events as possible, prevent default if indicated
@@ -1021,7 +1049,7 @@ Guacamole.Keyboard = function(element) {
         update_modifier_state(e);
 
         // Log event, call for interpretation
-        var keyupEvent = new KeyupEvent(keyCode, e.keyIdentifier, e.key, e.location || e.keyLocation);
+        var keyupEvent = new KeyupEvent(keyCode, e.keyIdentifier, e.key, getEventLocation(e));
         eventLog.push(keyupEvent);
         interpret_events();
 

--- a/guacamole/src/main/webapp/app/element/directives/guacResize.js
+++ b/guacamole/src/main/webapp/app/element/directives/guacResize.js
@@ -83,7 +83,7 @@ angular.module('element').directive('guacResize', ['$document', function guacRes
 
                     // Call resize callback, if defined
                     if (guacResize) {
-                        $scope.$apply(function elementSizeChanged() {
+                        $scope.$evalAsync(function elementSizeChanged() {
                             guacResize(element.offsetWidth, element.offsetHeight);
                         });
                     }

--- a/guacamole/src/main/webapp/app/element/templates/blank.html
+++ b/guacamole/src/main/webapp/app/element/templates/blank.html
@@ -1,22 +1,29 @@
-<!--
-   Copyright (C) 2014 Glyptodon LLC
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <title>_</title>
+    </head>
+    <!--
+       Copyright (C) 2015 Glyptodon LLC
 
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
+       Permission is hereby granted, free of charge, to any person obtaining a copy
+       of this software and associated documentation files (the "Software"), to deal
+       in the Software without restriction, including without limitation the rights
+       to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+       copies of the Software, and to permit persons to whom the Software is
+       furnished to do so, subject to the following conditions:
 
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
+       The above copyright notice and this permission notice shall be included in
+       all copies or substantial portions of the Software.
 
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
--->
-<html><body></body></html>
+       THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+       IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+       FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+       AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+       LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+       OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+       THE SOFTWARE.
+    -->
+    <body></body>
+</html>

--- a/guacamole/src/main/webapp/index.html
+++ b/guacamole/src/main/webapp/index.html
@@ -1,37 +1,37 @@
-<!--
-Copyright 2014 Glyptodon LLC.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
--->
 <!DOCTYPE html>
 <html ng-app="index" ng-controller="indexController">
     <head>
-        <link rel="icon" type="image/png" href="images/guacamole-logo-64.png"/>
-        <link rel="icon" type="image/png" sizes="144x144" href="images/guacamole-logo-144.png"/>
-        <link rel="apple-touch-icon" type="image/png" href="images/guacamole-logo-144.png"/>
-        <title ng-bind="page.title | translate"></title>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densitydpi=medium-dpi"/>
         <meta name="mobile-web-app-capable" content="yes"/>
         <meta name="apple-mobile-web-app-capable" content="yes"/>
+        <link rel="icon" type="image/png" href="images/guacamole-logo-64.png"/>
+        <link rel="icon" type="image/png" sizes="144x144" href="images/guacamole-logo-144.png"/>
+        <link rel="apple-touch-icon" type="image/png" href="images/guacamole-logo-144.png"/>
         <link rel="stylesheet" type="text/css" href="guacamole.min.css">
+        <title ng-bind="page.title | translate"></title>
     </head>
+    <!--
+        Copyright 2015 Glyptodon LLC.
+
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in
+        all copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+        THE SOFTWARE.
+    -->
     <body ng-class="page.bodyClassName">
 
         <!-- Content for logged-in users -->


### PR DESCRIPTION
This change resolves the simpler of the outstanding browser warnings:

1. ```keyLocation``` is deprecated
2. ```webkitAudioContext``` is deprecated
3. Charset not declared within first 1024 bytes of each HTML file

Firefox also fell victim to a ```$rootScope:inprog``` error, as it sometimes handles resize events synchronously, resulting in a digest loop. This change switches over to using ```$evalAsync()``` instead of ```$apply()``` for that particular case.