### PR TITLE
GUAC-1218: Provide "value" property for "BOOLEAN" parameters.

### DIFF
--- a/guacamole-ext/src/main/resources/org/glyptodon/guacamole/protocols/rdp.json
+++ b/guacamole-ext/src/main/resources/org/glyptodon/guacamole/protocols/rdp.json
@@ -69,12 +69,14 @@
                 {
                     "name"  : "disable-auth",
                     "title" : "Disable authentication",
-                    "type"  : "BOOLEAN"
+                    "type"  : "BOOLEAN",
+                    "value" : "true"
                 },
                 {
                     "name"  : "ignore-cert",
                     "title" : "Ignore server certificate",
-                    "type"  : "BOOLEAN"
+                    "type"  : "BOOLEAN",
+                    "value" : "true"
                 }
             ]
         },


### PR DESCRIPTION
Lacking the `value` property, `BOOLEAN` parameters do not work as expected. They behave as if `undefined` indicates the parameter is enabled, and thus appear checked by default, yet neither the checked or unchecked states have any effect on the parameters of the connection.