### PR TITLE
GUAC-1221: Remove old guacamole.properties example

### DIFF
--- a/guacamole/doc/example/guacamole.properties
+++ b/guacamole/doc/example/guacamole.properties
@@ -1,9 +1,0 @@
-
-# Hostname and port of guacamole proxy
-guacd-hostname: localhost
-guacd-port:     4822
-
-# Auth provider class (authenticates user/pass combination, needed if using the provided login screen)
-auth-provider: net.sourceforge.guacamole.net.basic.BasicFileAuthenticationProvider
-basic-user-mapping: /path/to/user-mapping.xml
-


### PR DESCRIPTION
The example `guacamole.properties` is no longer relevant, as Guacamole no longer requires `guacamole.properties` to work and provides defaults for everything.