### PR TITLE
GUAC-1255: Merge German translation from Sven Thuma.

### DIFF
--- a/guacamole/pom.xml
+++ b/guacamole/pom.xml
@@ -168,6 +168,7 @@
                                 <jsSourceFile>lib/blob/blob.js</jsSourceFile>
                                 <jsSourceFile>lib/filesaver/filesaver.js</jsSourceFile>
                                 <jsSourceFile>lib/messageformat/messageformat.js</jsSourceFile>
+                                <jsSourceFile>lib/messageformat/de.js</jsSourceFile>
                                 <jsSourceFile>lib/messageformat/fr.js</jsSourceFile>
                                 <jsSourceFile>lib/messageformat/nl.js</jsSourceFile>
                                 <jsSourceFile>lib/messageformat/ru.js</jsSourceFile>

--- a/guacamole/src/main/webapp/lib/messageformat/de.js
+++ b/guacamole/src/main/webapp/lib/messageformat/de.js
@@ -1,0 +1,6 @@
+MessageFormat.locale.de = function ( n ) {
+  if ( n === 1 ) {
+    return "one";
+  }
+  return "other";
+};

--- a/guacamole/src/main/webapp/translations/de.json
+++ b/guacamole/src/main/webapp/translations/de.json
@@ -1,0 +1,533 @@
+{
+    
+    "NAME" : "Deutsch (DE)",
+    
+    "APP" : {
+
+        "ACTION_ACKNOWLEDGE"        : "OK",
+        "ACTION_CANCEL"             : "Abbruch",
+        "ACTION_CLONE"              : "Kopieren",
+        "ACTION_CONTINUE"           : "Weiter",
+        "ACTION_DELETE"             : "Löschen",
+        "ACTION_DELETE_SESSIONS"    : "Beende Sitzung",
+        "ACTION_LOGIN"              : "Anmelden",
+        "ACTION_LOGOUT"             : "Abmelden",
+        "ACTION_MANAGE_CONNECTIONS" : "Verbindungen",
+        "ACTION_MANAGE_PREFERENCES" : "Einstellungen",
+        "ACTION_MANAGE_SETTINGS"    : "Einstellungen",
+        "ACTION_MANAGE_SESSIONS"    : "Aktive Sitzungen",
+        "ACTION_MANAGE_USERS"       : "Benutzer",
+        "ACTION_NAVIGATE_BACK"      : "Zurück",
+        "ACTION_NAVIGATE_HOME"      : "Startseite",
+        "ACTION_SAVE"               : "Speichern",
+        "ACTION_UPDATE_PASSWORD"    : "Aktualisiere Passwort",
+
+        "DIALOG_HEADER_ERROR" : "Fehler",
+
+        "ERROR_PASSWORD_BLANK"    : "Bitte ein Passwort vergeben.",
+        "ERROR_PASSWORD_MISMATCH" : "Die Passwörter stimmen nicht überein.",
+        
+        "FIELD_HEADER_PASSWORD"       : "Passwort:",
+        "FIELD_HEADER_PASSWORD_AGAIN" : "Wiederhole Passwort:",
+
+        "FORMAT_DATE_TIME_PRECISE" : "dd-MM-yyyy HH:mm:ss",
+
+        "INFO_ACTIVE_USER_COUNT" : "In Benutzung durch {USERS} {USERS, plural, one{user} other{users}}.",
+
+        "NAME" : "Guacamole ${project.version}"
+
+    },
+
+    "CLIENT" : {
+
+        "ACTION_ACKNOWLEDGE"               : "@:APP.ACTION_ACKNOWLEDGE",
+        "ACTION_CLEAR_COMPLETED_TRANSFERS" : "Entferne abgeschlossene Übertragungen",
+        "ACTION_DISCONNECT"                : "Trennen",
+        "ACTION_NAVIGATE_HOME"             : "@:APP.ACTION_NAVIGATE_HOME",
+        "ACTION_RECONNECT"                 : "Neu Verbinden",
+        "ACTION_SAVE_FILE"                 : "@:APP.ACTION_SAVE",
+        "ACTION_UPLOAD_FILES"              : "Dateien hochladen",
+
+        "DIALOG_HEADER_CONNECTING"       : "Verbindung",
+        "DIALOG_HEADER_CONNECTION_ERROR" : "Verbindungsfehler",
+        "DIALOG_HEADER_DISCONNECTED"     : "Verbindung getrennt",
+
+        "ERROR_CLIENT_201"     : "Aufgrund hoher Serverauslastung wurde diese Verbindung zurückgesetzt. Versuche es in wenigen Minuten erneut.",
+        "ERROR_CLIENT_202"     : "Der Verbindungsaufbau wurde durch den Guacamole Server abgebrochen da der Entfernte Computer nicht reagiert. Versuche es noch einmal oder kontaktiere den Systemadministrator.",        
+        "ERROR_CLIENT_203"     : "Der entfernte Computer hat einen Fehler hervorgerufen und die Verbindung geschlossen. Versuche es noch einmal oder kontaktiere den Systemadministrator.",
+        "ERROR_CLIENT_205"     : "Diese Verbindung kollidiert mit einer bestehenen Verbindung. Versuche es später erneut.",
+        "ERROR_CLIENT_301"     : "Anmeldung Fehlgeschlagen. Bitte schließen Sie und versuchen Sie es erneut.",
+        "ERROR_CLIENT_303"     : "Sie haben keine Berechtigung auf diese Verbindung zuzugreifen. Wenn Sie diese Berechtigung benötigen, bitten Sie den Systemadministrator diese Berechtigung hinzuzufügen oder prüfen Sie Ihre Systemeinstellugen.",
+        "ERROR_CLIENT_308"     : "Die Verbindung wurde durch den Guacamole Server geschlossen da keine aktive Interkommukaion mit dem Browser besteht. Dies wird gewöhnlich durch Netzwerkprobleme verursacht, wie eine schlechte drahtlose Verbindung oder eine sehr langsame Netzwerkverbindung. Bitte überprüfen Sie Ihre Netzwerkverbindung und versuchen Sie es erneut.",
+        "ERROR_CLIENT_31D"     : "Der Zugang zu dieser Verbindung wurde durch den Guacamole Server verweigert, da die maximale Anzahl der gleichzeitigen Zugiffe für diese Verbindung für einen einzelnen Benutzer erreicht wurde.",
+        "ERROR_CLIENT_DEFAULT" : "Die Verbindung wurde aufgrund eines interen Fehlers im Guacamole Server beendet. Sollte dieses Problem weiterhin bestehen informieren Sie den Systemadministrator oder überprüfen Sie die Protokolle.",
+
+        "ERROR_TUNNEL_201"     : "Der Verbindungsversuch wurde aufgrund zu vieler bestehenden Verbindungen durch den Guacamole Server zurückgewiesen. Versuche es in wenigen Minuten erneut.",
+        "ERROR_TUNNEL_202"     : "Die Verbindung zum Server wurde aufgrund hoher Latenz geschlossen. Dies wird gewöhnlich durch Netzwerkprobleme verursacht, wie eine schlechte drahtlose Verbindung oder eine sehr langsame Netzwerkverbindung. Bitte überprüfen Sie Ihre Netzwerkverbindung und versuchen Sie es erneut.",
+        "ERROR_TUNNEL_203"     : "Die Verbindung wurde aufgrund eines interen Fehlers beendet. Versuche es noch einmal oder kontaktiere den Systemadministrator.",
+        "ERROR_TUNNEL_204"     : "Die angeforderte Verbindung exisiert nicht. Bitte überprüfe den Verbindungsnamen und versuche es erneut.",
+        "ERROR_TUNNEL_205"     : "Diese Verbindung ist in Verwendung, ein konkurrierender Zugriff ist nicht gestattet. Versuche es später erneut.",
+        "ERROR_TUNNEL_301"     : "Sie haben keine Zugriffsberechtigung für diese Verbindung. Bitte melden Sie sich an und versuchen es erneut.",
+        "ERROR_TUNNEL_303"     : "Sie haben keine Zugriffsberechtigung für diese Verbindung. Wenn Sie diese Berechtigung benötigen, bitten Sie den Systemadministrator diese Berechtigung hinzuzufügen oder prüfen Sie Ihre Systemeinstellugen.",
+        "ERROR_TUNNEL_308"     : "Die Verbindung wurde durch den Guacamole Server geschlossen da keine aktive Interkommunikation mit dem Browser besteht. Dies wird gewöhnlich durch Netzwerkprobleme verursacht, wie eine schlechte drahtlose Verbindung oder eine sehr langsame Netzwerkverbindung. Bitte überprüfen Sie Ihre Netzwerkverbindung und versuchen Sie es erneut.",
+        "ERROR_TUNNEL_31D"     : "Der Zugang zu dieser Verbindung wurde durch den Guacamole Server verweigert, da die maximale Anzahl der gleichzeitigen Zugiffe für einen einzelnen Benutzer erreicht wurde. Bitte schliesse eine oder mehrere Verbindungen und versuche es erneut.",
+        "ERROR_TUNNEL_DEFAULT" : "Die Verbindung wurde aufgrund eines interen Fehlers im Guacamole Server beendet. Sollte dieses Problem weiterhin bestehen informieren Sie den Systemadministrator oder überprüfen Sie die Protokolle.",
+
+        "ERROR_UPLOAD_100"     : "Dateiübertragungen werden entweder nicht unterstützt oder sind nicht aktiviert. Bitte kontaktiere den Systemadministrator oder überprüfe die Protokolle.",
+        "ERROR_UPLOAD_201"     : "Die maximale Anzahl gleichzeitiger Dateiübertragungen erreicht. Bitte warte bis laufende Dateiübertagungen abgeschlossen sind und versuche es erneut.",
+        "ERROR_UPLOAD_202"     : "Die Dateiübertragung konnte nicht gestartet werden da der Entfernet Computer nicht reagiert. Bitte versuche es erneut oder kontaktiere den Systemadministrator.",
+        "ERROR_UPLOAD_203"     : "Der entfernte Computer hat bei der Übertragungen einen Fehler verursacht. Bitte versuche es erneut oder kontaktiere den Systemadministrator.",
+        "ERROR_UPLOAD_204"     : "Das Übertragungsziel existiert nicht. Bitte überprüfe ob der Zielort exisitert und versuche es erneut.",
+        "ERROR_UPLOAD_205"     : "Das Übertragungsziel ist zur Zeit gesperrt. Bitte warte bis alle laufenden Prozesse beendet wurden und versuche es erneut.",
+        "ERROR_UPLOAD_301"     : "Es besteht ohne Anmeldung keine Berechtigung zur Dateiübertragung. Bitte anmelden und erneut versuchen.",
+        "ERROR_UPLOAD_303"     : "Es besteht keine Berechtingung zur Dateiübertragung. Wenn Sie diese Berechtigung benötigen überprüfen Sie die Systemeinstellungen oder überprüfen Sie diese gemeinsam mit dem Systemadministrator.",
+        "ERROR_UPLOAD_308"     : "Die Dateiübertragung weist keinen Fortschritt auf. Dies wird gewöhnlich durch Netzwerkprobleme verursacht, wie eine schlechte drahtlose Verbindung oder eine sehr langsame Netzwerkverbindung. Bitte überprüfen Sie Ihre Netzwerkverbindung und versuchen Sie es erneut.",
+        "ERROR_UPLOAD_31D"     : "Die maximale Anzahl gleichzeiter Dateiübertragungen erreicht. Bitte warte bis laufende Dateiübertagungen abgeschlossen sind und versuche es erneut.",
+        "ERROR_UPLOAD_DEFAULT" : "Die Verbindung wurde aufgrund eines interen Fehlers im Guacamole Server beendet. Sollte dieses Problem weiterhin bestehen informieren Sie den Systemadministrator oder überprüfen Sie die Protokolle.",
+
+        "HELP_CLIPBOARD"           : "Kopierter oder ausgeschnittener Text aus Guacamole wird hier angezeigt. Änderungen am Text werden direkt auf die entfernte Zwischenablage angewandt.",
+        "HELP_INPUT_METHOD_NONE"   : "Keine Eingabemethode in Verwendung. Tastatureingaben werden von der Hardwaretastatur akzeptiert.",
+        "HELP_INPUT_METHOD_OSK"    : "Bildschirmeingaben und die eingebettete Guacamole Bildschrimtastatur werden akzeptiert. Die Bildschirmtastatur gestattet Tastenkombinationen die ansonsten unmöglich sind (z.B.: Strl-Alt-Del).",
+        "HELP_INPUT_METHOD_TEXT"   : "Gestattet Eingaben von Text und emuliert Tastaturkombinationen basierend auf den eingegebenen Text. Dies wird benötigt für Geräte ohne Hardwaretastatur.",
+        "HELP_MOUSE_MODE"          : "Beeinflusst, wie sich die entfernte Maus bei Touchpadberührungen verhält.",
+        "HELP_MOUSE_MODE_ABSOLUTE" : "Tippen Sie auf die Zielposition, der Klick erfolgt am Ort der Berührung des Touchscreen's.",
+        "HELP_MOUSE_MODE_RELATIVE" : "Den Mauszeiger zur Zielposition bewegen und klicken. Der Klick erfolgt an der Position des Mauszeigers.",
+
+        "INFO_NO_FILE_TRANSFERS" : "Keine Dateiübertragungen.",
+
+        "NAME_INPUT_METHOD_NONE"   : "Keine",
+        "NAME_INPUT_METHOD_OSK"    : "Bildschirmtastatur",
+        "NAME_INPUT_METHOD_TEXT"   : "Texteingabe",
+        "NAME_KEY_CTRL"            : "Strg",
+        "NAME_KEY_ALT"             : "Alt",
+        "NAME_KEY_ESC"             : "Esc",
+        "NAME_KEY_TAB"             : "Tab",
+        "NAME_MOUSE_MODE_ABSOLUTE" : "Touchscreen",
+        "NAME_MOUSE_MODE_RELATIVE" : "Touchpad",
+
+        "SECTION_HEADER_CLIPBOARD"      : "Zwischenablage",
+        "SECTION_HEADER_DISPLAY"        : "Display",
+        "SECTION_HEADER_FILE_TRANSFERS" : "Dateiübertragung",
+        "SECTION_HEADER_INPUT_METHOD"   : "Eingabemethode",
+        "SECTION_HEADER_MOUSE_MODE"     : "Mausemulationsmodus",
+
+        "TEXT_ZOOM_AUTO_FIT"              : "Autoanpassung Fenstergröße",
+        "TEXT_CLIENT_STATUS_IDLE"         : "Inaktiv.",
+        "TEXT_CLIENT_STATUS_CONNECTING"   : "Verbindungsaufbau zu Guacamole...",
+        "TEXT_CLIENT_STATUS_DISCONNECTED" : "Verbindung wurde getrennt.",
+        "TEXT_CLIENT_STATUS_WAITING"      : "Verbindungsaufbau zu Guacamole. Bitte warten...",
+        "TEXT_RECONNECT_COUNTDOWN"        : "Neuverbindung in {REMAINING} {REMAINING, plural, one{second} other{seconds}}...",
+        "TEXT_FILE_TRANSFER_PROGRESS"     : "{PROGRESS} {UNIT, select, b{B} kb{KB} mb{MB} gb{GB} other{}}",
+
+        "URL_OSK_LAYOUT" : "layouts/en-us-qwerty.json"
+
+    },
+
+    "FORM" : {
+
+        "HELP_SHOW_PASSWORD" : "Passwort anzeigen",
+        "HELP_HIDE_PASSWORD" : "Passwort ausblenden"
+
+    },
+
+    "HOME" : {
+
+        "INFO_ACTIVE_USER_COUNT" : "@:APP.INFO_ACTIVE_USER_COUNT",
+
+        "INFO_NO_RECENT_CONNECTIONS" : "Keine aktiven Verbindungen.",
+        
+        "PASSWORD_CHANGED" : "Passwort geändert.",
+
+        "SECTION_HEADER_ALL_CONNECTIONS"    : "Alle Verbindungen",
+        "SECTION_HEADER_RECENT_CONNECTIONS" : "Letzte Verbindungen"
+
+    },
+
+    "LOGIN": {
+
+        "ACTION_ACKNOWLEDGE" : "@:APP.ACTION_ACKNOWLEDGE",
+        "ACTION_CONTINUE"    : "@:APP.ACTION_CONTINUE",
+        "ACTION_LOGIN"       : "@:APP.ACTION_LOGIN",
+
+        "DIALOG_HEADER_ERROR" : "@:APP.DIALOG_HEADER_ERROR",
+
+        "ERROR_INVALID_LOGIN" : "Anmeldungsfehler",
+
+        "FIELD_HEADER_USERNAME" : "Benutzername",
+        "FIELD_HEADER_PASSWORD" : "Passwort"
+
+    },
+
+    "MANAGE_CONNECTION" : {
+
+        "ACTION_ACKNOWLEDGE"          : "@:APP.ACTION_ACKNOWLEDGE",
+        "ACTION_CANCEL"               : "@:APP.ACTION_CANCEL",
+        "ACTION_CLONE"                : "@:APP.ACTION_CLONE",
+        "ACTION_DELETE"               : "@:APP.ACTION_DELETE",
+        "ACTION_SAVE"                 : "@:APP.ACTION_SAVE",
+
+        "DIALOG_HEADER_CONFIRM_DELETE" : "Lösche Verbindung",
+        "DIALOG_HEADER_ERROR"          : "@:APP.DIALOG_HEADER_ERROR",
+
+        "FIELD_HEADER_LOCATION" : "Standort:",
+        "FIELD_HEADER_NAME"     : "Name:",
+        "FIELD_HEADER_PROTOCOL" : "Protokol:",
+
+        "FORMAT_HISTORY_START" : "@:APP.FORMAT_DATE_TIME_PRECISE",
+
+        "INFO_CONNECTION_DURATION_UNKNOWN" : "--",
+        "INFO_CONNECTION_ACTIVE_NOW"       : "Aktivieren",
+        "INFO_CONNECTION_NOT_USED"         : "Diese Verbindung wurde bisher nicht verwendet.",
+
+        "SECTION_HEADER_EDIT_CONNECTION" : "Bearbeite Verbindung",
+        "SECTION_HEADER_HISTORY"         : "Verlauf",
+        "SECTION_HEADER_PARAMETERS"      : "Parameter",
+
+        "TABLE_HEADER_HISTORY_USERNAME" : "Benutzername",
+        "TABLE_HEADER_HISTORY_START"    : "Begin",
+        "TABLE_HEADER_HISTORY_DURATION" : "Dauer",
+
+        "TEXT_CONFIRM_DELETE"   : "Dieser Löschvorgang ist unumkehrbar. Soll diese Verbindung wirklich gelöscht werden?",
+        "TEXT_HISTORY_DURATION" : "{VALUE} {UNIT, select, second{{VALUE, plural, one{second} other{seconds}}} minute{{VALUE, plural, one{minute} other{minutes}}} hour{{VALUE, plural, one{hour} other{hours}}} day{{VALUE, plural, one{day} other{days}}} other{}}"
+
+    },
+
+    "MANAGE_CONNECTION_GROUP" : {
+
+        "ACTION_ACKNOWLEDGE"   : "@:APP.ACTION_ACKNOWLEDGE",
+        "ACTION_CANCEL"        : "@:APP.ACTION_CANCEL",
+        "ACTION_DELETE"        : "@:APP.ACTION_DELETE",
+        "ACTION_SAVE"          : "@:APP.ACTION_SAVE",
+
+        "DIALOG_HEADER_CONFIRM_DELETE" : "Lösche Verbindungsgruppe",
+        "DIALOG_HEADER_ERROR"          : "@:APP.DIALOG_HEADER_ERROR",
+
+        "FIELD_HEADER_LOCATION" : "Standort:",
+        "FIELD_HEADER_NAME"     : "Name:",
+        "FIELD_HEADER_TYPE"     : "Typ:",
+
+        "NAME_TYPE_BALANCING"       : "Balancing",
+        "NAME_TYPE_ORGANIZATIONAL"  : "Organisation",
+
+        "SECTION_HEADER_EDIT_CONNECTION_GROUP" : "Ändere Verbindungsgruppe",
+
+        "TEXT_CONFIRM_DELETE" : "Dieser Löschvorgang ist unumkehrbar. Soll diese Verbindungsgruppe wirklich gelöscht werden?"
+
+    },
+
+    "MANAGE_USER" : {
+
+        "ACTION_ACKNOWLEDGE"   : "@:APP.ACTION_ACKNOWLEDGE",
+        "ACTION_CANCEL"        : "@:APP.ACTION_CANCEL",
+        "ACTION_DELETE"        : "@:APP.ACTION_DELETE",
+        "ACTION_SAVE"          : "@:APP.ACTION_SAVE",
+
+        "DIALOG_HEADER_CONFIRM_DELETE" : "Lösche Benutzer",
+        "DIALOG_HEADER_ERROR"          : "@:APP.DIALOG_HEADER_ERROR",
+
+        "ERROR_PASSWORD_MISMATCH" : "@:APP.ERROR_PASSWORD_MISMATCH",
+
+        "FIELD_HEADER_ADMINISTER_SYSTEM"             : "Administration:",
+        "FIELD_HEADER_CHANGE_OWN_PASSWORD"           : "Ändere eigenes Passwort:",
+        "FIELD_HEADER_CREATE_NEW_USERS"              : "Erstelle neue Benutzer:",
+        "FIELD_HEADER_CREATE_NEW_CONNECTIONS"        : "Erstelle neue Verbindung:",
+        "FIELD_HEADER_CREATE_NEW_CONNECTION_GROUPS"  : "Erstelle neue Verbindungsgruppe:",
+        "FIELD_HEADER_PASSWORD"                      : "@:APP.FIELD_HEADER_PASSWORD",
+        "FIELD_HEADER_PASSWORD_AGAIN"                : "@:APP.FIELD_HEADER_PASSWORD_AGAIN",
+        "FIELD_HEADER_USERNAME"                      : "Benutzername:",
+        
+        "SECTION_HEADER_CONNECTIONS" : "Verbindungen",
+        "SECTION_HEADER_EDIT_USER"   : "Ändere Benutzer",
+        "SECTION_HEADER_PERMISSIONS" : "Berechtigungen",
+
+        "TEXT_CONFIRM_DELETE" : "Dieser Löschvorgang ist unumkehrbar. Soll dieser Benutzer wirklich gelöscht werden?"
+
+    },
+    
+    "PROTOCOL_RDP" : {
+
+        "FIELD_HEADER_COLOR_DEPTH"     : "Farbtiefe:",
+        "FIELD_HEADER_CONSOLE"         : "Mit Konsole verbinden (Windows 2003 / 2003 R2):",
+        "FIELD_HEADER_CONSOLE_AUDIO"   : "Audiounterstützung Konsole:",
+        "FIELD_HEADER_CLIENT_NAME"     : "Client-Name:",
+        "FIELD_HEADER_DISABLE_AUDIO"   : "Deaktivere Audio:",
+        "FIELD_HEADER_DISABLE_AUTH"    : "Deaktivere Authentifizierung:",
+        "FIELD_HEADER_DOMAIN"          : "Domäne:",
+        "FIELD_HEADER_DPI"             : "Auflösung (DPI):",
+        "FIELD_HEADER_DRIVE_PATH"      : "Laufwerkspfad:",
+        "FIELD_HEADER_ENABLE_DESKTOP_COMPOSITION" : "Aktiviere Desktop Gestaltung (Aero):",
+        "FIELD_HEADER_ENABLE_DRIVE"               : "Aktiviere Laufwerk:",
+        "FIELD_HEADER_ENABLE_FONT_SMOOTHING"      : "Aktiviere Schriftartglättung (ClearType):",
+        "FIELD_HEADER_ENABLE_FULL_WINDOW_DRAG"    : "Aktiviere Fensterziehen:",
+        "FIELD_HEADER_ENABLE_MENU_ANIMATIONS"     : "Aktiviere Menüanimationen:",
+        "FIELD_HEADER_ENABLE_PRINTING"            : "Aktiviere Drucken:",
+        "FIELD_HEADER_ENABLE_THEMING"             : "Aktiviere Thema:",
+        "FIELD_HEADER_ENABLE_WALLPAPER"           : "Aktiviere Desktophintergrund:",
+        "FIELD_HEADER_HEIGHT"          : "Höhe:",
+        "FIELD_HEADER_HOSTNAME"        : "Hostname:",
+        "FIELD_HEADER_IGNORE_CERT"     : "Server Zertifikat ignorieren:",
+        "FIELD_HEADER_INITIAL_PROGRAM" : "Startprogramm:",
+        "FIELD_HEADER_PASSWORD"        : "Passwort:",
+        "FIELD_HEADER_PORT"            : "Port:",
+        "FIELD_HEADER_REMOTE_APP_ARGS" : "Parameter:",
+        "FIELD_HEADER_REMOTE_APP_DIR"  : "Arbeitsverzeichnis:",
+        "FIELD_HEADER_REMOTE_APP"      : "Programm:",
+        "FIELD_HEADER_SECURITY"        : "Sicherheitsverfahren:",
+        "FIELD_HEADER_SERVER_LAYOUT"   : "Tastatur Layout:",
+        "FIELD_HEADER_USERNAME"        : "Benutzername:",
+        "FIELD_HEADER_WIDTH"           : "Breite:",
+        "FIELD_HEADER_STATIC_CHANNELS" : "Statischer Kanalname:",
+
+        "FIELD_OPTION_COLOR_DEPTH_16"    : "Hohe Farbtiefe (16-bit)",
+        "FIELD_OPTION_COLOR_DEPTH_24"    : "Echtfarben (24-bit)",
+        "FIELD_OPTION_COLOR_DEPTH_32"    : "Echtfarben (32-bit)",
+        "FIELD_OPTION_COLOR_DEPTH_8"     : "256 Farben",
+        "FIELD_OPTION_COLOR_DEPTH_EMPTY" : "",
+
+        "FIELD_OPTION_SECURITY_ANY"   : "Jede",
+        "FIELD_OPTION_SECURITY_EMPTY" : "",
+        "FIELD_OPTION_SECURITY_NLA"   : "NLA (Netzwerkebene Authentifizierung)",
+        "FIELD_OPTION_SECURITY_RDP"   : "RDP Verschlüsselung",
+        "FIELD_OPTION_SECURITY_TLS"   : "TLS Verschlüsselung",
+
+        "FIELD_OPTION_SERVER_LAYOUT_DE_DE_QWERTZ" : "Deutsch (Qwertz)",
+        "FIELD_OPTION_SERVER_LAYOUT_EMPTY"        : "",
+        "FIELD_OPTION_SERVER_LAYOUT_EN_US_QWERTY" : "US Englisch (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_FAILSAFE"     : "Unicode",
+        "FIELD_OPTION_SERVER_LAYOUT_FR_FR_AZERTY" : "Französisch (Azerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_IT_IT_QWERTY" : "Italienisch (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_SV_SE_QWERTY" : "Schwedisch (Qwerty)",
+
+        "NAME" : "RDP",
+
+        "SECTION_HEADER_AUTHENTICATION"     : "Authentifizierung",
+        "SECTION_HEADER_BASIC_PARAMETERS"   : "Basiseinstellungen",
+        "SECTION_HEADER_DEVICE_REDIRECTION" : "Geräteumleitung",
+        "SECTION_HEADER_DISPLAY"            : "Bildschirm",
+        "SECTION_HEADER_NETWORK"            : "Netzwerk",
+        "SECTION_HEADER_PERFORMANCE"        : "Geschwindigkeit",
+        "SECTION_HEADER_REMOTEAPP"          : "Entferntes Programm"
+
+    },
+
+    "PROTOCOL_SSH" : {
+
+        "FIELD_HEADER_FONT_NAME"   : "Schriftart Name:",
+        "FIELD_HEADER_FONT_SIZE"   : "Schriftart Größe:",
+        "FIELD_HEADER_ENABLE_SFTP" : "Aktiviere SFTP:",
+        "FIELD_HEADER_HOSTNAME"    : "Hostname:",
+        "FIELD_HEADER_USERNAME"    : "Benutzername:",
+        "FIELD_HEADER_PASSWORD"    : "Passwort:",
+        "FIELD_HEADER_PASSPHRASE"  : "Passphrase:",
+        "FIELD_HEADER_PORT"        : "Port:",
+        "FIELD_HEADER_PRIVATE_KEY" : "Privater Schlüssel:",
+
+        "FIELD_OPTION_FONT_SIZE_8"     : "8",
+        "FIELD_OPTION_FONT_SIZE_9"     : "9",
+        "FIELD_OPTION_FONT_SIZE_10"    : "10",
+        "FIELD_OPTION_FONT_SIZE_11"    : "11",
+        "FIELD_OPTION_FONT_SIZE_12"    : "12",
+        "FIELD_OPTION_FONT_SIZE_14"    : "14",
+        "FIELD_OPTION_FONT_SIZE_18"    : "18",
+        "FIELD_OPTION_FONT_SIZE_24"    : "24",
+        "FIELD_OPTION_FONT_SIZE_30"    : "30",
+        "FIELD_OPTION_FONT_SIZE_36"    : "36",
+        "FIELD_OPTION_FONT_SIZE_48"    : "48",
+        "FIELD_OPTION_FONT_SIZE_60"    : "60",
+        "FIELD_OPTION_FONT_SIZE_72"    : "72",
+        "FIELD_OPTION_FONT_SIZE_96"    : "96",
+        "FIELD_OPTION_FONT_SIZE_EMPTY" : "",
+
+        "NAME" : "SSH",
+
+        "SECTION_HEADER_AUTHENTICATION" : "Authentifizierung",
+        "SECTION_HEADER_DISPLAY"        : "Bildschirm",
+        "SECTION_HEADER_NETWORK"        : "Netzwerk",
+        "SECTION_HEADER_SFTP"           : "SFTP"
+
+    },
+
+    "PROTOCOL_TELNET" : {
+
+        "FIELD_HEADER_FONT_NAME"      : "Schriftart Name:",
+        "FIELD_HEADER_FONT_SIZE"      : "Schriftart Größe:",
+        "FIELD_HEADER_HOSTNAME"       : "Hostname:",
+        "FIELD_HEADER_USERNAME"       : "Benutzername:",
+        "FIELD_HEADER_PASSWORD"       : "Passwort:",
+        "FIELD_HEADER_PASSWORD_REGEX" : "Reguläre Passwortersetzungen:",
+        "FIELD_HEADER_PORT"           : "Port:",
+
+        "FIELD_OPTION_FONT_SIZE_8"     : "8",
+        "FIELD_OPTION_FONT_SIZE_9"     : "9",
+        "FIELD_OPTION_FONT_SIZE_10"    : "10",
+        "FIELD_OPTION_FONT_SIZE_11"    : "11",
+        "FIELD_OPTION_FONT_SIZE_12"    : "12",
+        "FIELD_OPTION_FONT_SIZE_14"    : "14",
+        "FIELD_OPTION_FONT_SIZE_18"    : "18",
+        "FIELD_OPTION_FONT_SIZE_24"    : "24",
+        "FIELD_OPTION_FONT_SIZE_30"    : "30",
+        "FIELD_OPTION_FONT_SIZE_36"    : "36",
+        "FIELD_OPTION_FONT_SIZE_48"    : "48",
+        "FIELD_OPTION_FONT_SIZE_60"    : "60",
+        "FIELD_OPTION_FONT_SIZE_72"    : "72",
+        "FIELD_OPTION_FONT_SIZE_96"    : "96",
+        "FIELD_OPTION_FONT_SIZE_EMPTY" : "",
+
+        "NAME" : "Telnet",
+
+        "SECTION_HEADER_AUTHENTICATION" : "Authentifizierung",
+        "SECTION_HEADER_DISPLAY"        : "Bildschirm",
+        "SECTION_HEADER_NETWORK"        : "Netzwerk"
+
+    },
+
+    "PROTOCOL_VNC" : {
+
+        "FIELD_HEADER_AUDIO_SERVERNAME" : "Audioservername:",
+        "FIELD_HEADER_COLOR_DEPTH"      : "Farbtiefe:",
+        "FIELD_HEADER_CURSOR"           : "Cursor:",
+        "FIELD_HEADER_DEST_HOST"        : "Ziel Host:",
+        "FIELD_HEADER_DEST_PORT"        : "Ziel Port:",
+        "FIELD_HEADER_ENABLE_AUDIO"     : "Aktiviere Audio:",
+        "FIELD_HEADER_HOSTNAME"         : "Hostname:",
+        "FIELD_HEADER_PASSWORD"         : "Passwort:",
+        "FIELD_HEADER_PORT"             : "Port:",
+        "FIELD_HEADER_READ_ONLY"        : "Nur-Lesen:",
+        "FIELD_HEADER_SWAP_RED_BLUE"    : "Vertausche rot/blau Komponenten:",
+
+        "FIELD_OPTION_COLOR_DEPTH_8"     : "256 Farben",
+        "FIELD_OPTION_COLOR_DEPTH_16"    : "Hohe Farbtiefe (16-bit)",
+        "FIELD_OPTION_COLOR_DEPTH_24"    : "Echfarben (24-bit)",
+        "FIELD_OPTION_COLOR_DEPTH_32"    : "Echfarben (32-bit)",
+        "FIELD_OPTION_COLOR_DEPTH_EMPTY" : "",
+
+        "FIELD_OPTION_CURSOR_EMPTY"  : "",
+        "FIELD_OPTION_CURSOR_LOCAL"  : "Lokal",
+        "FIELD_OPTION_CURSOR_REMOTE" : "Entfernt",
+
+        "NAME" : "VNC",
+
+        "SECTION_HEADER_AUDIO"          : "Audio",
+        "SECTION_HEADER_AUTHENTICATION" : "Authentifizierung",
+        "SECTION_HEADER_DISPLAY"        : "Bildschirm",
+        "SECTION_HEADER_NETWORK"        : "Netzwerk",
+        "SECTION_HEADER_REPEATER"       : "VNC Repeater"
+
+    },
+
+    "SETTINGS" : {
+
+        "SECTION_HEADER_SETTINGS" : "Einstellungen"
+
+    },
+
+    "SETTINGS_CONNECTIONS" : {
+
+        "ACTION_ACKNOWLEDGE"          : "@:APP.ACTION_ACKNOWLEDGE",
+        "ACTION_NEW_CONNECTION"       : "Neue Verbindung",
+        "ACTION_NEW_CONNECTION_GROUP" : "Neue Verbindungsgruppe",
+
+        "DIALOG_HEADER_ERROR" : "@:APP.DIALOG_HEADER_ERROR",
+
+        "HELP_CONNECTIONS"   : "Klicke oder Tippe auf eine Verbindung um diese zu verwalten. Abhänig von Ihrer Zugriffsebene können Verbindungen hinzugefügt, gelöscht oder Parameter (Protokol, Hostname, Port, etc.) geändert werden.",
+        
+        "INFO_ACTIVE_USER_COUNT" : "@:APP.INFO_ACTIVE_USER_COUNT",
+
+        "SECTION_HEADER_CONNECTIONS"     : "Verbindungen"
+
+    },
+
+    "SETTINGS_PREFERENCES" : {
+
+        "ACTION_ACKNOWLEDGE"        : "@:APP.ACTION_ACKNOWLEDGE",
+        "ACTION_CANCEL"             : "@:APP.ACTION_CANCEL",
+        "ACTION_UPDATE_PASSWORD"    : "@:APP.ACTION_UPDATE_PASSWORD",
+
+        "DIALOG_HEADER_ERROR"    : "@:APP.DIALOG_HEADER_ERROR",
+
+        "ERROR_PASSWORD_BLANK"    : "@:APP.ERROR_PASSWORD_BLANK",
+        "ERROR_PASSWORD_MISMATCH" : "@:APP.ERROR_PASSWORD_MISMATCH",
+
+        "FIELD_HEADER_LANGUAGE"           : "Anzeigesprache:",
+        "FIELD_HEADER_PASSWORD"           : "Passwort:",
+        "FIELD_HEADER_PASSWORD_OLD"       : "Aktuelles Passwort:",
+        "FIELD_HEADER_PASSWORD_NEW"       : "Neues Passwort:",
+        "FIELD_HEADER_PASSWORD_NEW_AGAIN" : "Passwortbestättigung:",
+        "FIELD_HEADER_USERNAME"           : "Benutzername:",
+        
+        "HELP_DEFAULT_INPUT_METHOD" : "Die Standardeingabemethode bestimmt wie Tastaturereignisse an Guacamole weitergeleitet werden. Eine Änderung dieser Einstellung kann erforderlich sein, wenn ein mobiles Gerät verwendet wird oder bei der Eingabe durch einen IME. Dieses Verhalten kann im Menü innerhalb der Guacamole Verbindung geändert werden.",
+        "HELP_DEFAULT_MOUSE_MODE"   : "Der Standard Mausemulationsmodus bestimmt wie sich die entfernte Maus bei Touchpad Berührungen verhält. Dieses Verhalten kann im Menü innerhalb der Guacamole Verbindung geändert werden.",
+        "HELP_INPUT_METHOD_NONE"    : "@:CLIENT.HELP_INPUT_METHOD_NONE",
+        "HELP_INPUT_METHOD_OSK"     : "@:CLIENT.HELP_INPUT_METHOD_OSK",
+        "HELP_INPUT_METHOD_TEXT"    : "@:CLIENT.HELP_INPUT_METHOD_TEXT",
+        "HELP_LANGUAGE"             : "Um die Spracheinstellungen von den Guacamole zu ändern,  wählen Sie eine der verfügbaren Sprachen.",
+        "HELP_MOUSE_MODE_ABSOLUTE"  : "@:CLIENT.HELP_MOUSE_MODE_ABSOLUTE",
+        "HELP_MOUSE_MODE_RELATIVE"  : "@:CLIENT.HELP_MOUSE_MODE_RELATIVE",
+        "HELP_UPDATE_PASSWORD"      : "Wenn Sie das Passwort ändern wollen, geben Sie das aktuelle und das gewünschte Passwort ein und klicken Sie auf \"Ändere Passwort\". Die Änderung wird sofort wirksam.",
+
+        "INFO_PASSWORD_CHANGED" : "Passwort geändert.",
+
+        "NAME_INPUT_METHOD_NONE" : "@:CLIENT.NAME_INPUT_METHOD_NONE",
+        "NAME_INPUT_METHOD_OSK"  : "@:CLIENT.NAME_INPUT_METHOD_OSK",
+        "NAME_INPUT_METHOD_TEXT" : "@:CLIENT.NAME_INPUT_METHOD_TEXT",
+
+        "SECTION_HEADER_DEFAULT_INPUT_METHOD" : "Standard Eingabemethode",
+        "SECTION_HEADER_DEFAULT_MOUSE_MODE"   : "Standard Mausemulationsmodus",
+        "SECTION_HEADER_UPDATE_PASSWORD"      : "Ändere Passwort"
+
+    },
+
+    "SETTINGS_USERS" : {
+
+        "ACTION_ACKNOWLEDGE"   : "@:APP.ACTION_ACKNOWLEDGE",
+        "ACTION_NEW_USER"      : "Neuer Benutzer",
+
+        "DIALOG_HEADER_ERROR" : "@:APP.DIALOG_HEADER_ERROR",
+
+        "HELP_USERS" : "Klicke oder Tippe auf einen Benutzer um diesen zu verwalten. Abhänig von Ihrer Zugriffsebene können Benutzer hinzugefügt, gelöscht bzw. dessen Passwort geändert werden.",
+
+        "SECTION_HEADER_USERS"       : "Benutzer"
+
+    },
+    
+    "SETTINGS_SESSIONS" : {
+        
+        "ACTION_ACKNOWLEDGE" : "@:APP.ACTION_ACKNOWLEDGE",
+        "ACTION_CANCEL"      : "@:APP.ACTION_CANCEL",
+        "ACTION_DELETE"      : "Beende Sitzung",
+        
+        "DIALOG_HEADER_CONFIRM_DELETE" : "Beende Sitzung",
+        "DIALOG_HEADER_ERROR"          : "@:APP.DIALOG_HEADER_ERROR",
+        
+        "FIELD_PLACEHOLDER_FILTER" : "Filter",
+        
+        "FORMAT_STARTDATE" : "@:APP.FORMAT_DATE_TIME_PRECISE",
+
+        "HELP_SESSIONS" : "Alle aktiven Guacamole Sitzungen werden hier aufgelistet. Wenn Sie eine oder mehrere Sitzungen beenden wollen, wählen Sie diese Sitzung durch Aktivierung der nebenstehende Box und klicken auf \"Beende Sitzung\". Beendung einer Sitzung trennt den Benutzer von dessen Verbindung unverzüglich.",
+        
+        "INFO_NO_SESSIONS" : "Keine aktiven Sitzungen",
+
+        "SECTION_HEADER_SESSIONS" : "Aktive Sitzungen",
+        
+        "TABLE_HEADER_SESSION_USERNAME"        : "Benutzername",
+        "TABLE_HEADER_SESSION_STARTDATE"       : "Aktive seit",
+        "TABLE_HEADER_SESSION_REMOTEHOST"      : "Entfernter Host",
+        "TABLE_HEADER_SESSION_CONNECTION_NAME" : "Verbindungsname",
+        
+        "TEXT_CONFIRM_DELETE" : "Sind Sie sicher, dass alle ausgwählten Sitzungen beendet werden sollen? Die Benutzer dieser Sitzungen werden unverzüglich getrennt."
+
+    },
+
+    "USER_MENU" : {
+
+        "ACTION_LOGOUT"             : "@:APP.ACTION_LOGOUT",
+        "ACTION_MANAGE_CONNECTIONS" : "@:APP.ACTION_MANAGE_CONNECTIONS",
+        "ACTION_MANAGE_PREFERENCES" : "@:APP.ACTION_MANAGE_PREFERENCES",
+        "ACTION_MANAGE_SESSIONS"    : "@:APP.ACTION_MANAGE_SESSIONS",
+        "ACTION_MANAGE_SETTINGS"    : "@:APP.ACTION_MANAGE_SETTINGS",
+        "ACTION_MANAGE_USERS"       : "@:APP.ACTION_MANAGE_USERS",
+        "ACTION_NAVIGATE_HOME"      : "@:APP.ACTION_NAVIGATE_HOME"
+
+    }
+
+}

