### PR TITLE
GUAC-1293: Improve file browser usability

### DIFF
--- a/guacamole/src/main/webapp/app/client/controllers/clientController.js
+++ b/guacamole/src/main/webapp/app/client/controllers/clientController.js
@@ -586,6 +586,16 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
         return !!$scope.filesystemMenuContents && $scope.menu.shown;
     };
 
+    // Automatically refresh display when filesystem menu is shown
+    $scope.$watch('isFilesystemMenuShown()', function refreshFilesystem() {
+
+        // Refresh filesystem, if defined
+        var filesystem = $scope.filesystemMenuContents;
+        if (filesystem)
+            ManagedFilesystem.refresh(filesystem, filesystem.currentDirectory);
+
+    });
+
     /**
      * Returns the full path to the given file as an ordered array of parent
      * directories.

--- a/guacamole/src/main/webapp/app/client/directives/guacFileBrowser.js
+++ b/guacamole/src/main/webapp/app/client/directives/guacFileBrowser.js
@@ -145,7 +145,7 @@ angular.module('client').directive('guacFileBrowser', [function guacFileBrowser(
                 // Change current directory when directories are clicked
                 if ($scope.isDirectory(file)) {
                     element.addClass('directory');
-                    element.on('click', function changeDirectory() {
+                    element.on('dblclick', function changeDirectory() {
                         $scope.changeDirectory(file);
                     });
                 }
@@ -153,10 +153,16 @@ angular.module('client').directive('guacFileBrowser', [function guacFileBrowser(
                 // Initiate downloads when normal files are clicked
                 else if ($scope.isNormalFile(file)) {
                     element.addClass('normal-file');
-                    element.on('click', function downloadFile() {
+                    element.on('dblclick', function downloadFile() {
                         $scope.downloadFile(file);
                     });
                 }
+
+                // Mark file as focused upon click
+                element.on('click', function focusFile() {
+                    element.parent().children().removeClass('focused');
+                    element.addClass('focused');
+                });
 
                 return element;
 

--- a/guacamole/src/main/webapp/app/client/directives/guacFileBrowser.js
+++ b/guacamole/src/main/webapp/app/client/directives/guacFileBrowser.js
@@ -162,7 +162,7 @@ angular.module('client').directive('guacFileBrowser', [function guacFileBrowser(
                 }
 
                 // Mark file as focused upon click
-                element.on('click', function focusFile(e) {
+                element.on('click', function handleFileClick() {
 
                     // Fire file-specific action if already focused
                     if (element.hasClass('focused')) {
@@ -175,10 +175,6 @@ angular.module('client').directive('guacFileBrowser', [function guacFileBrowser(
                         element.parent().children().removeClass('focused');
                         element.addClass('focused');
                     }
-
-                    // Do not allow default action
-                    e.preventDefault();
-                    e.stopPropagation();
 
                 });
 

--- a/guacamole/src/main/webapp/app/client/directives/guacFileBrowser.js
+++ b/guacamole/src/main/webapp/app/client/directives/guacFileBrowser.js
@@ -123,13 +123,6 @@ angular.module('client').directive('guacFileBrowser', [function guacFileBrowser(
             };
 
             /**
-             * Refreshes the contents of the current directory.
-             */
-            $scope.refresh = function refresh() {
-                ManagedFilesystem.refresh($scope.filesystem, $scope.filesystem.currentDirectory);
-            };
-
-            /**
              * Creates a new element representing the given file and properly
              * handling user events, bypassing the overhead incurred through
              * use of ngRepeat and related techniques.
@@ -257,7 +250,7 @@ angular.module('client').directive('guacFileBrowser', [function guacFileBrowser(
 
             // Refresh file browser when any upload completes
             $scope.$on('guacUploadComplete', function uploadComplete(event, filename) {
-                $scope.refresh();
+                ManagedFilesystem.refresh($scope.filesystem, $scope.filesystem.currentDirectory);
             });
 
         }]

--- a/guacamole/src/main/webapp/app/client/directives/guacFileBrowser.js
+++ b/guacamole/src/main/webapp/app/client/directives/guacFileBrowser.js
@@ -123,6 +123,13 @@ angular.module('client').directive('guacFileBrowser', [function guacFileBrowser(
             };
 
             /**
+             * Refreshes the contents of the current directory.
+             */
+            $scope.refresh = function refresh() {
+                ManagedFilesystem.refresh($scope.filesystem, $scope.filesystem.currentDirectory);
+            };
+
+            /**
              * Creates a new element representing the given file and properly
              * handling user events, bypassing the overhead incurred through
              * use of ngRepeat and related techniques.
@@ -247,6 +254,11 @@ angular.module('client').directive('guacFileBrowser', [function guacFileBrowser(
                 });
 
             }); // end retrieve file template
+
+            // Refresh file browser when any upload completes
+            $scope.$on('guacUploadComplete', function uploadComplete(event, filename) {
+                $scope.refresh();
+            });
 
         }]
 

--- a/guacamole/src/main/webapp/app/client/directives/guacFileBrowser.js
+++ b/guacamole/src/main/webapp/app/client/directives/guacFileBrowser.js
@@ -165,8 +165,10 @@ angular.module('client').directive('guacFileBrowser', [function guacFileBrowser(
                 element.on('click', function focusFile(e) {
 
                     // Fire file-specific action if already focused
-                    if (element.hasClass('focused'))
+                    if (element.hasClass('focused')) {
                         fileAction();
+                        element.removeClass('focused');
+                    }
 
                     // Otherwise mark as focused
                     else {

--- a/guacamole/src/main/webapp/app/client/directives/guacFileBrowser.js
+++ b/guacamole/src/main/webapp/app/client/directives/guacFileBrowser.js
@@ -142,26 +142,42 @@ angular.module('client').directive('guacFileBrowser', [function guacFileBrowser(
                 // Create from internal template
                 var element = angular.element($interpolate(fileTemplate)(file));
 
+                // Double-clicking on unknown file types will do nothing
+                var fileAction = function doNothing() {};
+
                 // Change current directory when directories are clicked
                 if ($scope.isDirectory(file)) {
                     element.addClass('directory');
-                    element.on('dblclick', function changeDirectory() {
+                    fileAction = function changeDirectory() {
                         $scope.changeDirectory(file);
-                    });
+                    };
                 }
 
                 // Initiate downloads when normal files are clicked
                 else if ($scope.isNormalFile(file)) {
                     element.addClass('normal-file');
-                    element.on('dblclick', function downloadFile() {
+                    fileAction = function downloadFile() {
                         $scope.downloadFile(file);
-                    });
+                    };
                 }
 
                 // Mark file as focused upon click
-                element.on('click', function focusFile() {
-                    element.parent().children().removeClass('focused');
-                    element.addClass('focused');
+                element.on('click', function focusFile(e) {
+
+                    // Fire file-specific action if already focused
+                    if (element.hasClass('focused'))
+                        fileAction();
+
+                    // Otherwise mark as focused
+                    else {
+                        element.parent().children().removeClass('focused');
+                        element.addClass('focused');
+                    }
+
+                    // Do not allow default action
+                    e.preventDefault();
+                    e.stopPropagation();
+
                 });
 
                 // Prevent text selection during navigation

--- a/guacamole/src/main/webapp/app/client/directives/guacFileBrowser.js
+++ b/guacamole/src/main/webapp/app/client/directives/guacFileBrowser.js
@@ -164,6 +164,12 @@ angular.module('client').directive('guacFileBrowser', [function guacFileBrowser(
                     element.addClass('focused');
                 });
 
+                // Prevent text selection during navigation
+                element.on('selectstart', function avoidSelect(e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                });
+
                 return element;
 
             };

--- a/guacamole/src/main/webapp/app/client/styles/file-browser.css
+++ b/guacamole/src/main/webapp/app/client/styles/file-browser.css
@@ -29,6 +29,12 @@
 
 .file-browser .list-item .caption {
     white-space: nowrap;
+    border: 1px solid transparent;
+}
+
+.file-browser .list-item.focused .caption {
+    border: 1px dotted rgba(0, 0, 0, 0.5);
+    background: rgba(204, 221, 170, 0.5);
 }
 
 /* Directory / file icons */

