### PR TITLE
GUAC-800: Allow explicit disable/enable of user accounts.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/ModeledUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/ModeledUser.java
@@ -38,6 +38,7 @@ import org.glyptodon.guacamole.auth.jdbc.permission.ConnectionGroupPermissionSer
 import org.glyptodon.guacamole.auth.jdbc.permission.ConnectionPermissionService;
 import org.glyptodon.guacamole.auth.jdbc.permission.UserPermissionService;
 import org.glyptodon.guacamole.form.Field;
+import org.glyptodon.guacamole.form.Form;
 import org.glyptodon.guacamole.net.auth.User;
 import org.glyptodon.guacamole.net.auth.permission.ObjectPermissionSet;
 import org.glyptodon.guacamole.net.auth.permission.SystemPermission;
@@ -58,15 +59,19 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
     public static final String DISABLED_ATTRIBUTE_NAME = "disabled";
 
     /**
-     * A typed field corresponding to the disabled attribute of a user.
+     * All attributes related to restricting user accounts, within a logical
+     * form.
      */
-    public static final Field DISABLED_ATTRIBUTE = new Field(DISABLED_ATTRIBUTE_NAME, "Disabled", "true");
+    public static final Form ACCOUNT_RESTRICTIONS = new Form("restrictions", "Account Restrictions", Arrays.asList(
+        new Field(DISABLED_ATTRIBUTE_NAME, "Disabled", "true")
+    ));
 
     /**
-     * All possible attributes of user objects.
+     * All possible attributes of user objects organized as individual,
+     * logical forms.
      */
