### PR TITLE
GUAC-1213: Add date/time restrictions for user accounts.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/ModeledUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/ModeledUser.java
@@ -426,28 +426,28 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
         // Translate access window start time
         try { getModel().setAccessWindowStart(parseTime(attributes.get(ACCESS_WINDOW_START_ATTRIBUTE_NAME))); }
         catch (ParseException e) {
-            logger.warn("Not setting start time of user access window - invalid time format.");
+            logger.warn("Not setting start time of user access window: {}", e.getMessage());
             logger.debug("Unable to parse time attribute.", e);
         }
 
         // Translate access window end time
         try { getModel().setAccessWindowEnd(parseTime(attributes.get(ACCESS_WINDOW_END_ATTRIBUTE_NAME))); }
         catch (ParseException e) {
-            logger.warn("Not setting end time of user access window - invalid time format.");
+            logger.warn("Not setting end time of user access window: {}", e.getMessage());
             logger.debug("Unable to parse time attribute.", e);
         }
 
         // Translate account validity start date
         try { getModel().setValidFrom(parseDate(attributes.get(VALID_FROM_ATTRIBUTE_NAME))); }
         catch (ParseException e) {
-            logger.warn("Not setting user validity start date - invalid date format.");
+            logger.warn("Not setting user validity start date: {}", e.getMessage());
             logger.debug("Unable to parse date attribute.", e);
         }
 
         // Translate account validity end date
         try { getModel().setValidUntil(parseDate(attributes.get(VALID_UNTIL_ATTRIBUTE_NAME))); }
         catch (ParseException e) {
-            logger.warn("Not setting user validity end date - invalid date format.");
+            logger.warn("Not setting user validity end date: {}", e.getMessage());
             logger.debug("Unable to parse date attribute.", e);
         }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/UserModel.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/UserModel.java
@@ -22,6 +22,8 @@
 
 package org.glyptodon.guacamole.auth.jdbc.user;
 
+import java.sql.Date;
+import java.sql.Time;
 import org.glyptodon.guacamole.auth.jdbc.base.ObjectModel;
 
 /**
@@ -54,6 +56,40 @@ public class UserModel extends ObjectModel {
      * used until this occurs.
      */
     private boolean expired;