--- a/guacamole/src/main/webapp/app/client/styles/file-transfer-dialog.css
+++ b/guacamole/src/main/webapp/app/client/styles/file-transfer-dialog.css
@@ -25,6 +25,7 @@
     position: absolute;
     right: 0;
     bottom: 0;
+    z-index: 20;
 
     font-size: 0.8em;
     padding: 0.5em;
@@ -35,6 +36,6 @@
 }
 
 #file-transfer-dialog .transfer-manager {
-    border: 1px solid rgba(0, 0, 0, 0.125);
-    box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.125);
+    border: 1px solid rgba(0, 0, 0, 0.5);
+    box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.25);
 }

--- a/guacamole/src/main/webapp/app/client/templates/guacFileBrowser.html
+++ b/guacamole/src/main/webapp/app/client/templates/guacFileBrowser.html
@@ -23,7 +23,7 @@
 
     <!-- Parent directory -->
     <div class="list-item directory previous" ng-show="filesystem.currentDirectory.parent">
-        <div class="caption" ng-click="changeDirectory(filesystem.currentDirectory.parent)">
+        <div class="caption" ng-dblclick="changeDirectory(filesystem.currentDirectory.parent)">
             <div class="icon"></div>..
         </div>
     </div>

--- a/guacamole/src/main/webapp/app/client/templates/guacFileBrowser.html
+++ b/guacamole/src/main/webapp/app/client/templates/guacFileBrowser.html
@@ -21,13 +21,6 @@
        THE SOFTWARE.
     -->
 
