### PR TITLE
GUAC-1244: Ensure small scroll events are handled

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Mouse.js
+++ b/guacamole-common-js/src/main/webapp/modules/Mouse.js
@@ -40,12 +40,6 @@ Guacamole.Mouse = function(element) {
     var guac_mouse = this;
 
     /**
-     * Timeout before a single mouse scroll happens.
-     * @type Number
-     */
-    var mouse_scroll_timeout = null;
-
-    /**
      * The number of mousemove events to require before re-enabling mouse
      * event handling after receiving a touch event.
      */
@@ -55,17 +49,17 @@ Guacamole.Mouse = function(element) {
      * The minimum amount of pixels scrolled required for a single scroll button
      * click.
      */
-    this.scrollThreshold = 120;
+    this.scrollThreshold = 53;
 
     /**
      * The number of pixels to scroll per line.
      */
-    this.PIXELS_PER_LINE = 40;
+    this.PIXELS_PER_LINE = 18;
 
     /**
      * The number of pixels to scroll per page.
      */
-    this.PIXELS_PER_PAGE = 640;
+    this.PIXELS_PER_PAGE = this.PIXELS_PER_LINE * 16;
 
     /**
      * The current mouse state. The properties of this state are updated when
@@ -279,54 +273,54 @@ Guacamole.Mouse = function(element) {
         // Update overall delta
         scroll_delta += delta;
 
-        if (mouse_scroll_timeout === null) {
+        // Up
+        if (scroll_delta <= -guac_mouse.scrollThreshold) {
 
-            // Send actual mouse scroll event after a threshold
-            mouse_scroll_timeout = window.setTimeout(function () {
+            // Repeatedly click the up button until insufficient delta remains
+            do {
 
-                // Up
-                if (scroll_delta < 0) {
-                    do {
-
-                        if (guac_mouse.onmousedown) {
-                            guac_mouse.currentState.up = true;
-                            guac_mouse.onmousedown(guac_mouse.currentState);
-                        }
-
-                        if (guac_mouse.onmouseup) {
-                            guac_mouse.currentState.up = false;
-                            guac_mouse.onmouseup(guac_mouse.currentState);
-                        }
-
-                        scroll_delta += guac_mouse.scrollThreshold;
-
-                    } while (scroll_delta < 0);
+                if (guac_mouse.onmousedown) {
+                    guac_mouse.currentState.up = true;
+                    guac_mouse.onmousedown(guac_mouse.currentState);
                 }
 
-                // Down
-                else if (scroll_delta > 0) {
-                    do {
-
-                        if (guac_mouse.onmousedown) {
-                            guac_mouse.currentState.down = true;
-                            guac_mouse.onmousedown(guac_mouse.currentState);
-                        }
-
-                        if (guac_mouse.onmouseup) {
-                            guac_mouse.currentState.down = false;
-                            guac_mouse.onmouseup(guac_mouse.currentState);
-                        }
-
-                        scroll_delta -= guac_mouse.scrollThreshold;
-
-                    } while (scroll_delta > 0);
+                if (guac_mouse.onmouseup) {
+                    guac_mouse.currentState.up = false;
+                    guac_mouse.onmouseup(guac_mouse.currentState);
                 }
 
-                scroll_delta = 0;
-                window.clearTimeout(mouse_scroll_timeout);
-                mouse_scroll_timeout = null;
+                scroll_delta += guac_mouse.scrollThreshold;
 
-            }, 100);
+            } while (scroll_delta <= -guac_mouse.scrollThreshold);
+
+            // Reset delta
+            scroll_delta = 0;
+
+        }
+
+        // Down
+        if (scroll_delta >= guac_mouse.scrollThreshold) {
+
+            // Repeatedly click the down button until insufficient delta remains
+            do {
+
+                if (guac_mouse.onmousedown) {
+                    guac_mouse.currentState.down = true;
+                    guac_mouse.onmousedown(guac_mouse.currentState);
+                }
+
+                if (guac_mouse.onmouseup) {
+                    guac_mouse.currentState.down = false;
+                    guac_mouse.onmouseup(guac_mouse.currentState);
+                }
+
+                scroll_delta -= guac_mouse.scrollThreshold;
+
+            } while (scroll_delta >= guac_mouse.scrollThreshold);
+
+            // Reset delta
+            scroll_delta = 0;
+
         }
 
         cancelEvent(e);

--- a/guacamole-common-js/src/main/webapp/modules/Mouse.js
+++ b/guacamole-common-js/src/main/webapp/modules/Mouse.js
@@ -279,13 +279,15 @@ Guacamole.Mouse = function(element) {
         // Update overall delta
         scroll_delta += delta;
 
-        if (mouse_scroll_timeout == null) {
-            // send actual mouse scroll event after a threshold
+        if (mouse_scroll_timeout === null) {
+
+            // Send actual mouse scroll event after a threshold
             mouse_scroll_timeout = window.setTimeout(function () {
 
                 // Up
                 if (scroll_delta < 0) {
                     do {
+
                         if (guac_mouse.onmousedown) {
                             guac_mouse.currentState.up = true;
                             guac_mouse.onmousedown(guac_mouse.currentState);
@@ -297,11 +299,14 @@ Guacamole.Mouse = function(element) {
                         }
 
                         scroll_delta += guac_mouse.scrollThreshold;
+
                     } while (scroll_delta < 0);
                 }
+
                 // Down
                 else if (scroll_delta > 0) {
                     do {
+
                         if (guac_mouse.onmousedown) {
                             guac_mouse.currentState.down = true;
                             guac_mouse.onmousedown(guac_mouse.currentState);
@@ -313,11 +318,14 @@ Guacamole.Mouse = function(element) {
                         }
 
                         scroll_delta -= guac_mouse.scrollThreshold;
+
                     } while (scroll_delta > 0);
                 }
+
                 scroll_delta = 0;
                 window.clearTimeout(mouse_scroll_timeout);
                 mouse_scroll_timeout = null;
+
             }, 100);
         }
 


### PR DESCRIPTION
The changes from #207 do seem to solve the problem, but introduce the following issues:

1. 100 millisecond latency between the mouse scroll wheel click and response via Guacamole.
2. Over-emphasis of small scroll events for devices which use true smooth scrolling, and actually provide real pixel values in `e.delta`.

I have built off the changes from #207 replacing the use of a timer with better constants derived from the delta values used by Firefox and Chrome. The key change introduced through #207, resetting `scroll_delta` after a series of scrolls is applied, remains.

The primary driving factor behind missed scroll events was that `e.delta` does not necessarily evenly divide into `scrollThreshold`, leading to accumulating error.