### PR TITLE
GUAC-1083: Allow use of CORS with Guacamole.HTTPTunnel

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Tunnel.js
+++ b/guacamole-common-js/src/main/webapp/modules/Tunnel.js
@@ -137,10 +137,16 @@ Guacamole.Tunnel.State = {
  * 
  * @constructor
  * @augments Guacamole.Tunnel
- * @param {String} tunnelURL The URL of the HTTP tunneling service.
- * @param {Boolean} withCredentials HTTP requests 'withCredentials' header value.
+ *
+ * @param {String} tunnelURL
+ *     The URL of the HTTP tunneling service.
+ *
+ * @param {Boolean} [crossDomain=false]
+ *     Whether tunnel requests will be cross-domain, and thus must use CORS
+ *     mechanisms and headers. By default, it is assumed that tunnel requests
+ *     will be made to the same domain.
  */
-Guacamole.HTTPTunnel = function(tunnelURL, withCredentials) {
+Guacamole.HTTPTunnel = function(tunnelURL, crossDomain) {
 
     /**
      * Reference to this HTTP tunnel.
@@ -163,7 +169,9 @@ Guacamole.HTTPTunnel = function(tunnelURL, withCredentials) {
     var sendingMessages = false;
     var outputMessageBuffer = "";
 
-    withCredentials = !!withCredentials;
+    // If requests are expected to be cross-domain, the cookie that the HTTP
+    // tunnel depends on will only be sent if withCredentials is true
+    var withCredentials = !!crossDomain;
 
     /**
      * The current receive timeout ID, if any.

--- a/guacamole-common-js/src/main/webapp/modules/Tunnel.js
+++ b/guacamole-common-js/src/main/webapp/modules/Tunnel.js
@@ -138,8 +138,9 @@ Guacamole.Tunnel.State = {
  * @constructor
  * @augments Guacamole.Tunnel
  * @param {String} tunnelURL The URL of the HTTP tunneling service.
+ * @param {Boolean} withCredentials HTTP requests 'withCredentials' header value.
  */
-Guacamole.HTTPTunnel = function(tunnelURL) {
+Guacamole.HTTPTunnel = function(tunnelURL, withCredentials) {
 
     /**
      * Reference to this HTTP tunnel.
@@ -161,6 +162,8 @@ Guacamole.HTTPTunnel = function(tunnelURL) {
 
     var sendingMessages = false;
     var outputMessageBuffer = "";
+
+    withCredentials = !!withCredentials;
 
     /**
      * The current receive timeout ID, if any.
@@ -278,6 +281,7 @@ Guacamole.HTTPTunnel = function(tunnelURL) {
 
             var message_xmlhttprequest = new XMLHttpRequest();
             message_xmlhttprequest.open("POST", TUNNEL_WRITE + tunnel_uuid);
+            message_xmlhttprequest.withCredentials = withCredentials;
             message_xmlhttprequest.setRequestHeader("Content-type", "application/x-www-form-urlencoded; charset=UTF-8");
 
             // Once response received, send next queued event.
@@ -508,6 +512,7 @@ Guacamole.HTTPTunnel = function(tunnelURL) {
         // Make request, increment request ID
         var xmlhttprequest = new XMLHttpRequest();
         xmlhttprequest.open("GET", TUNNEL_READ + tunnel_uuid + ":" + (request_id++));
+        xmlhttprequest.withCredentials = withCredentials;
         xmlhttprequest.send(null);
 
         return xmlhttprequest;
@@ -547,6 +552,7 @@ Guacamole.HTTPTunnel = function(tunnelURL) {
         };
 
         connect_xmlhttprequest.open("POST", TUNNEL_CONNECT, true);
+        connect_xmlhttprequest.withCredentials = withCredentials;
         connect_xmlhttprequest.setRequestHeader("Content-type", "application/x-www-form-urlencoded; charset=UTF-8");
         connect_xmlhttprequest.send(data);
 


### PR DESCRIPTION
This change adds support for CORS to `Guacamole.HTTPTunnel` through the changes from #80. The only changes added to #80 by this specific PR are:

1. Clarification of the additional `Guacamole.HTTPTunnel` constructor parameter.
2. Squashing of the commit-revert-commit-commit (which was really intended as a single commit) into the single commit it should have been.