-    public static final Collection<Field> ATTRIBUTES = Collections.unmodifiableCollection(Arrays.asList(
-        DISABLED_ATTRIBUTE
+    public static final Collection<Form> ATTRIBUTES = Collections.unmodifiableCollection(Arrays.asList(
+        ACCOUNT_RESTRICTIONS
     ));
 
     /**

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/ModeledUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/ModeledUser.java
@@ -23,7 +23,10 @@
 package org.glyptodon.guacamole.auth.jdbc.user;
 
 import com.google.inject.Inject;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import org.glyptodon.guacamole.auth.jdbc.base.ModeledDirectoryObject;
 import org.glyptodon.guacamole.auth.jdbc.security.PasswordEncryptionService;
@@ -34,6 +37,7 @@ import org.glyptodon.guacamole.auth.jdbc.activeconnection.ActiveConnectionPermis
 import org.glyptodon.guacamole.auth.jdbc.permission.ConnectionGroupPermissionService;
 import org.glyptodon.guacamole.auth.jdbc.permission.ConnectionPermissionService;
 import org.glyptodon.guacamole.auth.jdbc.permission.UserPermissionService;
+import org.glyptodon.guacamole.form.Field;
 import org.glyptodon.guacamole.net.auth.User;
 import org.glyptodon.guacamole.net.auth.permission.ObjectPermissionSet;
 import org.glyptodon.guacamole.net.auth.permission.SystemPermission;
@@ -46,6 +50,24 @@ import org.glyptodon.guacamole.net.auth.permission.SystemPermissionSet;
  * @author Michael Jumper
  */
 public class ModeledUser extends ModeledDirectoryObject<UserModel> implements User {
+
+    /**
+     * The name of the attribute which controls whether a user account is
+     * disabled.
+     */
+    public static final String DISABLED_ATTRIBUTE_NAME = "disabled";
+
+    /**
+     * A typed field corresponding to the disabled attribute of a user.
+     */
+    public static final Field DISABLED_ATTRIBUTE = new Field(DISABLED_ATTRIBUTE_NAME, "Disabled", "true");
+
+    /**
+     * All possible attributes of user objects.
+     */
+    public static final Collection<Field> ATTRIBUTES = Collections.unmodifiableCollection(Arrays.asList(
+        DISABLED_ATTRIBUTE
+    ));
 
     /**
      * Service for hashing passwords.
@@ -183,12 +205,21 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
 
     @Override
     public Map<String, String> getAttributes() {
-        return Collections.<String, String>emptyMap();
+
+        Map<String, String> attributes = new HashMap<String, String>();
+
+        // Set disabled attribute
+        attributes.put("disabled", getModel().isDisabled() ? "true" : null);
+
+        return attributes;
     }
 
     @Override
     public void setAttributes(Map<String, String> attributes) {
-        // Drop all attributes - none currently supported
+
+        // Translate disabled attribute
+        getModel().setDisabled("true".equals(attributes.get("disabled")));
+
     }
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/UserContext.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/UserContext.java
@@ -33,7 +33,7 @@ import java.util.Collections;
 import org.glyptodon.guacamole.GuacamoleException;
 import org.glyptodon.guacamole.auth.jdbc.base.RestrictedObject;
 import org.glyptodon.guacamole.auth.jdbc.activeconnection.ActiveConnectionDirectory;
-import org.glyptodon.guacamole.form.Field;
+import org.glyptodon.guacamole.form.Form;
 import org.glyptodon.guacamole.net.auth.ActiveConnection;
 import org.glyptodon.guacamole.net.auth.Connection;
 import org.glyptodon.guacamole.net.auth.ConnectionGroup;
@@ -134,18 +134,18 @@ public class UserContext extends RestrictedObject
     }
 
     @Override
-    public Collection<Field> getUserAttributes() {
+    public Collection<Form> getUserAttributes() {
         return ModeledUser.ATTRIBUTES;
     }
 
     @Override
-    public Collection<Field> getConnectionAttributes() {
-        return Collections.<Field>emptyList();
+    public Collection<Form> getConnectionAttributes() {
+        return Collections.<Form>emptyList();
     }
 
     @Override
-    public Collection<Field> getConnectionGroupAttributes() {
-        return Collections.<Field>emptyList();
+    public Collection<Form> getConnectionGroupAttributes() {
+        return Collections.<Form>emptyList();
     }
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/UserContext.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/UserContext.java
@@ -135,7 +135,7 @@ public class UserContext extends RestrictedObject
 
     @Override
     public Collection<Field> getUserAttributes() {
-        return Collections.<Field>emptyList();
+        return ModeledUser.ATTRIBUTES;
     }
 
     @Override

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/UserContextService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/UserContextService.java
@@ -67,7 +67,7 @@ public class UserContextService  {
 
         // Authenticate user
         ModeledUser user = userService.retrieveUser(credentials);
-        if (user != null) {
+        if (user != null && !user.getModel().isDisabled()) {
 
             // Upon successful authentication, return new user context
             UserContext context = userContextProvider.get();

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/UserModel.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/UserModel.java
@@ -43,6 +43,12 @@ public class UserModel extends ObjectModel {
     private byte[] passwordSalt;
 
     /**
+     * Whether the user account is disabled. Disabled accounts exist and can
+     * be modified, but cannot be used.
+     */
+    private boolean disabled;
+
+    /**
      * Creates a new, empty user.
      */
     public UserModel() {
@@ -95,6 +101,30 @@ public class UserModel extends ObjectModel {
      */
     public void setPasswordSalt(byte[] passwordSalt) {
         this.passwordSalt = passwordSalt;
+    }
+
+    /**
+     * Returns whether the user has been disabled. Disabled users are not
+     * allowed to login. Although their account data exists, all login attempts
+     * will fail as if the account does not exist.
+     *
+     * @return
+     *     true if the account is disabled, false otherwise.
+     */
+    public boolean isDisabled() {
+        return disabled;
+    }
+
+    /**
+     * Sets whether the user is disabled. Disabled users are not allowed to
+     * login. Although their account data exists, all login attempts will fail
+     * as if the account does not exist.
+     *
+     * @param disabled
+     *     true if the account should be disabled, false otherwise.
+     */
+    public void setDisabled(boolean disabled) {
+        this.disabled = disabled;
     }
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/en_US.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/en_US.json
@@ -1,5 +1,9 @@
 {
     "USER_ATTRIBUTES" : {
-        "FIELD_HEADER_DISABLED" : "Disabled:"
+
+        "FIELD_HEADER_DISABLED" : "Login disabled:",
+
+        "SECTION_HEADER_RESTRICTIONS" : "Account Restrictions"
+
     }
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/en_US.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/en_US.json
@@ -1,0 +1,5 @@
+{
+    "USER_ATTRIBUTES" : {
+        "FIELD_HEADER_DISABLED" : "Disabled:"
+    }
+}

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
@@ -76,6 +76,7 @@ CREATE TABLE `guacamole_user` (
   `username`      varchar(128) NOT NULL,
   `password_hash` binary(32)   NOT NULL,
   `password_salt` binary(32),
+  `disabled`      boolean      NOT NULL DEFAULT 0,
 
   PRIMARY KEY (`user_id`),
   UNIQUE KEY `username` (`username`)

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/upgrade/upgrade-pre-0.9.7.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/upgrade/upgrade-pre-0.9.7.sql
@@ -1,0 +1,28 @@
+--
+-- Copyright (C) 2015 Glyptodon LLC
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+-- THE SOFTWARE.
+--
+
+--
+-- Add per-user disable flag
+--
+
+ALTER TABLE guacamole_user ADD COLUMN disabled BOOLEAN NOT NULL DEFAULT 0;
+

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/guac-manifest.json
@@ -7,6 +7,10 @@
 
     "authProviders" : [
         "net.sourceforge.guacamole.net.auth.mysql.MySQLAuthenticationProvider"
+    ],
+
+    "translations" : [
+        "translations/en_US.json"
     ]
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/glyptodon/guacamole/auth/jdbc/user/UserMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/glyptodon/guacamole/auth/jdbc/user/UserMapper.xml
@@ -32,6 +32,7 @@
         <result column="username"      property="identifier"   jdbcType="VARCHAR"/>
         <result column="password_hash" property="passwordHash" jdbcType="BINARY"/>
         <result column="password_salt" property="passwordSalt" jdbcType="BINARY"/>
+        <result column="disabled"      property="disabled"     jdbcType="BOOLEAN"/>
     </resultMap>
 
     <!-- Select all usernames -->
@@ -57,7 +58,8 @@
             user_id,
             username,
             password_hash,
-            password_salt
+            password_salt,
+            disabled
         FROM guacamole_user
         WHERE username IN
             <foreach collection="identifiers" item="identifier"
@@ -74,7 +76,8 @@
             guacamole_user.user_id,
             username,
             password_hash,
-            password_salt
+            password_salt,
+            disabled
         FROM guacamole_user
         JOIN guacamole_user_permission ON affected_user_id = guacamole_user.user_id
         WHERE username IN
@@ -94,7 +97,8 @@
             user_id,
             username,
             password_hash,
-            password_salt
+            password_salt,
+            disabled
         FROM guacamole_user
         WHERE
             username = #{username,jdbcType=VARCHAR}
@@ -114,12 +118,14 @@
         INSERT INTO guacamole_user (
             username,
             password_hash,
-            password_salt
+            password_salt,
+            disabled
         )
         VALUES (
             #{object.identifier,jdbcType=VARCHAR},
             #{object.passwordHash,jdbcType=BINARY},
-            #{object.passwordSalt,jdbcType=BINARY}
+            #{object.passwordSalt,jdbcType=BINARY},
+            #{object.disabled,jdbcType=BOOLEAN}
         )
 
     </insert>
@@ -128,7 +134,8 @@
     <update id="update" parameterType="org.glyptodon.guacamole.auth.jdbc.user.UserModel">
         UPDATE guacamole_user
         SET password_hash = #{object.passwordHash,jdbcType=BINARY},
-            password_salt = #{object.passwordSalt,jdbcType=BINARY}
+            password_salt = #{object.passwordSalt,jdbcType=BINARY},
+            disabled = #{object.disabled,jdbcType=BOOLEAN}
         WHERE user_id = #{object.objectID,jdbcType=VARCHAR}
     </update>
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
@@ -117,6 +117,7 @@ CREATE TABLE guacamole_user (
   username      varchar(128) NOT NULL,
   password_hash bytea        NOT NULL,
   password_salt bytea,
+  disabled      boolean      NOT NULL DEFAULT FALSE,
 
   PRIMARY KEY (user_id),
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/upgrade/upgrade-pre-0.9.7.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/upgrade/upgrade-pre-0.9.7.sql
@@ -1,0 +1,28 @@
+--
+-- Copyright (C) 2015 Glyptodon LLC
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+-- THE SOFTWARE.
+--
+
+--
+-- Add per-user disable flag
+--
+
+ALTER TABLE guacamole_user ADD COLUMN disabled boolean NOT NULL DEFAULT FALSE;
+

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/guac-manifest.json
@@ -7,6 +7,10 @@
 
     "authProviders" : [
         "org.glyptodon.guacamole.auth.postgresql.PostgreSQLAuthenticationProvider"
+    ],
+
+    "translations" : [
+        "translations/en_US.json"
     ]
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/glyptodon/guacamole/auth/jdbc/user/UserMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/glyptodon/guacamole/auth/jdbc/user/UserMapper.xml
@@ -32,6 +32,7 @@
         <result column="username"      property="identifier"   jdbcType="VARCHAR"/>
         <result column="password_hash" property="passwordHash" jdbcType="BINARY"/>
         <result column="password_salt" property="passwordSalt" jdbcType="BINARY"/>
+        <result column="disabled"      property="disabled"     jdbcType="BOOLEAN"/>
     </resultMap>
 
     <!-- Select all usernames -->
@@ -57,7 +58,8 @@
             user_id,
             username,
             password_hash,
-            password_salt
+            password_salt,
+            disabled
         FROM guacamole_user
         WHERE username IN
             <foreach collection="identifiers" item="identifier"
@@ -74,7 +76,8 @@
             guacamole_user.user_id,
             username,
             password_hash,
-            password_salt
+            password_salt,
+            disabled
         FROM guacamole_user
         JOIN guacamole_user_permission ON affected_user_id = guacamole_user.user_id
         WHERE username IN
@@ -94,7 +97,8 @@
             user_id,
             username,
             password_hash,
-            password_salt
+            password_salt,
+            disabled
         FROM guacamole_user
         WHERE
             username = #{username,jdbcType=VARCHAR}
@@ -114,12 +118,14 @@
         INSERT INTO guacamole_user (
             username,
             password_hash,
-            password_salt
+            password_salt,
+            disabled
         )
         VALUES (
             #{object.identifier,jdbcType=VARCHAR},
             #{object.passwordHash,jdbcType=BINARY},
-            #{object.passwordSalt,jdbcType=BINARY}
+            #{object.passwordSalt,jdbcType=BINARY},
+            #{object.disabled,jdbcType=BOOLEAN}
         )
 
     </insert>
@@ -128,7 +134,8 @@
     <update id="update" parameterType="org.glyptodon.guacamole.auth.jdbc.user.UserModel">
         UPDATE guacamole_user
         SET password_hash = #{object.passwordHash,jdbcType=BINARY},
-            password_salt = #{object.passwordSalt,jdbcType=BINARY}
+            password_salt = #{object.passwordSalt,jdbcType=BINARY},
+            disabled = #{object.disabled,jdbcType=BOOLEAN}
         WHERE user_id = #{object.objectID,jdbcType=VARCHAR}
     </update>
 

--- a/guacamole-ext/src/main/java/org/glyptodon/guacamole/form/Form.java
+++ b/guacamole-ext/src/main/java/org/glyptodon/guacamole/form/Form.java
@@ -73,6 +73,8 @@ public class Form {
      *     The fields to provided within the new Form.
      */
     public Form(String name, String title, Collection<Field> fields) {
+        this.name = name;
+        this.title = title;
         this.fields = fields;
     }
 

--- a/guacamole-ext/src/main/java/org/glyptodon/guacamole/net/auth/Connection.java
+++ b/guacamole-ext/src/main/java/org/glyptodon/guacamole/net/auth/Connection.java
@@ -86,21 +86,23 @@ public interface Connection extends Identifiable, Connectable {
     public void setConfiguration(GuacamoleConfiguration config);
 
     /**
-     * Returns all attributes associated with this connection.
+     * Returns all attributes associated with this connection. The returned map
+     * may not be modifiable.
      *
      * @return
      *     A map of all attribute identifiers to their corresponding values,
-     *     for all attributes associated with this connection.
+     *     for all attributes associated with this connection, which may not be
+     *     modifiable.
      */
     Map<String, String> getAttributes();
 
     /**
-     * Replaces all attributes associated with this connection with the
-     * attributes in the given map.
+     * Sets the given attributes. If an attribute within the map is not
+     * supported, it will simply be dropped. Any attributes not within the
+     * given map will be left untouched.
      *
      * @param attributes
-     *     A map of all attribute identifiers to their corresponding values,
-     *     for all attributes associated with this connection.
+     *     A map of all attribute identifiers to their corresponding values.
      */
     void setAttributes(Map<String, String> attributes);
 

--- a/guacamole-ext/src/main/java/org/glyptodon/guacamole/net/auth/ConnectionGroup.java
+++ b/guacamole-ext/src/main/java/org/glyptodon/guacamole/net/auth/ConnectionGroup.java
@@ -130,21 +130,23 @@ public interface ConnectionGroup extends Identifiable, Connectable {
             throws GuacamoleException;
 
     /**
-     * Returns all attributes associated with this connection group.
+     * Returns all attributes associated with this connection group. The
+     * returned map may not be modifiable.
      *
      * @return
      *     A map of all attribute identifiers to their corresponding values,
-     *     for all attributes associated with this connection group.
+     *     for all attributes associated with this connection group, which may
+     *     not be modifiable.
      */
     Map<String, String> getAttributes();
 
     /**
-     * Replaces all attributes associated with this connection group with the
-     * attributes in the given map.
+     * Sets the given attributes. If an attribute within the map is not
+     * supported, it will simply be dropped. Any attributes not within the
+     * given map will be left untouched.
      *
      * @param attributes
-     *     A map of all attribute identifiers to their corresponding values,
-     *     for all attributes associated with this connection group.
+     *     A map of all attribute identifiers to their corresponding values.
      */
     void setAttributes(Map<String, String> attributes);
 

--- a/guacamole-ext/src/main/java/org/glyptodon/guacamole/net/auth/User.java
+++ b/guacamole-ext/src/main/java/org/glyptodon/guacamole/net/auth/User.java
@@ -53,21 +53,23 @@ public interface User extends Identifiable {
     public void setPassword(String password);
 
     /**
-     * Returns all attributes associated with this user.
+     * Returns all attributes associated with this user. The returned map may
+     * not be modifiable.
      *
      * @return
      *     A map of all attribute identifiers to their corresponding values,
-     *     for all attributes associated with this user.
+     *     for all attributes associated with this user, which may not be
+     *     modifiable.
      */
     Map<String, String> getAttributes();
 
     /**
-     * Replaces all attributes associated with this user with the attributes in
-     * the given map.
+     * Sets the given attributes. If an attribute within the map is not
+     * supported, it will simply be dropped. Any attributes not within the
+     * given map will be left untouched.
      *
      * @param attributes
-     *     A map of all attribute identifiers to their corresponding values,
-     *     for all attributes associated with this user.
+     *     A map of all attribute identifiers to their corresponding values.
      */
     void setAttributes(Map<String, String> attributes);
 

--- a/guacamole-ext/src/main/java/org/glyptodon/guacamole/net/auth/UserContext.java
+++ b/guacamole-ext/src/main/java/org/glyptodon/guacamole/net/auth/UserContext.java
@@ -24,7 +24,7 @@ package org.glyptodon.guacamole.net.auth;
 
 import java.util.Collection;
 import org.glyptodon.guacamole.GuacamoleException;
-import org.glyptodon.guacamole.form.Field;
+import org.glyptodon.guacamole.form.Form;
 
 /**
  * The context of an active user. The functions of this class enforce all
@@ -121,7 +121,7 @@ public interface UserContext {
      * @return
      *     A collection of all attributes applicable to users.
      */
-    Collection<Field> getUserAttributes();
+    Collection<Form> getUserAttributes();
 
     /**
      * Retrieves a collection of all attributes applicable to connections. This
@@ -132,7 +132,7 @@ public interface UserContext {
      * @return
      *     A collection of all attributes applicable to connections.
      */
-    Collection<Field> getConnectionAttributes();
+    Collection<Form> getConnectionAttributes();
 
     /**
      * Retrieves a collection of all attributes applicable to connection
@@ -143,6 +143,6 @@ public interface UserContext {
      * @return
      *     A collection of all attributes applicable to connection groups.
      */
-    Collection<Field> getConnectionGroupAttributes();
+    Collection<Form> getConnectionGroupAttributes();
 
 }

--- a/guacamole-ext/src/main/java/org/glyptodon/guacamole/net/auth/simple/SimpleUserContext.java
+++ b/guacamole-ext/src/main/java/org/glyptodon/guacamole/net/auth/simple/SimpleUserContext.java
@@ -28,7 +28,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 import org.glyptodon.guacamole.GuacamoleException;
-import org.glyptodon.guacamole.form.Field;
+import org.glyptodon.guacamole.form.Form;
 import org.glyptodon.guacamole.net.auth.ActiveConnection;
 import org.glyptodon.guacamole.net.auth.Connection;
 import org.glyptodon.guacamole.net.auth.ConnectionGroup;
@@ -176,18 +176,18 @@ public class SimpleUserContext implements UserContext {
     }
 
     @Override
-    public Collection<Field> getUserAttributes() {
-        return Collections.<Field>emptyList();
+    public Collection<Form> getUserAttributes() {
+        return Collections.<Form>emptyList();
     }
 
     @Override
-    public Collection<Field> getConnectionAttributes() {
-        return Collections.<Field>emptyList();
+    public Collection<Form> getConnectionAttributes() {
+        return Collections.<Form>emptyList();
     }
 
     @Override
-    public Collection<Field> getConnectionGroupAttributes() {
-        return Collections.<Field>emptyList();
+    public Collection<Form> getConnectionGroupAttributes() {
+        return Collections.<Form>emptyList();
     }
 
 }

--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/schema/SchemaRESTService.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/schema/SchemaRESTService.java
@@ -34,7 +34,7 @@ import javax.ws.rs.core.MediaType;
 import org.glyptodon.guacamole.GuacamoleException;
 import org.glyptodon.guacamole.environment.Environment;
 import org.glyptodon.guacamole.environment.LocalEnvironment;
-import org.glyptodon.guacamole.form.Field;
+import org.glyptodon.guacamole.form.Form;
 import org.glyptodon.guacamole.net.auth.UserContext;
 import org.glyptodon.guacamole.net.basic.rest.AuthProviderRESTExposure;
 import org.glyptodon.guacamole.net.basic.rest.auth.AuthenticationService;
@@ -65,8 +65,8 @@ public class SchemaRESTService {
      *     performing the operation.
      *
      * @return
-     *     A collection of form fields which describe the possible attributes
-     *     of a user object.
+     *     A collection of forms which describe the possible attributes of a
+     *     user object.
      *
      * @throws GuacamoleException
      *     If an error occurs while retrieving the possible attributes.
@@ -74,7 +74,7 @@ public class SchemaRESTService {
     @GET
     @Path("/users/attributes")
     @AuthProviderRESTExposure
-    public Collection<Field> getUserAttributes(@QueryParam("token") String authToken) throws GuacamoleException {
+    public Collection<Form> getUserAttributes(@QueryParam("token") String authToken) throws GuacamoleException {
 
         // Retrieve all possible user attributes
         UserContext userContext = authenticationService.getUserContext(authToken);
@@ -90,8 +90,8 @@ public class SchemaRESTService {
      *     performing the operation.
      *
      * @return
-     *     A collection of form fields which describe the possible attributes
-     *     of a connection object.
+     *     A collection of forms which describe the possible attributes of a
+     *     connection object.
      *
      * @throws GuacamoleException
      *     If an error occurs while retrieving the possible attributes.
@@ -99,7 +99,7 @@ public class SchemaRESTService {
     @GET
     @Path("/connections/attributes")
     @AuthProviderRESTExposure
-    public Collection<Field> getConnectionAttributes(@QueryParam("token") String authToken) throws GuacamoleException {
+    public Collection<Form> getConnectionAttributes(@QueryParam("token") String authToken) throws GuacamoleException {
 
         // Retrieve all possible connection attributes
         UserContext userContext = authenticationService.getUserContext(authToken);
@@ -115,8 +115,8 @@ public class SchemaRESTService {
      *     performing the operation.
      *
      * @return
-     *     A collection of form fields which describe the possible attributes
-     *     of a connection group object.
+     *     A collection of forms which describe the possible attributes of a
+     *     connection group object.
      *
      * @throws GuacamoleException
      *     If an error occurs while retrieving the possible attributes.
@@ -124,7 +124,7 @@ public class SchemaRESTService {
     @GET
     @Path("/connectionGroups/attributes")
     @AuthProviderRESTExposure
-    public Collection<Field> getConnectionGroupAttributes(@QueryParam("token") String authToken) throws GuacamoleException {
+    public Collection<Form> getConnectionGroupAttributes(@QueryParam("token") String authToken) throws GuacamoleException {
 
         // Retrieve all possible connection group attributes
         UserContext userContext = authenticationService.getUserContext(authToken);

--- a/guacamole/src/main/webapp/app/manage/controllers/manageConnectionController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageConnectionController.js
@@ -146,6 +146,15 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
     $scope.permissions = null;
 
     /**
+     * All available connection attributes. This is only the set of attribute
+     * definitions, organized as logical groupings of attributes, not attribute
+     * values.
+     *
+     * @type Form[]
+     */
+    $scope.attributes = null;
+
+    /**
      * Returns whether critical data has completed being loaded.
      *
      * @returns {Boolean}
@@ -161,11 +170,17 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
             && $scope.historyDateFormat    !== null
             && $scope.historyEntryWrappers !== null
             && $scope.permissions          !== null
+            && $scope.attributes           !== null
             && $scope.canSaveConnection    !== null
             && $scope.canDeleteConnection  !== null
             && $scope.canCloneConnection   !== null;
 
     };
+
+    // Pull connection attribute schema
+    schemaService.getConnectionAttributes().success(function attributesReceived(attributes) {
+        $scope.attributes = attributes;
+    });
 
     // Pull connection group hierarchy
     connectionGroupService.getConnectionGroupTree(ConnectionGroup.ROOT_IDENTIFIER, 

--- a/guacamole/src/main/webapp/app/manage/controllers/manageConnectionGroupController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageConnectionGroupController.js
@@ -37,6 +37,7 @@ angular.module('manage').controller('manageConnectionGroupController', ['$scope'
     var connectionGroupService = $injector.get('connectionGroupService');
     var guacNotification       = $injector.get('guacNotification');
     var permissionService      = $injector.get('permissionService');
+    var schemaService          = $injector.get('schemaService');
     
     /**
      * An action to be provided along with the object sent to showStatus which
@@ -95,6 +96,15 @@ angular.module('manage').controller('manageConnectionGroupController', ['$scope'
     $scope.permissions = null;
 
     /**
+     * All available connection group attributes. This is only the set of
+     * attribute definitions, organized as logical groupings of attributes, not
+     * attribute values.
+     *
+     * @type Form[]
+     */
+    $scope.attributes = null;
+
+    /**
      * Returns whether critical data has completed being loaded.
      *
      * @returns {Boolean}
@@ -106,11 +116,17 @@ angular.module('manage').controller('manageConnectionGroupController', ['$scope'
         return $scope.rootGroup                !== null
             && $scope.connectionGroup          !== null
             && $scope.permissions              !== null
+            && $scope.attributes               !== null
             && $scope.canSaveConnectionGroup   !== null
             && $scope.canDeleteConnectionGroup !== null;
 
     };
     
+    // Pull connection group attribute schema
+    schemaService.getConnectionGroupAttributes().success(function attributesReceived(attributes) {
+        $scope.attributes = attributes;
+    });
+
     // Query the user's permissions for the current connection group
     permissionService.getPermissions(authenticationService.getCurrentUserID())
             .success(function permissionsReceived(permissions) {

--- a/guacamole/src/main/webapp/app/manage/controllers/manageUserController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageUserController.js
@@ -105,9 +105,10 @@ angular.module('manage').controller('manageUserController', ['$scope', '$injecto
 
     /**
      * All available user attributes. This is only the set of attribute
-     * definitions, not attribute values.
+     * definitions, organized as logical groupings of attributes, not attribute
+     * values.
      *
-     * @type Field[]
+     * @type Form[]
      */
     $scope.attributes = null;
 

--- a/guacamole/src/main/webapp/app/manage/controllers/manageUserController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageUserController.js
@@ -37,9 +37,9 @@ angular.module('manage').controller('manageUserController', ['$scope', '$injecto
     var authenticationService  = $injector.get('authenticationService');
     var connectionGroupService = $injector.get('connectionGroupService');
     var guacNotification       = $injector.get('guacNotification');
-    var userService            = $injector.get('userService');
     var permissionService      = $injector.get('permissionService');
     var schemaService          = $injector.get('schemaService');
+    var userService            = $injector.get('userService');
 
     /**
      * An action to be provided along with the object sent to showStatus which

--- a/guacamole/src/main/webapp/app/manage/controllers/manageUserController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageUserController.js
@@ -39,6 +39,7 @@ angular.module('manage').controller('manageUserController', ['$scope', '$injecto
     var guacNotification       = $injector.get('guacNotification');
     var userService            = $injector.get('userService');
     var permissionService      = $injector.get('permissionService');
+    var schemaService          = $injector.get('schemaService');
 
     /**
      * An action to be provided along with the object sent to showStatus which
@@ -103,6 +104,14 @@ angular.module('manage').controller('manageUserController', ['$scope', '$injecto
     $scope.permissions = null;
 
     /**
+     * All available user attributes. This is only the set of attribute
+     * definitions, not attribute values.
+     *
+     * @type Field[]
+     */
+    $scope.attributes = null;
+
+    /**
      * Returns whether critical data has completed being loaded.
      *
      * @returns {Boolean}
@@ -115,10 +124,16 @@ angular.module('manage').controller('manageUserController', ['$scope', '$injecto
             && $scope.permissionFlags     !== null
             && $scope.rootGroup           !== null
             && $scope.permissions         !== null
+            && $scope.attributes          !== null
             && $scope.canSaveUser         !== null
             && $scope.canDeleteUser       !== null;
 
     };
+
+    // Pull user attribute schema
+    schemaService.getUserAttributes().success(function attributesReceived(attributes) {
+        $scope.attributes = attributes;
+    });
 
     // Pull user data
     userService.getUser(username).success(function userReceived(user) {

--- a/guacamole/src/main/webapp/app/manage/styles/attributes.css
+++ b/guacamole/src/main/webapp/app/manage/styles/attributes.css
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/* Do not stretch attributes to fit available area */
+.attributes input[type=text],
+.attributes input[type=password],
+.attributes input[type=number] {
+    width: auto;
+}
+
+.attributes .form .fields {
+    display: table;
+    margin: 1em;
+}
+
+.attributes .form .fields .labeled-field {
+    display: table-row;
+}
+
+.attributes .form .fields .field-header,
+.attributes .form .fields .form-field {
+    display: table-cell;
+    padding: 0.125em;
+    vertical-align: top;
+}
+
+.attributes .form .fields .field-header {
+    padding-right: 1em;
+}
+
+.attributes .form h3 {
+
+    font-size: 1.25em;
+    font-weight: bold;
+    text-transform: uppercase;
+    padding: 0.75em 0.5em;
+    margin: 1em 0;
+
+    border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+    border-top: 1px solid rgba(0, 0, 0, 0.125);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.125);
+    background: rgba(0, 0, 0, 0.04);
+
+    width: 100%;
+
+}

--- a/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
@@ -57,6 +57,11 @@ THE SOFTWARE.
         </table>
     </div>
 
+    <!-- Connection attributes section -->
+    <div class="attributes">
+        <guac-form namespace="'CONNECTION_ATTRIBUTES'" content="attributes" model="connection.attributes"></guac-form>
+    </div>
+
     <!-- Connection parameters -->
     <h2 class="header">{{'MANAGE_CONNECTION.SECTION_HEADER_PARAMETERS' | translate}}</h2>
     <div class="section connection-parameters" ng-class="{loading: !parameters}">

--- a/guacamole/src/main/webapp/app/manage/templates/manageConnectionGroup.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageConnectionGroup.html
@@ -57,6 +57,11 @@ THE SOFTWARE.
         </table>
     </div>
 
+    <!-- Connection group attributes section -->
+    <div class="attributes">
+        <guac-form namespace="'CONNECTION_GROUP_ATTRIBUTES'" content="attributes" model="connectionGroup.attributes"></guac-form>
+    </div>
+
     <!-- Form action buttons -->
     <div class="action-buttons">
         <button ng-show="canSaveConnectionGroup" ng-click="saveConnectionGroup()">{{'MANAGE_CONNECTION_GROUP.ACTION_SAVE' | translate}}</button>

--- a/guacamole/src/main/webapp/app/manage/templates/manageUser.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageUser.html
@@ -47,6 +47,11 @@ THE SOFTWARE.
         </table>
     </div>
 
+    <!-- User attributes section -->
+    <div class="attributes">
+        <guac-form namespace="'USER_ATTRIBUTES'" content="attributes" model="user.attributes"></guac-form>
+    </div>
+
     <!-- System permissions section -->
     <h2 class="header">{{'MANAGE_USER.SECTION_HEADER_PERMISSIONS' | translate}}</h2>
     <div class="section">
@@ -63,8 +68,7 @@ THE SOFTWARE.
             </tr>
         </table>
     </div>
-        
-    <!-- Connection and connection group permission section -->
+    
     <h2 class="header">{{'MANAGE_USER.SECTION_HEADER_CONNECTIONS' | translate}}</h2>
     <div class="section" ng-class="{loading: !rootGroup}">
         <guac-group-list

--- a/guacamole/src/main/webapp/app/rest/services/schemaService.js
+++ b/guacamole/src/main/webapp/app/rest/services/schemaService.js
@@ -36,12 +36,13 @@ angular.module('rest').factory('schemaService', ['$injector',
     /**
      * Makes a request to the REST API to get the list of available attributes
      * for user objects, returning a promise that provides an array of
-     * @link{Field} objects if successful. Each element of the array describes
-     * a possible attribute.
+     * @link{Form} objects if successful. Each element of the array describes
+     * a logical grouping of possible attributes.
      *
-     * @returns {Promise.<Field[]>}
-     *     A promise which will resolve with an array of @link{Field}
-     *     objects, where each @link{Field} describes a possible attribute.
+     * @returns {Promise.<Form[]>}
+     *     A promise which will resolve with an array of @link{Form}
+     *     objects, where each @link{Form} describes a logical grouping of
+     *     possible attributes.
      */
     service.getUserAttributes = function getUserAttributes() {
 
@@ -63,12 +64,13 @@ angular.module('rest').factory('schemaService', ['$injector',
     /**
      * Makes a request to the REST API to get the list of available attributes
      * for connection objects, returning a promise that provides an array of
-     * @link{Field} objects if successful. Each element of the array describes
-     * a possible attribute.
+     * @link{Form} objects if successful. Each element of the array describes
+     * a logical grouping of possible attributes.
      *
-     * @returns {Promise.<Field[]>}
-     *     A promise which will resolve with an array of @link{Field}
-     *     objects, where each @link{Field} describes a possible attribute.
+     * @returns {Promise.<Form[]>}
+     *     A promise which will resolve with an array of @link{Form}
+     *     objects, where each @link{Form} describes a logical grouping of
+     *     possible attributes.
      */
     service.getConnectionAttributes = function getConnectionAttributes() {
 
@@ -90,12 +92,13 @@ angular.module('rest').factory('schemaService', ['$injector',
     /**
      * Makes a request to the REST API to get the list of available attributes
      * for connection group objects, returning a promise that provides an array
-     * of @link{Field} objects if successful. Each element of the array
-     * describes a possible attribute.
+     * of @link{Form} objects if successful. Each element of the array
+     * a logical grouping of possible attributes.
      *
-     * @returns {Promise.<Field[]>}
-     *     A promise which will resolve with an array of @link{Field}
-     *     objects, where each @link{Field} describes a possible attribute.
+     * @returns {Promise.<Form[]>}
+     *     A promise which will resolve with an array of @link{Form}
+     *     objects, where each @link{Form} describes a logical grouping of
+     *     possible attributes.
      */
     service.getConnectionGroupAttributes = function getConnectionGroupAttributes() {
 


### PR DESCRIPTION
This change adds a "disabled" attribute to the user object provided by the JDBC auth, and a corresponding column to the `guacamole_user` table. The necessary strings for the new admin section and field are provided by a translation string overlay within the JDBC auth.

Disabled users cannot log in, even though their account technically exists. Attempts to log in as a disabled user are rejected as if the provided credentials were invalid.

![account-restrictions](https://cloud.githubusercontent.com/assets/4632905/7824333/0f8ed6da-03b7-11e5-9458-5b61c24a0c30.png)