--- a/guacamole/src/main/webapp/translations/de.json
+++ b/guacamole/src/main/webapp/translations/de.json
@@ -32,7 +32,7 @@
 
         "FORMAT_DATE_TIME_PRECISE" : "dd-MM-yyyy HH:mm:ss",
 
-        "INFO_ACTIVE_USER_COUNT" : "In Benutzung durch {USERS} {USERS, plural, one{user} other{users}}.",
+        "INFO_ACTIVE_USER_COUNT" : "In Benutzung durch {USERS} Benutzer.",
 
         "NAME" : "Guacamole ${project.version}"
 
@@ -116,7 +116,7 @@
         "TEXT_CLIENT_STATUS_CONNECTING"   : "Verbindungsaufbau zu Guacamole...",
         "TEXT_CLIENT_STATUS_DISCONNECTED" : "Verbindung wurde getrennt.",
         "TEXT_CLIENT_STATUS_WAITING"      : "Verbindungsaufbau zu Guacamole. Bitte warten...",
-        "TEXT_RECONNECT_COUNTDOWN"        : "Neuverbindung in {REMAINING} {REMAINING, plural, one{second} other{seconds}}...",
+        "TEXT_RECONNECT_COUNTDOWN"        : "Neuverbindung in {REMAINING} {REMAINING, plural, one{Sekunde} other{Sekunden}}...",
         "TEXT_FILE_TRANSFER_PROGRESS"     : "{PROGRESS} {UNIT, select, b{B} kb{KB} mb{MB} gb{GB} other{}}",
 
         "URL_OSK_LAYOUT" : "layouts/en-us-qwerty.json"
