### PR TITLE
GUAC-1213: Add support for date/time fields.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/ModeledUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/ModeledUser.java
@@ -45,9 +45,10 @@ import org.glyptodon.guacamole.auth.jdbc.permission.ConnectionGroupPermissionSer
 import org.glyptodon.guacamole.auth.jdbc.permission.ConnectionPermissionService;
 import org.glyptodon.guacamole.auth.jdbc.permission.UserPermissionService;
 import org.glyptodon.guacamole.form.BooleanField;
+import org.glyptodon.guacamole.form.DateField;
 import org.glyptodon.guacamole.form.Field;
 import org.glyptodon.guacamole.form.Form;
-import org.glyptodon.guacamole.form.TextField;
+import org.glyptodon.guacamole.form.TimeField;
 import org.glyptodon.guacamole.form.TimeZoneField;
 import org.glyptodon.guacamole.net.auth.User;
 import org.glyptodon.guacamole.net.auth.permission.ObjectPermissionSet;
@@ -68,16 +69,6 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
      * Logger for this class.
      */
     private static final Logger logger = LoggerFactory.getLogger(ModeledUser.class);
-
-    /**
-     * The format to use for all date attributes associated with users.
-     */
-    private static final String DATE_FORMAT = "yyyy-MM-dd";
-
-    /**
-     * The format to use for all time attributes associated with users.
-     */
-    private static final String TIME_FORMAT = "HH:mm:ss";
 
     /**
      * The name of the attribute which controls whether a user account is
@@ -128,10 +119,10 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
     public static final Form ACCOUNT_RESTRICTIONS = new Form("restrictions", Arrays.<Field>asList(
         new BooleanField(DISABLED_ATTRIBUTE_NAME, "true"),
         new BooleanField(EXPIRED_ATTRIBUTE_NAME, "true"),
-        new TextField(ACCESS_WINDOW_START_ATTRIBUTE_NAME),
-        new TextField(ACCESS_WINDOW_END_ATTRIBUTE_NAME),
-        new TextField(VALID_FROM_ATTRIBUTE_NAME),
-        new TextField(VALID_UNTIL_ATTRIBUTE_NAME),
+        new TimeField(ACCESS_WINDOW_START_ATTRIBUTE_NAME),
+        new TimeField(ACCESS_WINDOW_END_ATTRIBUTE_NAME),
+        new DateField(VALID_FROM_ATTRIBUTE_NAME),
+        new DateField(VALID_UNTIL_ATTRIBUTE_NAME),
         new TimeZoneField(TIMEZONE_ATTRIBUTE_NAME)
     ));
 
@@ -288,7 +279,7 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
      *     The formatted date, or null if the provided time was null.
      */
     private String formatDate(Date date) {
-        DateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT);
+        DateFormat dateFormat = new SimpleDateFormat(DateField.FORMAT);
         return date == null ? null : dateFormat.format(date);
     }
 
@@ -303,7 +294,7 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
      *     The formatted time, or null if the provided time was null.
      */
     private String formatTime(Time time) {
-        DateFormat timeFormat = new SimpleDateFormat(TIME_FORMAT);
+        DateFormat timeFormat = new SimpleDateFormat(TimeField.FORMAT);
         return time == null ? null : timeFormat.format(time);
     }
 
@@ -331,7 +322,7 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
             return null;
 
         // Parse date according to format
-        DateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT);
+        DateFormat dateFormat = new SimpleDateFormat(DateField.FORMAT);
         return new Date(dateFormat.parse(dateString).getTime());
 
     }
@@ -360,7 +351,7 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
             return null;
 
         // Parse time according to format
-        DateFormat timeFormat = new SimpleDateFormat(TIME_FORMAT);
+        DateFormat timeFormat = new SimpleDateFormat(TimeField.FORMAT);
         return new Time(timeFormat.parse(timeString).getTime());
 
     }

--- a/guacamole-ext/src/main/java/org/glyptodon/guacamole/form/DateField.java
+++ b/guacamole-ext/src/main/java/org/glyptodon/guacamole/form/DateField.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2015 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.glyptodon.guacamole.form;
+
+/**
+ * Represents a date field. The field may contain only date values which
+ * conform to a standard pattern, defined by DateField.FORMAT.
+ *
+ * @author Michael Jumper
+ */
+public class DateField extends Field {
+
+    /**
+     * The date format used by date fields, compatible with SimpleDateFormat.
+     */
+    public static final String FORMAT = "yyyy-MM-dd";
+
+    /**
+     * Creates a new DateField with the given name.
+     *
+     * @param name
+     *     The unique name to associate with this field.
+     */
+    public DateField(String name) {
+        super(name, Field.Type.DATE);
+    }
+
+}

