### PR TITLE
GUAC-1294: Use mimetype text/plain for REST endpoints which return plain strings.

### DIFF
--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/connection/ConnectionRESTService.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/connection/ConnectionRESTService.java
@@ -241,6 +241,7 @@ public class ConnectionRESTService {
      *     If an error occurs while creating the connection.
      */
     @POST
+    @Produces(MediaType.TEXT_PLAIN)
     @AuthProviderRESTExposure
     public String createConnection(@QueryParam("token") String authToken,
             APIConnection connection) throws GuacamoleException {

--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/connectiongroup/ConnectionGroupRESTService.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/connectiongroup/ConnectionGroupRESTService.java
@@ -193,6 +193,7 @@ public class ConnectionGroupRESTService {
      *     If an error occurs while creating the connection group.
      */
     @POST
+    @Produces(MediaType.TEXT_PLAIN)
     @AuthProviderRESTExposure
     public String createConnectionGroup(@QueryParam("token") String authToken,
             APIConnectionGroup connectionGroup) throws GuacamoleException {

--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/user/UserRESTService.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/user/UserRESTService.java
@@ -225,6 +225,7 @@ public class UserRESTService {
      * @return The username of the newly created user.
      */
     @POST
+    @Produces(MediaType.TEXT_PLAIN)
     @AuthProviderRESTExposure
     public String createUser(@QueryParam("token") String authToken, APIUser user) 
             throws GuacamoleException {


### PR DESCRIPTION
The default mimetype, declared at the REST service level, would be `application/json`. This causes a parse error in Chrome and Firefox when the response is not actually valid JSON.

See: https://glyptodon.org/jira/browse/GUAC-1294