@@ -188,7 +188,7 @@
         "TABLE_HEADER_HISTORY_DURATION" : "Dauer",
 
         "TEXT_CONFIRM_DELETE"   : "Dieser Löschvorgang ist unumkehrbar. Soll diese Verbindung wirklich gelöscht werden?",
-        "TEXT_HISTORY_DURATION" : "{VALUE} {UNIT, select, second{{VALUE, plural, one{second} other{seconds}}} minute{{VALUE, plural, one{minute} other{minutes}}} hour{{VALUE, plural, one{hour} other{hours}}} day{{VALUE, plural, one{day} other{days}}} other{}}"
+        "TEXT_HISTORY_DURATION" : "{VALUE} {UNIT, select, second{{VALUE, plural, one{Sekunde} other{Sekunden}}} minute{{VALUE, plural, one{Minute} other{Minuten}}} hour{{VALUE, plural, one{Stunde} other{Stunden}}} day{{VALUE, plural, one{Tag} other{Tage}}} other{}}"
 
     },
 

--- a/guacamole/src/main/webapp/translations/de.json
+++ b/guacamole/src/main/webapp/translations/de.json
@@ -1,6 +1,6 @@
 {
     
-    "NAME" : "Deutsch (DE)",
+    "NAME" : "Deutsch",
     
     "APP" : {
 


### PR DESCRIPTION
This change merges the German translation contributed by Sven Thuma. In addition, I've performed the usual changes:

1. Removed the country code from the language name.
2. Added the missing messageformat.js locale file.

I've also gone ahead and translated the pluralized words, which were left in English in the original submission. I assume they were simply forgotten, or the format was unfamiliar. I'm relatively confident that my German is not so horrible that I did this wrong, but it's *is* possible.