### PR TITLE
GUAC-1262: Add missing german translations

### DIFF
--- a/guacamole/src/main/webapp/translations/de.json
+++ b/guacamole/src/main/webapp/translations/de.json
@@ -43,6 +43,7 @@
         "ACTION_ACKNOWLEDGE"               : "@:APP.ACTION_ACKNOWLEDGE",
         "ACTION_CLEAR_COMPLETED_TRANSFERS" : "Entferne abgeschlossene Übertragungen",
         "ACTION_DISCONNECT"                : "Trennen",
+        "ACTION_NAVIGATE_BACK"             : "@:APP.ACTION_NAVIGATE_BACK",
         "ACTION_NAVIGATE_HOME"             : "@:APP.ACTION_NAVIGATE_HOME",
         "ACTION_RECONNECT"                 : "Neu Verbinden",
         "ACTION_SAVE_FILE"                 : "@:APP.ACTION_SAVE",
@@ -106,7 +107,8 @@
         "NAME_MOUSE_MODE_RELATIVE" : "Touchpad",
 
         "SECTION_HEADER_CLIPBOARD"      : "Zwischenablage",
-        "SECTION_HEADER_DISPLAY"        : "Display",
+        "SECTION_HEADER_DEVICES"        : "Geräte",
+        "SECTION_HEADER_DISPLAY"        : "Anzeige",
         "SECTION_HEADER_FILE_TRANSFERS" : "Dateiübertragung",
         "SECTION_HEADER_INPUT_METHOD"   : "Eingabemethode",
         "SECTION_HEADER_MOUSE_MODE"     : "Mausemulationsmodus",


### PR DESCRIPTION
"ACTION_NAVIGATE_BACK" : "@:APP.ACTION_NAVIGATE_BACK",
"SECTION_HEADER_DEVICES" : "Devices",