### PR TITLE
GUAC-1249: Ensure stacking context of login UI fields is explicit.

### DIFF
--- a/guacamole/src/main/webapp/app/login/styles/login.css
+++ b/guacamole/src/main/webapp/app/login/styles/login.css
@@ -62,6 +62,7 @@ div.login-ui {
 .login-ui .login-fields .labeled-field {
     display: block;
     position: relative;
+    z-index: 1;
 }
 
 .login-ui .login-fields .labeled-field .field-header {


### PR DESCRIPTION
[GUAC-1249](https://glyptodon.org/jira/browse/GUAC-1249) ("Labels do not show on login page in IE 11") appears to result from IE11 not properly creating a new stacking context for the `position: relative` field `<div>`. Lacking a new stacking context, the `z-index: -1` property of the placeholder `<span>` forces the placeholder below other opaque page elements, rendering the placeholder permanently invisible.

Explicitly forcing a new stacking context by applying `z-index: 1` to the parent `<div>` solves the issue without risking violating standard behavior.

See: http://www.w3.org/TR/CSS21/visuren.html#propdef-z-index