+
+    /**
+     * The time each day after which this user account may be used, stored in
+     * local time according to the value of timeZone.
+     */
+    private Time accessWindowStart;
+
+    /**
+     * The time each day after which this user account may NOT be used, stored
+     * in local time according to the value of timeZone.
+     */
+    private Time accessWindowEnd;
+
+    /**
+     * The day after which this account becomes valid and usable. Account
+     * validity begins at midnight of this day. Time information within the
+     * Date object is ignored.
+     */
+    private Date validFrom;
+
+    /**
+     * The day after which this account can no longer be used. Account validity
+     * ends at midnight of the day following this day. Time information within
+     * the Date object is ignored.
+     */
+    private Date validUntil;
+
+    /**
+     * The ID of the time zone used for all time comparisons for this user.
+     * Both accessWindowStart and accessWindowEnd values will use this time
+     * zone, as will checks for whether account validity dates have passed. If
+     * unset, the server's local time zone is used.
+     */
+    private String timeZone;
 
     /**
      * Creates a new, empty user.
@@ -156,6 +192,138 @@ public class UserModel extends ObjectModel {
      */
     public void setExpired(boolean expired) {
         this.expired = expired;
+    }
+
+    /**
+     * Returns the time each day after which this user account may be used. The
+     * time returned will be local time according to the time zone set with
+     * setTimeZone().
+     *
+     * @return
+     *     The time each day after which this user account may be used, or null
+     *     if this restriction does not apply.
+     */
+    public Time getAccessWindowStart() {
+        return accessWindowStart;
+    }
+
+    /**
+     * Sets the time each day after which this user account may be used. The
+     * time given must be in local time according to the time zone set with
+     * setTimeZone().
+     *
+     * @param accessWindowStart
+     *     The time each day after which this user account may be used, or null
+     *     if this restriction does not apply.
+     */
+    public void setAccessWindowStart(Time accessWindowStart) {
+        this.accessWindowStart = accessWindowStart;
+    }
+
+    /**
+     * Returns the time each day after which this user account may NOT be used.
+     * The time returned will be local time according to the time zone set with
+     * setTimeZone().
+     *
+     * @return
+     *     The time each day after which this user account may NOT be used, or
+     *     null if this restriction does not apply.
+     */
+    public Time getAccessWindowEnd() {
+        return accessWindowEnd;
+    }
+
+    /**
+     * Sets the time each day after which this user account may NOT be used.
+     * The time given must be in local time according to the time zone set with
+     * setTimeZone().
+     *
+     * @param accessWindowEnd
+     *     The time each day after which this user account may NOT be used, or
+     *     null if this restriction does not apply.
+     */
+    public void setAccessWindowEnd(Time accessWindowEnd) {
+        this.accessWindowEnd = accessWindowEnd;
+    }
+
+    /**
+     * Returns the day after which this account becomes valid and usable.
+     * Account validity begins at midnight of this day. Any time information
+     * within the returned Date object must be ignored.
+     *
+     * @return
+     *     The day after which this account becomes valid and usable, or null
+     *     if this restriction does not apply.
+     */
+    public Date getValidFrom() {
+        return validFrom;
+    }
+
+    /**
+     * Sets the day after which this account becomes valid and usable. Account
+     * validity begins at midnight of this day. Any time information within
+     * the provided Date object will be ignored.
+     *
+     * @param validFrom
+     *     The day after which this account becomes valid and usable, or null
+     *     if this restriction does not apply.
+     */
+    public void setValidFrom(Date validFrom) {
+        this.validFrom = validFrom;
+    }
+
+    /**
+     * Returns the day after which this account can no longer be used. Account
+     * validity ends at midnight of the day following this day. Any time
+     * information within the returned Date object must be ignored.
+     *
+     * @return
+     *     The day after which this account can no longer be used, or null if
+     *     this restriction does not apply.
+     */
+    public Date getValidUntil() {
+        return validUntil;
+    }
+
+    /**
+     * Sets the day after which this account can no longer be used. Account
+     * validity ends at midnight of the day following this day. Any time
+     * information within the provided Date object will be ignored.
+     *
+     * @param validUntil
+     *     The day after which this account can no longer be used, or null if
+     *     this restriction does not apply.
+     */
+    public void setValidUntil(Date validUntil) {
+        this.validUntil = validUntil;
+    }
+
+    /**
+     * Returns the Java ID of the time zone to be used for all time comparisons
+     * for this user. This ID should correspond to a value returned by
+     * TimeZone.getAvailableIDs(). If unset or invalid, the server's local time
+     * zone must be used.
+     *
+     * @return
+     *     The ID of the time zone to be used for all time comparisons, which
+     *     should correspond to a value returned by TimeZone.getAvailableIDs().
+     */
+    public String getTimeZone() {
+        return timeZone;
+    }
+
+    /**
+     * Sets the Java ID of the time zone to be used for all time comparisons
+     * for this user. This ID should correspond to a value returned by
+     * TimeZone.getAvailableIDs(). If unset or invalid, the server's local time
+     * zone will be used.
+     *
+     * @param timeZone
+     *     The ID of the time zone to be used for all time comparisons, which
+     *     should correspond to a value returned by TimeZone.getAvailableIDs().
+     */
+    public void setTimeZone(String timeZone) {
+        this.timeZone = timeZone;
     }
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/UserService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/UserService.java
@@ -302,11 +302,11 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
 
         // Verify user account is still valid as of today
         if (!user.isAccountValid())
-            throw new GuacamoleClientException("LOGIN.ERROR_NO_LONGER_VALID");
+            throw new GuacamoleClientException("LOGIN.ERROR_NOT_VALID");
 
         // Verify user account is allowed to be used at the current time
         if (!user.isAccountAccessible())