--- a/guacamole-ext/src/main/java/org/glyptodon/guacamole/form/Field.java
+++ b/guacamole-ext/src/main/java/org/glyptodon/guacamole/form/Field.java
@@ -90,6 +90,18 @@ public class Field {
          */
         public static String TIMEZONE = "TIMEZONE";
 
+        /**
+         * A date field whose legal values conform to the pattern "YYYY-MM-DD",
+         * zero-padded.
+         */
+        public static String DATE = "DATE";
+
+        /**
+         * A time field whose legal values conform to the pattern "HH:MM:SS",
+         * zero-padded, 24-hour.
+         */
+        public static String TIME = "TIME";
+
     }
 
     /**

--- a/guacamole-ext/src/main/java/org/glyptodon/guacamole/form/TimeField.java
+++ b/guacamole-ext/src/main/java/org/glyptodon/guacamole/form/TimeField.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2015 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.glyptodon.guacamole.form;
+
+/**
+ * Represents a time field. The field may contain only time values which
+ * conform to a standard pattern, defined by TimeField.FORMAT.
+ *
+ * @author Michael Jumper
+ */
+public class TimeField extends Field {
+
+    /**
+     * The time format used by time fields, compatible with SimpleDateFormat.
+     */
+    public static final String FORMAT = "HH:mm:ss";
+
+    /**
+     * Creates a new TimeField with the given name.
+     *
+     * @param name
+     *     The unique name to associate with this field.
+     */
+    public TimeField(String name) {
+        super(name, Field.Type.TIME);
+    }
+
+}

