### PR TITLE
GUAC-1084: Support re-use of a single ChainedTunnel instance

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Tunnel.js
+++ b/guacamole-common-js/src/main/webapp/modules/Tunnel.js
@@ -843,10 +843,13 @@ Guacamole.ChainedTunnel = function(tunnel_chain) {
     var tunnels = [];
 
     /**
-     * Stores a single committed tunnel once committed
+     * The tunnel committed via commit_tunnel(), if any, or null if no tunnel
+     * has yet been committed.
+     *
      * @private
+     * @type Guacamole.Tunnel
      */
-    var committedTunnel;
+    var committedTunnel = null;
 
     // Load all tunnels into array
     for (var i=0; i<arguments.length; i++)


### PR DESCRIPTION
As described by David Borth in [GUAC-1084](https://glyptodon.org/jira/browse/GUAC-1084):

> When using ChainedTunnel, each time 'connect' is called, the first tunnel is removed from the tunnels  list and used for connection
> Next time we want to connect (after disconnect) to the same ChainedTunnel, it will try to consume again a fresh tunnel from the list of remaining tunnels - what will cause it to fail if list is empty
> 
> Bottom line - the number of tunnels ChainedTunnel is initialized with, is the max number 'connect' execution would work

This change contains the contribution from #82, along with some minor clarifying changes to the comment describing `committedTunnel`.