-            throw new GuacamoleClientException("LOGIN.ERROR_NOT_WITHIN_ACCESS_WINDOW");
+            throw new GuacamoleClientException("LOGIN.ERROR_NOT_ACCESSIBLE");
 
         // Update password if password is expired
         if (userModel.isExpired()) {

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/UserService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/UserService.java
@@ -300,6 +300,14 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
         ModeledUser user = getObjectInstance(null, userModel);
         user.setCurrentUser(new AuthenticatedUser(user, credentials));
 
+        // Verify user account is still valid as of today
+        if (!user.isAccountValid())
+            throw new GuacamoleClientException("LOGIN.ERROR_NO_LONGER_VALID");
+
+        // Verify user account is allowed to be used at the current time
+        if (!user.isAccountAccessible())
+            throw new GuacamoleClientException("LOGIN.ERROR_NOT_WITHIN_ACCESS_WINDOW");
+
         // Update password if password is expired
         if (userModel.isExpired()) {
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/en.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/en.json
@@ -17,8 +17,13 @@
 
     "USER_ATTRIBUTES" : {
 
-        "FIELD_HEADER_DISABLED" : "Login disabled:",
-        "FIELD_HEADER_EXPIRED"  : "Password expired:",
+        "FIELD_HEADER_DISABLED"            : "Login disabled:",
+        "FIELD_HEADER_EXPIRED"             : "Password expired:",
+        "FIELD_HEADER_ACCESS_WINDOW_END"   : "Do not allow access after:",
+        "FIELD_HEADER_ACCESS_WINDOW_START" : "Allow access after:",
+        "FIELD_HEADER_TIMEZONE"            : "User time zone:",
+        "FIELD_HEADER_VALID_FROM"          : "Enable account after:",
+        "FIELD_HEADER_VALID_UNTIL"         : "Disable account after:",
 
         "SECTION_HEADER_RESTRICTIONS" : "Account Restrictions"
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/en.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/en.json
@@ -5,6 +5,8 @@
         "ERROR_PASSWORD_BLANK"    : "@:APP.ERROR_PASSWORD_BLANK",
         "ERROR_PASSWORD_SAME"     : "The new password must be different from the expired password.",
         "ERROR_PASSWORD_MISMATCH" : "@:APP.ERROR_PASSWORD_MISMATCH",
+        "ERROR_NOT_VALID"         : "This user account is not currently valid.",
+        "ERROR_NOT_ACCESSIBLE"    : "Access to this account is not currently allowed. Please try again later.",
 
         "INFO_PASSWORD_EXPIRED" : "Your password has expired and must be reset. Please enter a new password to continue.",
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
@@ -73,11 +73,24 @@ CREATE TABLE `guacamole_connection` (
 CREATE TABLE `guacamole_user` (
 
   `user_id`       int(11)      NOT NULL AUTO_INCREMENT,
+
+  -- Username and optionally-salted password
   `username`      varchar(128) NOT NULL,
   `password_hash` binary(32)   NOT NULL,
   `password_salt` binary(32),
+
+  -- Account disabled/expired status
   `disabled`      boolean      NOT NULL DEFAULT 0,
   `expired`       boolean      NOT NULL DEFAULT 0,
+
+  -- Time-based access restriction
+  `access_window_start`    TIME,
+  `access_window_end`      TIME,
+  `access_window_timezone` VARCHAR(64),
+
+  -- Date-based access restriction
+  `valid_from`  DATE,
+  `valid_until` DATE,
 
   PRIMARY KEY (`user_id`),
   UNIQUE KEY `username` (`username`)

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
@@ -86,11 +86,13 @@ CREATE TABLE `guacamole_user` (
   -- Time-based access restriction
   `access_window_start`    TIME,
   `access_window_end`      TIME,
-  `access_window_timezone` VARCHAR(64),
 
   -- Date-based access restriction
   `valid_from`  DATE,
   `valid_until` DATE,
+
+  -- Timezone used for all date/time comparisons and interpretation
+  `timezone` VARCHAR(64),
 
   PRIMARY KEY (`user_id`),
   UNIQUE KEY `username` (`username`)

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/upgrade/upgrade-pre-0.9.8.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/upgrade/upgrade-pre-0.9.8.sql
@@ -26,7 +26,6 @@
 
 ALTER TABLE guacamole_user ADD COLUMN access_window_start    TIME;
 ALTER TABLE guacamole_user ADD COLUMN access_window_end      TIME;
-ALTER TABLE guacamole_user ADD COLUMN access_window_timezone VARCHAR(64);
 
 --
 -- Add per-user date-based account validity restrictions.
@@ -34,3 +33,9 @@ ALTER TABLE guacamole_user ADD COLUMN access_window_timezone VARCHAR(64);
 
 ALTER TABLE guacamole_user ADD COLUMN valid_from  DATE;
 ALTER TABLE guacamole_user ADD COLUMN valid_until DATE;
+
+--
+-- Add per-user timezone for sake of time comparisons/interpretation.
+--
+
+ALTER TABLE guacamole_user ADD COLUMN timezone VARCHAR(64);

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/upgrade/upgrade-pre-0.9.8.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/upgrade/upgrade-pre-0.9.8.sql
@@ -1,0 +1,36 @@
+--
+-- Copyright (C) 2015 Glyptodon LLC
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+-- THE SOFTWARE.
+--
+
+--
+-- Add per-user time-based access restrictions.
+--
+
+ALTER TABLE guacamole_user ADD COLUMN access_window_start    TIME;
+ALTER TABLE guacamole_user ADD COLUMN access_window_end      TIME;
+ALTER TABLE guacamole_user ADD COLUMN access_window_timezone VARCHAR(64);
+
+--
+-- Add per-user date-based account validity restrictions.
+--
+
+ALTER TABLE guacamole_user ADD COLUMN valid_from  DATE;
+ALTER TABLE guacamole_user ADD COLUMN valid_until DATE;

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/glyptodon/guacamole/auth/jdbc/user/UserMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/glyptodon/guacamole/auth/jdbc/user/UserMapper.xml
@@ -28,12 +28,16 @@
 
     <!-- Result mapper for user objects -->
     <resultMap id="UserResultMap" type="org.glyptodon.guacamole.auth.jdbc.user.UserModel" >
-        <id     column="user_id"       property="objectID"     jdbcType="INTEGER"/>
-        <result column="username"      property="identifier"   jdbcType="VARCHAR"/>
-        <result column="password_hash" property="passwordHash" jdbcType="BINARY"/>
-        <result column="password_salt" property="passwordSalt" jdbcType="BINARY"/>
-        <result column="disabled"      property="disabled"     jdbcType="BOOLEAN"/>
-        <result column="expired"       property="expired"      jdbcType="BOOLEAN"/>
+        <id     column="user_id"             property="objectID"          jdbcType="INTEGER"/>
+        <result column="username"            property="identifier"        jdbcType="VARCHAR"/>
+        <result column="password_hash"       property="passwordHash"      jdbcType="BINARY"/>
+        <result column="password_salt"       property="passwordSalt"      jdbcType="BINARY"/>
+        <result column="disabled"            property="disabled"          jdbcType="BOOLEAN"/>
+        <result column="access_window_start" property="accessWindowStart" jdbcType="TIME"/>
+        <result column="access_window_end"   property="accessWindowEnd"   jdbcType="TIME"/>
+        <result column="valid_from"          property="validFrom"         jdbcType="DATE"/>
+        <result column="valid_until"         property="validUntil"        jdbcType="DATE"/>
+        <result column="timezone"            property="timeZone"          jdbcType="VARCHAR"/>
     </resultMap>
 
     <!-- Select all usernames -->
@@ -61,7 +65,12 @@
             password_hash,
             password_salt,
             disabled,
-            expired
+            expired,
+            access_window_start,
+            access_window_end,
+            valid_from,
+            valid_until,
+            timezone
         FROM guacamole_user
         WHERE username IN
             <foreach collection="identifiers" item="identifier"
@@ -80,7 +89,12 @@
             password_hash,
             password_salt,
             disabled,
-            expired
+            expired,
+            access_window_start,
+            access_window_end,
+            valid_from,
+            valid_until,
+            timezone
         FROM guacamole_user
         JOIN guacamole_user_permission ON affected_user_id = guacamole_user.user_id
         WHERE username IN
@@ -102,7 +116,12 @@
             password_hash,
             password_salt,
             disabled,
-            expired
+            expired,
+            access_window_start,
+            access_window_end,
+            valid_from,
+            valid_until,
+            timezone
         FROM guacamole_user
         WHERE
             username = #{username,jdbcType=VARCHAR}
@@ -124,14 +143,24 @@
             password_hash,
             password_salt,
             disabled,
-            expired
+            expired,
+            access_window_start,
+            access_window_end,
+            valid_from,
+            valid_until,
+            timezone
         )
         VALUES (
             #{object.identifier,jdbcType=VARCHAR},
             #{object.passwordHash,jdbcType=BINARY},
             #{object.passwordSalt,jdbcType=BINARY},
             #{object.disabled,jdbcType=BOOLEAN},
-            #{object.expired,jdbcType=BOOLEAN}
+            #{object.expired,jdbcType=BOOLEAN},
+            #{object.accessWindowStart,jdbcType=TIME},
+            #{object.accessWindowEnd,jdbcType=TIME},
+            #{object.validFrom,jdbcType=DATE},
+            #{object.validUntil,jdbcType=DATE},
+            #{object.timeZone,jdbcType=VARCHAR}
         )
 
     </insert>
@@ -142,7 +171,12 @@
         SET password_hash = #{object.passwordHash,jdbcType=BINARY},
             password_salt = #{object.passwordSalt,jdbcType=BINARY},
             disabled = #{object.disabled,jdbcType=BOOLEAN},
-            expired = #{object.expired,jdbcType=BOOLEAN}
+            expired = #{object.expired,jdbcType=BOOLEAN},
+            access_window_start = #{object.accessWindowStart,jdbcType=TIME},
+            access_window_end = #{object.accessWindowEnd,jdbcType=TIME},
+            valid_from = #{object.validFrom,jdbcType=DATE},
+            valid_until = #{object.validUntil,jdbcType=DATE},
+            timezone = #{object.timeZone,jdbcType=VARCHAR}
         WHERE user_id = #{object.objectID,jdbcType=VARCHAR}
     </update>
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
@@ -114,11 +114,24 @@ CREATE INDEX ON guacamole_connection(parent_id);
 CREATE TABLE guacamole_user (
 
   user_id       serial       NOT NULL,
+
+  -- Username and optionally-salted password
   username      varchar(128) NOT NULL,
   password_hash bytea        NOT NULL,
   password_salt bytea,
+
+  -- Account disabled/expired status
   disabled      boolean      NOT NULL DEFAULT FALSE,
   expired       boolean      NOT NULL DEFAULT FALSE,
+
+  -- Time-based access restriction
+  access_window_start    time,
+  access_window_end      time,
+  access_window_timezone varchar(64),
+
+  -- Date-based access restriction
+  valid_from  date,
+  valid_until date,
 
   PRIMARY KEY (user_id),
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
@@ -127,11 +127,13 @@ CREATE TABLE guacamole_user (
   -- Time-based access restriction
   access_window_start    time,
   access_window_end      time,
-  access_window_timezone varchar(64),
 
   -- Date-based access restriction
   valid_from  date,
   valid_until date,
+
+  -- Timezone used for all date/time comparisons and interpretation
+  timezone varchar(64),
 
   PRIMARY KEY (user_id),
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/upgrade/upgrade-pre-0.9.8.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/upgrade/upgrade-pre-0.9.8.sql
@@ -1,0 +1,36 @@
+--
+-- Copyright (C) 2015 Glyptodon LLC
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+-- THE SOFTWARE.
+--
+
+--
+-- Add per-user time-based access restrictions.
+--
+
+ALTER TABLE guacamole_user ADD COLUMN access_window_start    time;
+ALTER TABLE guacamole_user ADD COLUMN access_window_end      time;
+ALTER TABLE guacamole_user ADD COLUMN access_window_timezone varchar(64);
+
+--
+-- Add per-user date-based account validity restrictions.
+--
+
+ALTER TABLE guacamole_user ADD COLUMN valid_from  date;
+ALTER TABLE guacamole_user ADD COLUMN valid_until date;

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/upgrade/upgrade-pre-0.9.8.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/upgrade/upgrade-pre-0.9.8.sql
@@ -26,7 +26,6 @@
 
 ALTER TABLE guacamole_user ADD COLUMN access_window_start    time;
 ALTER TABLE guacamole_user ADD COLUMN access_window_end      time;
-ALTER TABLE guacamole_user ADD COLUMN access_window_timezone varchar(64);
 
 --
 -- Add per-user date-based account validity restrictions.
@@ -34,3 +33,9 @@ ALTER TABLE guacamole_user ADD COLUMN access_window_timezone varchar(64);
 
 ALTER TABLE guacamole_user ADD COLUMN valid_from  date;
 ALTER TABLE guacamole_user ADD COLUMN valid_until date;
+
+--
+-- Add per-user timezone for sake of time comparisons/interpretation.
+--
+
+ALTER TABLE guacamole_user ADD COLUMN timezone varchar(64);

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/glyptodon/guacamole/auth/jdbc/user/UserMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/glyptodon/guacamole/auth/jdbc/user/UserMapper.xml
@@ -28,12 +28,17 @@
 
     <!-- Result mapper for user objects -->
     <resultMap id="UserResultMap" type="org.glyptodon.guacamole.auth.jdbc.user.UserModel" >
-        <id     column="user_id"       property="objectID"     jdbcType="INTEGER"/>
-        <result column="username"      property="identifier"   jdbcType="VARCHAR"/>
-        <result column="password_hash" property="passwordHash" jdbcType="BINARY"/>
-        <result column="password_salt" property="passwordSalt" jdbcType="BINARY"/>
-        <result column="disabled"      property="disabled"     jdbcType="BOOLEAN"/>
-        <result column="expired"       property="expired"      jdbcType="BOOLEAN"/>
+        <id     column="user_id"             property="objectID"          jdbcType="INTEGER"/>
+        <result column="username"            property="identifier"        jdbcType="VARCHAR"/>
+        <result column="password_hash"       property="passwordHash"      jdbcType="BINARY"/>
+        <result column="password_salt"       property="passwordSalt"      jdbcType="BINARY"/>
+        <result column="disabled"            property="disabled"          jdbcType="BOOLEAN"/>
+        <result column="expired"             property="expired"           jdbcType="BOOLEAN"/>
+        <result column="access_window_start" property="accessWindowStart" jdbcType="TIME"/>
+        <result column="access_window_end"   property="accessWindowEnd"   jdbcType="TIME"/>
+        <result column="valid_from"          property="validFrom"         jdbcType="DATE"/>
+        <result column="valid_until"         property="validUntil"        jdbcType="DATE"/>
+        <result column="timezone"            property="timeZone"          jdbcType="VARCHAR"/>
     </resultMap>
 
     <!-- Select all usernames -->
@@ -61,7 +66,12 @@
             password_hash,
             password_salt,
             disabled,
-            expired
+            expired,
+            access_window_start,
+            access_window_end,
+            valid_from,
+            valid_until,
+            timezone
         FROM guacamole_user
         WHERE username IN
             <foreach collection="identifiers" item="identifier"
@@ -80,7 +90,12 @@
             password_hash,
             password_salt,
             disabled,
-            expired
+            expired,
+            access_window_start,
+            access_window_end,
+            valid_from,
+            valid_until,
+            timezone
         FROM guacamole_user
         JOIN guacamole_user_permission ON affected_user_id = guacamole_user.user_id
         WHERE username IN
@@ -102,7 +117,12 @@
             password_hash,
             password_salt,
             disabled,
-            expired
+            expired,
+            access_window_start,
+            access_window_end,
+            valid_from,
+            valid_until,
+            timezone
         FROM guacamole_user
         WHERE
             username = #{username,jdbcType=VARCHAR}
@@ -124,14 +144,24 @@
             password_hash,
             password_salt,
             disabled,
-            expired
+            expired,
+            access_window_start,
+            access_window_end,
+            valid_from,
+            valid_until,
+            timezone
         )
         VALUES (
             #{object.identifier,jdbcType=VARCHAR},
             #{object.passwordHash,jdbcType=BINARY},
             #{object.passwordSalt,jdbcType=BINARY},
             #{object.disabled,jdbcType=BOOLEAN},
-            #{object.expired,jdbcType=BOOLEAN}
+            #{object.expired,jdbcType=BOOLEAN},
+            #{object.accessWindowStart,jdbcType=TIME},
+            #{object.accessWindowEnd,jdbcType=TIME},
+            #{object.validFrom,jdbcType=DATE},
+            #{object.validUntil,jdbcType=DATE},
+            #{object.timeZone,jdbcType=VARCHAR}
         )
 
     </insert>
@@ -142,7 +172,12 @@
         SET password_hash = #{object.passwordHash,jdbcType=BINARY},
             password_salt = #{object.passwordSalt,jdbcType=BINARY},
             disabled = #{object.disabled,jdbcType=BOOLEAN},
-            expired = #{object.expired,jdbcType=BOOLEAN}
+            expired = #{object.expired,jdbcType=BOOLEAN},
+            access_window_start = #{object.accessWindowStart,jdbcType=TIME},
+            access_window_end = #{object.accessWindowEnd,jdbcType=TIME},
+            valid_from = #{object.validFrom,jdbcType=DATE},
+            valid_until = #{object.validUntil,jdbcType=DATE},
+            timezone = #{object.timeZone,jdbcType=VARCHAR}
         WHERE user_id = #{object.objectID,jdbcType=VARCHAR}
     </update>
 


### PR DESCRIPTION
This change implements the date/time restrictions required by [GUAC-1213](https://glyptodon.org/jira/browse/GUAC-1213), while avoiding the user interface coding that has been blocking us for so long.

The logic, etc. here all works... we now just need to make things pretty. The user attributes are all stubbed out as text fields.