--- a/guacamole/src/main/webapp/app/form/controllers/dateFieldController.js
+++ b/guacamole/src/main/webapp/app/form/controllers/dateFieldController.js
@@ -48,9 +48,26 @@ angular.module('form').controller('dateFieldController', ['$scope', '$injector',
 
     };
 
+    /**
+     * Parses the date components of the given string into a Date with only the
+     * date components set. The resulting Date will be in the UTC timezone,
+     * with the time left as midnight. The input string must be in the format
+     * YYYY-MM-DD (zero-padded).
+     *
+     * @param {String} str
+     *     The date string to parse.
+     *
+     * @returns {Date}
+     *     A Date object, in the UTC timezone, with only the date components
+     *     set.
+     */
+    var parseDate = function parseDate(str) {
+        return new Date(str + 'T00:00Z');
+    };
+
     // Update typed value when model is changed
     $scope.$watch('model', function modelChanged(model) {
-        $scope.typedValue = (model ? new Date(model + 'T00:00Z') : null);
+        $scope.typedValue = (model ? parseDate(model) : null);
     });
 
     // Update string value in model when typed value is changed

--- a/guacamole/src/main/webapp/app/form/controllers/dateFieldController.js
+++ b/guacamole/src/main/webapp/app/form/controllers/dateFieldController.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2015 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+/**
+ * Controller for date fields.
+ */
+angular.module('form').controller('dateFieldController', ['$scope',
+    function dateFieldController($scope) {
+
+    /* STUB */
+
+}]);

--- a/guacamole/src/main/webapp/app/form/controllers/dateFieldController.js
+++ b/guacamole/src/main/webapp/app/form/controllers/dateFieldController.js
@@ -24,9 +24,38 @@
 /**
  * Controller for date fields.
  */
-angular.module('form').controller('dateFieldController', ['$scope',
-    function dateFieldController($scope) {
+angular.module('form').controller('dateFieldController', ['$scope', '$injector',
+    function dateFieldController($scope, $injector) {
 
-    /* STUB */
+    // Required services
+    var $filter = $injector.get('$filter');
+
+    /**
+     * Options which dictate the behavior of the input field model, as defined
+     * by https://docs.angularjs.org/api/ng/directive/ngModelOptions
+     *
+     * @type Object.<String, String>
+     */
+    $scope.modelOptions = {
+
+        /**
+         * The time zone to use when reading/writing the Date object of the
+         * model.
+         *
+         * @type String
+         */
+        timezone : 'UTC'
+
+    };
+
+    // Update typed value when model is changed
+    $scope.$watch('model', function modelChanged(model) {
+        $scope.typedValue = (model ? new Date(model + 'T00:00Z') : null);
+    });
+
+    // Update string value in model when typed value is changed
+    $scope.$watch('typedValue', function typedValueChanged(typedValue) {
+        $scope.model = (typedValue ? $filter('date')(typedValue, 'yyyy-MM-dd', 'UTC') : '');
+    });
 
 }]);

--- a/guacamole/src/main/webapp/app/form/controllers/timeFieldController.js
+++ b/guacamole/src/main/webapp/app/form/controllers/timeFieldController.js
@@ -24,9 +24,38 @@
 /**
  * Controller for time fields.
  */
-angular.module('form').controller('timeFieldController', ['$scope',
-    function timeFieldController($scope) {
+angular.module('form').controller('timeFieldController', ['$scope', '$injector',
+    function timeFieldController($scope, $injector) {
 
-    /* STUB */
+    // Required services
+    var $filter = $injector.get('$filter');
+
+    /**
+     * Options which dictate the behavior of the input field model, as defined
+     * by https://docs.angularjs.org/api/ng/directive/ngModelOptions
+     *
+     * @type Object.<String, String>
+     */
+    $scope.modelOptions = {
+
+        /**
+         * The time zone to use when reading/writing the Date object of the
+         * model.
+         *
+         * @type String
+         */
+        timezone : 'UTC'
+
+    };
+
+    // Update typed value when model is changed
+    $scope.$watch('model', function modelChanged(model) {
+        $scope.typedValue = (model ? new Date('1970-01-01T' + model + 'Z') : null);
+    });
+
+    // Update string value in model when typed value is changed
+    $scope.$watch('typedValue', function typedValueChanged(typedValue) {
+        $scope.model = (typedValue ? $filter('date')(typedValue, 'HH:mm:ss', 'UTC') : '');
+    });
 
 }]);

--- a/guacamole/src/main/webapp/app/form/controllers/timeFieldController.js
+++ b/guacamole/src/main/webapp/app/form/controllers/timeFieldController.js
@@ -48,9 +48,26 @@ angular.module('form').controller('timeFieldController', ['$scope', '$injector',
 
     };
 
+    /**
+     * Parses the time components of the given string into a Date with only the
+     * time components set. The resulting Date will be in the UTC timezone,
+     * with the date left as 1970-01-01. The input string must be in the format
+     * HH:MM:SS (zero-padded, 24-hour).
+     *
+     * @param {String} str
+     *     The time string to parse.
+     *
+     * @returns {Date}
+     *     A Date object, in the UTC timezone, with only the time components
+     *     set.
+     */
+    var parseTime = function parseTime(str) {
+        return new Date('1970-01-01T' + str + 'Z');
+    };
+
     // Update typed value when model is changed
     $scope.$watch('model', function modelChanged(model) {
-        $scope.typedValue = (model ? new Date('1970-01-01T' + model + 'Z') : null);
+        $scope.typedValue = (model ? parseTime(model) : null);
     });
 
     // Update string value in model when typed value is changed

--- a/guacamole/src/main/webapp/app/form/controllers/timeFieldController.js
+++ b/guacamole/src/main/webapp/app/form/controllers/timeFieldController.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2015 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+/**
+ * Controller for time fields.
+ */
+angular.module('form').controller('timeFieldController', ['$scope',
+    function timeFieldController($scope) {
+
+    /* STUB */
+
+}]);

--- a/guacamole/src/main/webapp/app/form/services/formService.js
+++ b/guacamole/src/main/webapp/app/form/services/formService.js
@@ -131,6 +131,30 @@ angular.module('form').provider('formService', function formServiceProvider() {
             module      : 'form',
             controller  : 'timeZoneFieldController',
             templateUrl : 'app/form/templates/timeZoneField.html'
+        },
+
+        /**
+         * Field type which allows selection of individual dates.
+         *
+         * @see {@link Field.Type.DATE}
+         * @type FieldType
+         */
+        'DATE' : {
+            module      : 'form',
+            controller  : 'dateFieldController',
+            templateUrl : 'app/form/templates/dateField.html'
+        },
+
+        /**
+         * Field type which allows selection of times of day.
+         *
+         * @see {@link Field.Type.TIME}
+         * @type FieldType
+         */
+        'TIME' : {
+            module      : 'form',
+            controller  : 'timeFieldController',
+            templateUrl : 'app/form/templates/timeField.html'
         }
 
     };

--- a/guacamole/src/main/webapp/app/form/templates/dateField.html
+++ b/guacamole/src/main/webapp/app/form/templates/dateField.html
@@ -1,0 +1,3 @@
+<div class="date-field">
+    <input type="text" ng-model="model" autocorrect="off" autocapitalize="off"/>
+</div>

--- a/guacamole/src/main/webapp/app/form/templates/dateField.html
+++ b/guacamole/src/main/webapp/app/form/templates/dateField.html
@@ -1,3 +1,7 @@
 <div class="date-field">
-    <input type="text" ng-model="model" autocorrect="off" autocapitalize="off"/>
+    <input type="date"
+           ng-model="typedValue"
+           ng-model-options="modelOptions"
+           autocorrect="off"
+           autocapitalize="off"/>
 </div>

--- a/guacamole/src/main/webapp/app/form/templates/dateField.html
+++ b/guacamole/src/main/webapp/app/form/templates/dateField.html
@@ -2,6 +2,7 @@
     <input type="date"
            ng-model="typedValue"
            ng-model-options="modelOptions"
+           placeholder="{{'FORM.FIELD_PLACEHOLDER_DATE' | translate}}"
            autocorrect="off"
            autocapitalize="off"/>
 </div>

--- a/guacamole/src/main/webapp/app/form/templates/timeField.html
+++ b/guacamole/src/main/webapp/app/form/templates/timeField.html
@@ -2,6 +2,7 @@
     <input type="time"
            ng-model="typedValue"
            ng-model-options="modelOptions"
+           placeholder="{{'FORM.FIELD_PLACEHOLDER_TIME' | translate}}"
            autocorrect="off"
            autocapitalize="off"/>
 </div>

--- a/guacamole/src/main/webapp/app/form/templates/timeField.html
+++ b/guacamole/src/main/webapp/app/form/templates/timeField.html
@@ -1,3 +1,7 @@
 <div class="time-field">
-    <input type="text" ng-model="model" autocorrect="off" autocapitalize="off"/>
+    <input type="time"
+           ng-model="typedValue"
+           ng-model-options="modelOptions"
+           autocorrect="off"
+           autocapitalize="off"/>
 </div>

--- a/guacamole/src/main/webapp/app/form/templates/timeField.html
+++ b/guacamole/src/main/webapp/app/form/templates/timeField.html
@@ -1,0 +1,3 @@
+<div class="time-field">
+    <input type="text" ng-model="model" autocorrect="off" autocapitalize="off"/>
+</div>

--- a/guacamole/src/main/webapp/app/rest/types/Field.js
+++ b/guacamole/src/main/webapp/app/rest/types/Field.js
@@ -138,7 +138,24 @@ angular.module('rest').factory('Field', [function defineField() {
          *
          * @type String
          */
-        TIMEZONE : "TIMEZONE"
+        TIMEZONE : "TIMEZONE",
+
+        /**
+         * The type string associated with parameters that may contain dates.
+         * The format of the date is standardized as YYYY-MM-DD, zero-padded.
+         *
+         * @type String
+         */
+        DATE : "DATE",
+
+        /**
+         * The type string associated with parameters that may contain times.
+         * The format of the time is stnadardized as HH:MM:DD, zero-padded,
+         * 24-hour.
+         *
+         * @type String
+         */
+        TIME : "TIME"
 
     };
 

--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -127,6 +127,9 @@
 
     "FORM" : {
 
+        "FIELD_PLACEHOLDER_DATE" : "YYYY-MM-DD",
+        "FIELD_PLACEHOLDER_TIME" : "HH:MM:SS",
+
         "HELP_SHOW_PASSWORD" : "Click to show password",
         "HELP_HIDE_PASSWORD" : "Click to hide password"
 


### PR DESCRIPTION
This change adds `DATE` and `TIME` field types which leverage HTML5's date and time input types. For browsers that do not provide support for those input types, placeholders are provided as a formatting guide.