-    <!-- Parent directory -->
-    <div class="list-item directory previous" ng-show="filesystem.currentDirectory.parent">
-        <div class="caption" ng-dblclick="changeDirectory(filesystem.currentDirectory.parent)">
-            <div class="icon"></div>..
-        </div>
-    </div>
-
     <!-- Current directory contents -->
     <div class="current-directory-contents"></div>
 

--- a/guacamole/src/main/webapp/app/client/types/ManagedFileDownload.js
+++ b/guacamole/src/main/webapp/app/client/types/ManagedFileDownload.js
@@ -138,6 +138,9 @@ angular.module('client').factory('ManagedFileDownload', ['$rootScope', '$injecto
                 ManagedFileTransferState.setStreamState(managedFileDownload.transferState,
                     ManagedFileTransferState.StreamState.CLOSED);
 
+                // Notify of upload completion
+                $rootScope.$broadcast('guacDownloadComplete', filename);
+
             });
         };
 

--- a/guacamole/src/main/webapp/app/client/types/ManagedFileUpload.js
+++ b/guacamole/src/main/webapp/app/client/types/ManagedFileUpload.js
@@ -211,6 +211,9 @@ angular.module('client').factory('ManagedFileUpload', ['$rootScope', '$injector'
                         ManagedFileTransferState.setStreamState(managedFileUpload.transferState,
                             ManagedFileTransferState.StreamState.CLOSED);
 
+                        // Notify of upload completion
+                        $rootScope.$broadcast('guacUploadComplete', file.name);
+
                     }
 
                     // Otherwise, update progress


### PR DESCRIPTION
The Guacamole file browser currently suffers from the following usability issues:

1. Files download and the current directory changes when files are clicked. Double click is more intuitive.
2. The file transfer dialog can be hidden behind the file browser on smaller screens.
3. The contents of the file browser does not properly refresh after an upload completes.

These changes address the above (and avoid issues with double-click handling on mobile devices) through the following:

1. Clicking a file focuses that file, but performs no other action.
2. Clicking a *focused* file performs the action associated with that file, such as initiating a download or changing the current directory, and then de-focuses the file.
3. The file browser is automatically refreshed when any upload completes, or after the file browser becomes visible again after being hidden (ie: via `Ctrl`+`Alt`+`Shift`)

I also removed the parent directory entry from the file browser, as handling focus and double-click there became rather tricky, and the breadcrumbs fill that need nicely.