### PR TITLE
GUAC-298: Add VNC parameter for clipboard encoding.

### DIFF
--- a/guacamole-ext/src/main/resources/org/glyptodon/guacamole/protocols/vnc.json
+++ b/guacamole-ext/src/main/resources/org/glyptodon/guacamole/protocols/vnc.json
@@ -53,6 +53,17 @@
         },
 
         {
+            "name"  : "clipboard",
+            "fields" : [
+                {
+                    "name"    : "clipboard-encoding",
+                    "type"    : "ENUM",
+                    "options" : [ "", "ISO8859-1", "UTF-8", "UTF-16", "CP1252" ]
+                }
+            ]
+        },
+
+        {
             "name"  : "repeater",
             "fields" : [
                 {

--- a/guacamole/src/main/webapp/translations/de.json
+++ b/guacamole/src/main/webapp/translations/de.json
@@ -426,6 +426,7 @@
 
         "SECTION_HEADER_AUDIO"          : "Audio",
         "SECTION_HEADER_AUTHENTICATION" : "Authentifizierung",
+        "SECTION_HEADER_CLIPBOARD"      : "Zwischenablage",
         "SECTION_HEADER_DISPLAY"        : "Bildschirm",
         "SECTION_HEADER_NETWORK"        : "Netzwerk",
         "SECTION_HEADER_REPEATER"       : "VNC Repeater",

--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -394,6 +394,7 @@
     "PROTOCOL_VNC" : {
 
         "FIELD_HEADER_AUDIO_SERVERNAME" : "Audio server name:",
+        "FIELD_HEADER_CLIPBOARD_ENCODING" : "Encoding:",
         "FIELD_HEADER_COLOR_DEPTH"      : "Color depth:",
         "FIELD_HEADER_CURSOR"           : "Cursor:",
         "FIELD_HEADER_DEST_HOST"        : "Destination host:",
@@ -422,10 +423,17 @@
         "FIELD_OPTION_CURSOR_LOCAL"  : "Local",
         "FIELD_OPTION_CURSOR_REMOTE" : "Remote",
 
+        "FIELD_OPTION_CLIPBOARD_ENCODING_CP1252"    : "CP1252",
+        "FIELD_OPTION_CLIPBOARD_ENCODING_EMPTY"     : "",
+        "FIELD_OPTION_CLIPBOARD_ENCODING_ISO8859_1" : "ISO 8859-1",
+        "FIELD_OPTION_CLIPBOARD_ENCODING_UTF_8"     : "UTF-8",
+        "FIELD_OPTION_CLIPBOARD_ENCODING_UTF_16"    : "UTF-16",
+
         "NAME" : "VNC",
 
         "SECTION_HEADER_AUDIO"          : "Audio",
         "SECTION_HEADER_AUTHENTICATION" : "Authentication",
+        "SECTION_HEADER_CLIPBOARD"      : "Clipboard",
         "SECTION_HEADER_DISPLAY"        : "Display",
         "SECTION_HEADER_NETWORK"        : "Network",
         "SECTION_HEADER_REPEATER"       : "VNC Repeater",

--- a/guacamole/src/main/webapp/translations/fr.json
+++ b/guacamole/src/main/webapp/translations/fr.json
@@ -426,6 +426,7 @@
 
         "SECTION_HEADER_AUDIO"          : "Son",
         "SECTION_HEADER_AUTHENTICATION" : "Authentification",
+        "SECTION_HEADER_CLIPBOARD"      : "Presse-papiers",
         "SECTION_HEADER_DISPLAY"        : "Affichage",
         "SECTION_HEADER_NETWORK"        : "Réseau",
         "SECTION_HEADER_REPEATER"       : "Répéteur VNC",

--- a/guacamole/src/main/webapp/translations/it.json
+++ b/guacamole/src/main/webapp/translations/it.json
@@ -409,6 +409,7 @@
 
         "SECTION_HEADER_AUDIO"          : "Audio",
         "SECTION_HEADER_AUTHENTICATION" : "Authentication",
+        "SECTION_HEADER_CLIPBOARD"      : "Appunti",
         "SECTION_HEADER_DISPLAY"        : "Display",
         "SECTION_HEADER_NETWORK"        : "Network",
         "SECTION_HEADER_REPEATER"       : "VNC Repeater"

--- a/guacamole/src/main/webapp/translations/nl.json
+++ b/guacamole/src/main/webapp/translations/nl.json
@@ -418,6 +418,7 @@
 
         "SECTION_HEADER_AUDIO"          : "Geluid",
         "SECTION_HEADER_AUTHENTICATION" : "Authenticatie",
+        "SECTION_HEADER_CLIPBOARD"      : "Klembord",
         "SECTION_HEADER_DISPLAY"        : "Scherm",
         "SECTION_HEADER_NETWORK"        : "Netwerk",
         "SECTION_HEADER_REPEATER"       : "VNC Repeater",

--- a/guacamole/src/main/webapp/translations/ru.json
+++ b/guacamole/src/main/webapp/translations/ru.json
@@ -396,7 +396,9 @@
         "FIELD_OPTION_CURSOR_LOCAL"  : "Локальный",
         "FIELD_OPTION_CURSOR_REMOTE" : "Удаленный",
 
-        "NAME" : "VNC"
+        "NAME" : "VNC",
+
+        "SECTION_HEADER_CLIPBOARD" : "Буфер обмена"
 
     },
 


### PR DESCRIPTION
This change follows the change made in glyptodon/guacamole-server#59, adding the new `clipboard-encoding` parameter to the JSON describing the parameters available for the VNC protocol.