### PR TITLE
GUAC-830: Implement concurrency policy attributes

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/connection/ConnectionModel.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/connection/ConnectionModel.java
@@ -41,7 +41,21 @@ public class ConnectionModel extends GroupedObjectModel {
      * The name of the protocol to use when connecting to this connection.
      */
     private String protocol;
-    
+
+    /**
+     * The maximum number of connections that can be established to this
+     * connection concurrently, zero if no restriction applies, or null if the
+     * default restrictions should be applied.
+     */
+    private Integer maxConnections;
+
+    /**
+     * The maximum number of connections that can be established to this
+     * connection concurrently by any one user, zero if no restriction applies,
+     * or null if the default restrictions should be applied.
+     */
+    private Integer maxConnectionsPerUser;
+
     /**
      * Creates a new, empty connection.
      */
@@ -87,6 +101,58 @@ public class ConnectionModel extends GroupedObjectModel {
      */
     public void setProtocol(String protocol) {
         this.protocol = protocol;
+    }
+
+    /**
+     * Returns the maximum number of connections that can be established to
+     * this connection concurrently.
+     *
+     * @return
+     *     The maximum number of connections that can be established to this
+     *     connection concurrently, zero if no restriction applies, or null if
+     *     the default restrictions should be applied.
+     */
+    public Integer getMaxConnections() {
+        return maxConnections;
+    }
+
+    /**
+     * Sets the maximum number of connections that can be established to this
+     * connection concurrently.
+     *
+     * @param maxConnections
+     *     The maximum number of connections that can be established to this
+     *     connection concurrently, zero if no restriction applies, or null if
+     *     the default restrictions should be applied.
+     */
+    public void setMaxConnections(Integer maxConnections) {
+        this.maxConnections = maxConnections;
+    }
+
+    /**
+     * Returns the maximum number of connections that can be established to
+     * this connection concurrently by any one user.
+     *
+     * @return
+     *     The maximum number of connections that can be established to this
+     *     connection concurrently by any one user, zero if no restriction
+     *     applies, or null if the default restrictions should be applied.
+     */
+    public Integer getMaxConnectionsPerUser() {
+        return maxConnectionsPerUser;
+    }
+
+    /**
+     * Sets the maximum number of connections that can be established to this
+     * connection concurrently by any one user.
+     *
+     * @param maxConnectionsPerUser
+     *     The maximum number of connections that can be established to this
+     *     connection concurrently by any one user, zero if no restriction
+     *     applies, or null if the default restrictions should be applied.
+     */
+    public void setMaxConnectionsPerUser(Integer maxConnectionsPerUser) {
+        this.maxConnectionsPerUser = maxConnectionsPerUser;
     }
 
     @Override

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/connectiongroup/ConnectionGroupModel.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/connectiongroup/ConnectionGroupModel.java
@@ -42,7 +42,21 @@ public class ConnectionGroupModel extends GroupedObjectModel {
      * The type of this connection group, such as organizational or balancing.
      */
     private ConnectionGroup.Type type;
-    
+
+    /**
+     * The maximum number of connections that can be established to this
+     * connection group concurrently, zero if no restriction applies, or
+     * null if the default restrictions should be applied.
+     */
+    private Integer maxConnections;
+
+    /**
+     * The maximum number of connections that can be established to this
+     * connection group concurrently by any one user, zero if no restriction
+     * applies, or null if the default restrictions should be applied.
+     */
+    private Integer maxConnectionsPerUser;
+
     /**
      * Creates a new, empty connection group.
      */
@@ -89,6 +103,60 @@ public class ConnectionGroupModel extends GroupedObjectModel {
      */
     public void setType(ConnectionGroup.Type type) {
         this.type = type;
+    }
+
+    /**
+     * Returns the maximum number of connections that can be established to
+     * this connection group concurrently.
+     *
+     * @return
+     *     The maximum number of connections that can be established to this
+     *     connection group concurrently, zero if no restriction applies, or
+     *     null if the default restrictions should be applied.
+     */
+    public Integer getMaxConnections() {
+        return maxConnections;
+    }
+
+    /**
+     * Sets the maximum number of connections that can be established to this
+     * connection group concurrently.
+     *
+     * @param maxConnections
+     *     The maximum number of connections that can be established to this
+     *     connection group concurrently, zero if no restriction applies, or
+     *     null if the default restrictions should be applied.
+     */
+    public void setMaxConnections(Integer maxConnections) {
+        this.maxConnections = maxConnections;
+    }
+
+    /**
+     * Returns the maximum number of connections that can be established to
+     * this connection group concurrently by any one user.
+     *
+     * @return
+     *     The maximum number of connections that can be established to this
+     *     connection group concurrently by any one user, zero if no
+     *     restriction applies, or null if the default restrictions should be
+     *     applied.
+     */
+    public Integer getMaxConnectionsPerUser() {
+        return maxConnectionsPerUser;
+    }
+
+    /**
+     * Sets the maximum number of connections that can be established to this
+     * connection group concurrently by any one user.
+     *
+     * @param maxConnectionsPerUser
+     *     The maximum number of connections that can be established to this
+     *     connection group concurrently by any one user, zero if no
+     *     restriction applies, or null if the default restrictions should be
+     *     applied.
+     */
+    public void setMaxConnectionsPerUser(Integer maxConnectionsPerUser) {
+        this.maxConnectionsPerUser = maxConnectionsPerUser;
     }
 
     @Override

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/tunnel/ConfigurableGuacamoleTunnelService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/tunnel/ConfigurableGuacamoleTunnelService.java
@@ -231,7 +231,7 @@ public class ConfigurableGuacamoleTunnelService
 
         // Too many connections by this user
         if (userSpecificFailure)
-            throw new GuacamoleClientTooManyException("Cannot connect. Connection group already in use by this user.");
+            throw new GuacamoleClientTooManyException("Cannot connect. Connection already in use by this user.");
 
         // Too many connections, but not necessarily due purely to this user
         else

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/tunnel/ConfigurableGuacamoleTunnelService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/tunnel/ConfigurableGuacamoleTunnelService.java
@@ -160,7 +160,7 @@ public class ConfigurableGuacamoleTunnelService
             int count = multiset.count(value);
 
             // Bail out if the maximum has already been reached
-            if (count >= max || max == 0)
+            if (count >= max && max != 0)
                 return false;
 
             // Attempt to add one more value

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/tunnel/ConfigurableGuacamoleTunnelService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/tunnel/ConfigurableGuacamoleTunnelService.java
@@ -200,14 +200,23 @@ public class ConfigurableGuacamoleTunnelService
         // Return the first unreserved connection
         for (ModeledConnection connection : sortedConnections) {
 
+            // Determine per-user limits on this connection
+            Integer connectionMaxConnectionsPerUser = connection.getModel().getMaxConnectionsPerUser();
+            if (connectionMaxConnectionsPerUser == null)
+                connectionMaxConnectionsPerUser = connectionDefaultMaxConnectionsPerUser;
+
+            // Determine overall limits on this connection
+            Integer connectionMaxConnections = connection.getModel().getMaxConnections();
+            if (connectionMaxConnections == null)
+                connectionMaxConnections = connectionDefaultMaxConnections;
+
             // Attempt to aquire connection according to per-user limits
             Seat seat = new Seat(username, connection.getIdentifier());
-            if (tryAdd(activeSeats, seat,
-                    connectionDefaultMaxConnectionsPerUser)) {
+            if (tryAdd(activeSeats, seat, connectionMaxConnectionsPerUser)) {
 
                 // Attempt to aquire connection according to overall limits
                 if (tryAdd(activeConnections, connection.getIdentifier(),
-                        connectionDefaultMaxConnections))
+                        connectionMaxConnections))
                     return connection;
 
                 // Acquire failed - retry with next connection
@@ -243,14 +252,24 @@ public class ConfigurableGuacamoleTunnelService
         // Get username
         String username = user.getUser().getIdentifier();
 
+        // Determine per-user limits on this connection group
+        Integer connectionGroupMaxConnectionsPerUser = connectionGroup.getModel().getMaxConnectionsPerUser();
+        if (connectionGroupMaxConnectionsPerUser == null)
+            connectionGroupMaxConnectionsPerUser = connectionGroupDefaultMaxConnectionsPerUser;
+
+        // Determine overall limits on this connection group
+        Integer connectionGroupMaxConnections = connectionGroup.getModel().getMaxConnections();
+        if (connectionGroupMaxConnections == null)
+            connectionGroupMaxConnections = connectionGroupDefaultMaxConnections;
+
         // Attempt to aquire connection group according to per-user limits
         Seat seat = new Seat(username, connectionGroup.getIdentifier());
         if (tryAdd(activeGroupSeats, seat,
-                connectionGroupDefaultMaxConnectionsPerUser)) {
+                connectionGroupMaxConnectionsPerUser)) {
 
             // Attempt to aquire connection group according to overall limits
             if (tryAdd(activeGroups, connectionGroup.getIdentifier(),
-                    connectionGroupDefaultMaxConnections))
+                    connectionGroupMaxConnections))
                 return;
 
             // Acquire failed

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/UserContext.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/glyptodon/guacamole/auth/jdbc/user/UserContext.java
@@ -29,10 +29,11 @@ import org.glyptodon.guacamole.auth.jdbc.connection.ConnectionDirectory;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import java.util.Collection;
-import java.util.Collections;
 import org.glyptodon.guacamole.GuacamoleException;
 import org.glyptodon.guacamole.auth.jdbc.base.RestrictedObject;
 import org.glyptodon.guacamole.auth.jdbc.activeconnection.ActiveConnectionDirectory;
+import org.glyptodon.guacamole.auth.jdbc.connection.ModeledConnection;
+import org.glyptodon.guacamole.auth.jdbc.connectiongroup.ModeledConnectionGroup;
 import org.glyptodon.guacamole.form.Form;
 import org.glyptodon.guacamole.net.auth.ActiveConnection;
 import org.glyptodon.guacamole.net.auth.Connection;
@@ -140,12 +141,12 @@ public class UserContext extends RestrictedObject
 
     @Override
     public Collection<Form> getConnectionAttributes() {
-        return Collections.<Form>emptyList();
+        return ModeledConnection.ATTRIBUTES;
     }
 
     @Override
     public Collection<Form> getConnectionGroupAttributes() {
-        return Collections.<Form>emptyList();
+        return ModeledConnectionGroup.ATTRIBUTES;
     }
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/en.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/en.json
@@ -15,6 +15,24 @@
 
     },
 
+    "CONNECTION_ATTRIBUTES" : {
+
+        "FIELD_HEADER_MAX_CONNECTIONS"          : "Maximum number of connections:",
+        "FIELD_HEADER_MAX_CONNECTIONS_PER_USER" : "Maximum number of connections per user:",
+
+        "SECTION_HEADER_CONCURRENCY" : "Concurrency Limits"
+
+    },
+
+    "CONNECTION_GROUP_ATTRIBUTES" : {
+
+        "FIELD_HEADER_MAX_CONNECTIONS"          : "Maximum number of connections:",
+        "FIELD_HEADER_MAX_CONNECTIONS_PER_USER" : "Maximum number of connections per user:",
+
+        "SECTION_HEADER_CONCURRENCY" : "Concurrency Limits (Balancing Groups)"
+
+    },
+
     "USER_ATTRIBUTES" : {
 
         "FIELD_HEADER_DISABLED"            : "Login disabled:",

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
@@ -32,6 +32,10 @@ CREATE TABLE `guacamole_connection_group` (
   `type`                  enum('ORGANIZATIONAL',
                                'BALANCING') NOT NULL DEFAULT 'ORGANIZATIONAL',
 
+  -- Concurrency limits
+  `max_connections`          int(11),
+  `max_connections_per_user` int(11),
+
   PRIMARY KEY (`connection_group_id`),
   UNIQUE KEY `connection_group_name_parent` (`connection_group_name`, `parent_id`),
 
@@ -54,6 +58,10 @@ CREATE TABLE `guacamole_connection` (
   `parent_id`           int(11),
   `protocol`            varchar(32)  NOT NULL,
   
+  -- Concurrency limits
+  `max_connections`          int(11),
+  `max_connections_per_user` int(11),
+
   PRIMARY KEY (`connection_id`),
   UNIQUE KEY `connection_name_parent` (`connection_name`, `parent_id`),
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/upgrade/upgrade-pre-0.9.8.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/upgrade/upgrade-pre-0.9.8.sql
@@ -39,3 +39,17 @@ ALTER TABLE guacamole_user ADD COLUMN valid_until DATE;
 --
 
 ALTER TABLE guacamole_user ADD COLUMN timezone VARCHAR(64);
+
+--
+-- Add connection concurrency limits
+--
+
+ALTER TABLE guacamole_connection ADD COLUMN max_connections          INT(11);
+ALTER TABLE guacamole_connection ADD COLUMN max_connections_per_user INT(11);
+
+--
+-- Add connection group concurrency limits
+--
+
+ALTER TABLE guacamole_connection_group ADD COLUMN max_connections          INT(11);
+ALTER TABLE guacamole_connection_group ADD COLUMN max_connections_per_user INT(11);

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/glyptodon/guacamole/auth/jdbc/connection/ConnectionMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/glyptodon/guacamole/auth/jdbc/connection/ConnectionMapper.xml
@@ -28,10 +28,12 @@
 
     <!-- Result mapper for connection objects -->
     <resultMap id="ConnectionResultMap" type="org.glyptodon.guacamole.auth.jdbc.connection.ConnectionModel" >
-        <id     column="connection_id"   property="objectID"         jdbcType="INTEGER"/>
-        <result column="connection_name" property="name"             jdbcType="VARCHAR"/>
-        <result column="parent_id"       property="parentIdentifier" jdbcType="INTEGER"/>
-        <result column="protocol"        property="protocol"         jdbcType="VARCHAR"/>
+        <id     column="connection_id"            property="objectID"              jdbcType="INTEGER"/>
+        <result column="connection_name"          property="name"                  jdbcType="VARCHAR"/>
+        <result column="parent_id"                property="parentIdentifier"      jdbcType="INTEGER"/>
+        <result column="protocol"                 property="protocol"              jdbcType="VARCHAR"/>
+        <result column="max_connections"          property="maxConnections"        jdbcType="INTEGER"/>
+        <result column="max_connections_per_user" property="maxConnectionsPerUser" jdbcType="INTEGER"/>
     </resultMap>
 
     <!-- Select all connection identifiers -->
@@ -77,7 +79,9 @@
             connection_id,
             connection_name,
             parent_id,
-            protocol 
+            protocol,
+            max_connections,
+            max_connections_per_user
         FROM guacamole_connection
         WHERE connection_id IN
             <foreach collection="identifiers" item="identifier"
@@ -94,7 +98,9 @@
             guacamole_connection.connection_id,
             connection_name,
             parent_id,
-            protocol 
+            protocol,
+            max_connections,
+            max_connections_per_user
         FROM guacamole_connection
         JOIN guacamole_connection_permission ON guacamole_connection_permission.connection_id = guacamole_connection.connection_id
         WHERE guacamole_connection.connection_id IN
@@ -114,7 +120,9 @@
             connection_id,
             connection_name,
             parent_id,
-            protocol 
+            protocol,
+            max_connections,
+            max_connections_per_user
         FROM guacamole_connection
         WHERE 
             <if test="parentIdentifier != null">parent_id = #{parentIdentifier,jdbcType=VARCHAR}</if>
@@ -136,12 +144,16 @@
         INSERT INTO guacamole_connection (
             connection_name,
             parent_id,
-            protocol 
+            protocol,
+            max_connections,
+            max_connections_per_user
         )
         VALUES (
             #{object.name,jdbcType=VARCHAR},
             #{object.parentIdentifier,jdbcType=VARCHAR},
-            #{object.protocol,jdbcType=VARCHAR}
+            #{object.protocol,jdbcType=VARCHAR},
+            #{object.maxConnections,jdbcType=INTEGER},
+            #{object.maxConnectionsPerUser,jdbcType=INTEGER}
         )
 
     </insert>
@@ -149,9 +161,11 @@
     <!-- Update single connection -->
     <update id="update" parameterType="org.glyptodon.guacamole.auth.jdbc.connection.ConnectionModel">
         UPDATE guacamole_connection
-        SET connection_name = #{object.name,jdbcType=VARCHAR},
-            parent_id       = #{object.parentIdentifier,jdbcType=VARCHAR},
-            protocol        = #{object.protocol,jdbcType=VARCHAR}
+        SET connection_name          = #{object.name,jdbcType=VARCHAR},
+            parent_id                = #{object.parentIdentifier,jdbcType=VARCHAR},
+            protocol                 = #{object.protocol,jdbcType=VARCHAR},
+            max_connections          = #{object.maxConnections,jdbcType=INTEGER},
+            max_connections_per_user = #{object.maxConnectionsPerUser,jdbcType=INTEGER}
         WHERE connection_id = #{object.objectID,jdbcType=INTEGER}
     </update>
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/glyptodon/guacamole/auth/jdbc/connectiongroup/ConnectionGroupMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/glyptodon/guacamole/auth/jdbc/connectiongroup/ConnectionGroupMapper.xml
@@ -28,11 +28,13 @@
 
     <!-- Result mapper for connection objects -->
     <resultMap id="ConnectionGroupResultMap" type="org.glyptodon.guacamole.auth.jdbc.connectiongroup.ConnectionGroupModel" >
-        <id     column="connection_group_id"   property="objectID"         jdbcType="INTEGER"/>
-        <result column="connection_group_name" property="name"             jdbcType="VARCHAR"/>
-        <result column="parent_id"             property="parentIdentifier" jdbcType="INTEGER"/>
-        <result column="type"                  property="type"             jdbcType="VARCHAR"
+        <id     column="connection_group_id"      property="objectID"              jdbcType="INTEGER"/>
+        <result column="connection_group_name"    property="name"                  jdbcType="VARCHAR"/>
+        <result column="parent_id"                property="parentIdentifier"      jdbcType="INTEGER"/>
+        <result column="type"                     property="type"                  jdbcType="VARCHAR"
                 javaType="org.glyptodon.guacamole.net.auth.ConnectionGroup$Type"/>
+        <result column="max_connections"          property="maxConnections"        jdbcType="INTEGER"/>
+        <result column="max_connections_per_user" property="maxConnectionsPerUser" jdbcType="INTEGER"/>
     </resultMap>
 
     <!-- Select all connection group identifiers -->
@@ -78,7 +80,9 @@
             connection_group_id,
             connection_group_name,
             parent_id,
-            type
+            type,
+            max_connections,
+            max_connections_per_user
         FROM guacamole_connection_group
         WHERE connection_group_id IN
             <foreach collection="identifiers" item="identifier"
@@ -95,7 +99,9 @@
             guacamole_connection_group.connection_group_id,
             connection_group_name,
             parent_id,
-            type 
+            type,
+            max_connections,
+            max_connections_per_user
         FROM guacamole_connection_group
         JOIN guacamole_connection_group_permission ON guacamole_connection_group_permission.connection_group_id = guacamole_connection_group.connection_group_id
         WHERE guacamole_connection_group.connection_group_id IN
@@ -115,7 +121,9 @@
             connection_group_id,
             connection_group_name,
             parent_id,
-            type
+            type,
+            max_connections,
+            max_connections_per_user
         FROM guacamole_connection_group
         WHERE 
             <if test="parentIdentifier != null">parent_id = #{parentIdentifier,jdbcType=VARCHAR}</if>
@@ -137,12 +145,16 @@
         INSERT INTO guacamole_connection_group (
             connection_group_name,
             parent_id,
-            type
+            type,
+            max_connections,
+            max_connections_per_user
         )
         VALUES (
             #{object.name,jdbcType=VARCHAR},
             #{object.parentIdentifier,jdbcType=VARCHAR},
-            #{object.type,jdbcType=VARCHAR}
+            #{object.type,jdbcType=VARCHAR},
+            #{object.maxConnections,jdbcType=INTEGER},
+            #{object.maxConnectionsPerUser,jdbcType=INTEGER}
         )
 
     </insert>
@@ -150,9 +162,11 @@
     <!-- Update single connection group -->
     <update id="update" parameterType="org.glyptodon.guacamole.auth.jdbc.connectiongroup.ConnectionGroupModel">
         UPDATE guacamole_connection_group
-        SET connection_group_name = #{object.name,jdbcType=VARCHAR},
-            parent_id             = #{object.parentIdentifier,jdbcType=VARCHAR},
-            type                  = #{object.type,jdbcType=VARCHAR}
+        SET connection_group_name    = #{object.name,jdbcType=VARCHAR},
+            parent_id                = #{object.parentIdentifier,jdbcType=VARCHAR},
+            type                     = #{object.type,jdbcType=VARCHAR},
+            max_connections          = #{object.maxConnections,jdbcType=INTEGER},
+            max_connections_per_user = #{object.maxConnectionsPerUser,jdbcType=INTEGER}
         WHERE connection_group_id = #{object.objectID,jdbcType=INTEGER}
     </update>
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
@@ -63,6 +63,10 @@ CREATE TABLE guacamole_connection_group (
   type                  guacamole_connection_group_type
                         NOT NULL DEFAULT 'ORGANIZATIONAL',
 
+  -- Concurrency limits
+  max_connections          integer,
+  max_connections_per_user integer,
+
   PRIMARY KEY (connection_group_id),
 
   CONSTRAINT connection_group_name_parent
@@ -90,6 +94,10 @@ CREATE TABLE guacamole_connection (
   parent_id           integer,
   protocol            varchar(32)  NOT NULL,
   
+  -- Concurrency limits
+  max_connections          integer,
+  max_connections_per_user integer,
+
   PRIMARY KEY (connection_id),
 
   CONSTRAINT connection_name_parent

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/upgrade/upgrade-pre-0.9.8.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/upgrade/upgrade-pre-0.9.8.sql
@@ -39,3 +39,17 @@ ALTER TABLE guacamole_user ADD COLUMN valid_until date;
 --
 
 ALTER TABLE guacamole_user ADD COLUMN timezone varchar(64);
+
+--
+-- Add connection concurrency limits
+--
+
+ALTER TABLE guacamole_connection ADD COLUMN max_connections          integer;
+ALTER TABLE guacamole_connection ADD COLUMN max_connections_per_user integer;
+
+--
+-- Add connection group concurrency limits
+--
+
+ALTER TABLE guacamole_connection_group ADD COLUMN max_connections          integer;
+ALTER TABLE guacamole_connection_group ADD COLUMN max_connections_per_user integer;

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/glyptodon/guacamole/auth/jdbc/connection/ConnectionMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/glyptodon/guacamole/auth/jdbc/connection/ConnectionMapper.xml
@@ -28,10 +28,12 @@
 
     <!-- Result mapper for connection objects -->
     <resultMap id="ConnectionResultMap" type="org.glyptodon.guacamole.auth.jdbc.connection.ConnectionModel" >
-        <id     column="connection_id"   property="objectID"         jdbcType="INTEGER"/>
-        <result column="connection_name" property="name"             jdbcType="VARCHAR"/>
-        <result column="parent_id"       property="parentIdentifier" jdbcType="INTEGER"/>
-        <result column="protocol"        property="protocol"         jdbcType="VARCHAR"/>
+        <id     column="connection_id"            property="objectID"              jdbcType="INTEGER"/>
+        <result column="connection_name"          property="name"                  jdbcType="VARCHAR"/>
+        <result column="parent_id"                property="parentIdentifier"      jdbcType="INTEGER"/>
+        <result column="protocol"                 property="protocol"              jdbcType="VARCHAR"/>
+        <result column="max_connections"          property="maxConnections"        jdbcType="INTEGER"/>
+        <result column="max_connections_per_user" property="maxConnectionsPerUser" jdbcType="INTEGER"/>
     </resultMap>
 
     <!-- Select all connection identifiers -->
@@ -77,7 +79,9 @@
             connection_id,
             connection_name,
             parent_id,
-            protocol 
+            protocol,
+            max_connections,
+            max_connections_per_user
         FROM guacamole_connection
         WHERE connection_id IN
             <foreach collection="identifiers" item="identifier"
@@ -94,7 +98,9 @@
             guacamole_connection.connection_id,
             connection_name,
             parent_id,
-            protocol 
+            protocol,
+            max_connections,
+            max_connections_per_user
         FROM guacamole_connection
         JOIN guacamole_connection_permission ON guacamole_connection_permission.connection_id = guacamole_connection.connection_id
         WHERE guacamole_connection.connection_id IN
@@ -114,7 +120,9 @@
             connection_id,
             connection_name,
             parent_id,
-            protocol 
+            protocol,
+            max_connections,
+            max_connections_per_user
         FROM guacamole_connection
         WHERE 
             <if test="parentIdentifier != null">parent_id = #{parentIdentifier,jdbcType=INTEGER}::integer</if>
@@ -136,12 +144,16 @@
         INSERT INTO guacamole_connection (
             connection_name,
             parent_id,
-            protocol 
+            protocol,
+            max_connections,
+            max_connections_per_user
         )
         VALUES (
             #{object.name,jdbcType=VARCHAR},
             #{object.parentIdentifier,jdbcType=INTEGER}::integer,
-            #{object.protocol,jdbcType=VARCHAR}
+            #{object.protocol,jdbcType=VARCHAR},
+            #{object.maxConnections,jdbcType=INTEGER},
+            #{object.maxConnectionsPerUser,jdbcType=INTEGER}
         )
 
     </insert>
@@ -149,9 +161,11 @@
     <!-- Update single connection -->
     <update id="update" parameterType="org.glyptodon.guacamole.auth.jdbc.connection.ConnectionModel">
         UPDATE guacamole_connection
-        SET connection_name = #{object.name,jdbcType=VARCHAR},
-            parent_id       = #{object.parentIdentifier,jdbcType=INTEGER}::integer,
-            protocol        = #{object.protocol,jdbcType=VARCHAR}
+        SET connection_name          = #{object.name,jdbcType=VARCHAR},
+            parent_id                = #{object.parentIdentifier,jdbcType=INTEGER}::integer,
+            protocol                 = #{object.protocol,jdbcType=VARCHAR},
+            max_connections          = #{object.maxConnections,jdbcType=INTEGER},
+            max_connections_per_user = #{object.maxConnectionsPerUser,jdbcType=INTEGER}
         WHERE connection_id = #{object.objectID,jdbcType=INTEGER}::integer
     </update>
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/glyptodon/guacamole/auth/jdbc/connectiongroup/ConnectionGroupMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/glyptodon/guacamole/auth/jdbc/connectiongroup/ConnectionGroupMapper.xml
@@ -28,11 +28,13 @@
 
     <!-- Result mapper for connection objects -->
     <resultMap id="ConnectionGroupResultMap" type="org.glyptodon.guacamole.auth.jdbc.connectiongroup.ConnectionGroupModel" >
-        <id     column="connection_group_id"   property="objectID"         jdbcType="INTEGER"/>
-        <result column="connection_group_name" property="name"             jdbcType="VARCHAR"/>
-        <result column="parent_id"             property="parentIdentifier" jdbcType="INTEGER"/>
-        <result column="type"                  property="type"             jdbcType="VARCHAR"
+        <id     column="connection_group_id"      property="objectID"              jdbcType="INTEGER"/>
+        <result column="connection_group_name"    property="name"                  jdbcType="VARCHAR"/>
+        <result column="parent_id"                property="parentIdentifier"      jdbcType="INTEGER"/>
+        <result column="type"                     property="type"                  jdbcType="VARCHAR"
                 javaType="org.glyptodon.guacamole.net.auth.ConnectionGroup$Type"/>
+        <result column="max_connections"          property="maxConnections"        jdbcType="INTEGER"/>
+        <result column="max_connections_per_user" property="maxConnectionsPerUser" jdbcType="INTEGER"/>
     </resultMap>
 
     <!-- Select all connection group identifiers -->
@@ -78,7 +80,9 @@
             connection_group_id,
             connection_group_name,
             parent_id,
-            type
+            type,
+            max_connections,
+            max_connections_per_user
         FROM guacamole_connection_group
         WHERE connection_group_id IN
             <foreach collection="identifiers" item="identifier"
@@ -95,7 +99,9 @@
             guacamole_connection_group.connection_group_id,
             connection_group_name,
             parent_id,
-            type 
+            type,
+            max_connections,
+            max_connections_per_user
         FROM guacamole_connection_group
         JOIN guacamole_connection_group_permission ON guacamole_connection_group_permission.connection_group_id = guacamole_connection_group.connection_group_id
         WHERE guacamole_connection_group.connection_group_id IN
@@ -115,7 +121,9 @@
             connection_group_id,
             connection_group_name,
             parent_id,
-            type
+            type,
+            max_connections,
+            max_connections_per_user
         FROM guacamole_connection_group
         WHERE 
             <if test="parentIdentifier != null">parent_id = #{parentIdentifier,jdbcType=INTEGER}::integer</if>
@@ -137,12 +145,16 @@
         INSERT INTO guacamole_connection_group (
             connection_group_name,
             parent_id,
-            type
+            type,
+            max_connections,
+            max_connections_per_user
         )
         VALUES (
             #{object.name,jdbcType=VARCHAR},
             #{object.parentIdentifier,jdbcType=INTEGER}::integer,
-            #{object.type,jdbcType=VARCHAR}::guacamole_connection_group_type
+            #{object.type,jdbcType=VARCHAR}::guacamole_connection_group_type,
+            #{object.maxConnections,jdbcType=INTEGER},
+            #{object.maxConnectionsPerUser,jdbcType=INTEGER}
         )
 
     </insert>
@@ -150,9 +162,11 @@
     <!-- Update single connection group -->
     <update id="update" parameterType="org.glyptodon.guacamole.auth.jdbc.connectiongroup.ConnectionGroupModel">
         UPDATE guacamole_connection_group
-        SET connection_group_name = #{object.name,jdbcType=VARCHAR},
-            parent_id             = #{object.parentIdentifier,jdbcType=INTEGER}::integer,
-            type                  = #{object.type,jdbcType=VARCHAR}::guacamole_connection_group_type
+        SET connection_group_name    = #{object.name,jdbcType=VARCHAR},
+            parent_id                = #{object.parentIdentifier,jdbcType=INTEGER}::integer,
+            type                     = #{object.type,jdbcType=VARCHAR}::guacamole_connection_group_type,
+            max_connections          = #{object.maxConnections,jdbcType=INTEGER},
+            max_connections_per_user = #{object.maxConnectionsPerUser,jdbcType=INTEGER}
         WHERE connection_group_id = #{object.objectID,jdbcType=INTEGER}::integer
     </update>
 

--- a/guacamole-ext/src/main/java/org/glyptodon/guacamole/form/DateField.java
+++ b/guacamole-ext/src/main/java/org/glyptodon/guacamole/form/DateField.java
@@ -22,6 +22,11 @@
 
 package org.glyptodon.guacamole.form;
 
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 /**
  * Represents a date field. The field may contain only date values which
  * conform to a standard pattern, defined by DateField.FORMAT.
@@ -43,6 +48,50 @@ public class DateField extends Field {
      */
     public DateField(String name) {
         super(name, Field.Type.DATE);
+    }
+
+    /**
+     * Converts the given date into a string which follows the format used by
+     * date fields.
+     *
+     * @param date
+     *     The date value to format, which may be null.
+     *
+     * @return
+     *     The formatted date, or null if the provided time was null.
+     */
+    public static String format(Date date) {
+        DateFormat dateFormat = new SimpleDateFormat(DateField.FORMAT);
+        return date == null ? null : dateFormat.format(date);
+    }
+
+    /**
+     * Parses the given string into a corresponding date. The string must
+     * follow the standard format used by date fields, as defined by FORMAT
+     * and as would be produced by format().
+     *
+     * @param dateString
+     *     The date string to parse, which may be null.
+     *
+     * @return
+     *     The date corresponding to the given date string, or null if the
+     *     provided date string was null or blank.
+     *
+     * @throws ParseException
+     *     If the given date string does not conform to the standard format
+     *     used by date fields.
+     */
+    public static Date parse(String dateString)
+            throws ParseException {
+
+        // Return null if no date provided
+        if (dateString == null || dateString.isEmpty())
+            return null;
+
+        // Parse date according to format
+        DateFormat dateFormat = new SimpleDateFormat(DateField.FORMAT);
+        return dateFormat.parse(dateString);
+
     }
 
 }

--- a/guacamole-ext/src/main/java/org/glyptodon/guacamole/form/NumericField.java
+++ b/guacamole-ext/src/main/java/org/glyptodon/guacamole/form/NumericField.java
@@ -51,9 +51,11 @@ public class NumericField extends Field {
      */
     public static String format(Integer i) {
 
+        // Return null if no value provided
         if (i == null)
             return null;
 
+        // Convert to string
         return i.toString();
 
     }
@@ -74,9 +76,11 @@ public class NumericField extends Field {
      */
     public static Integer parse(String str) throws NumberFormatException {
 
+        // Return null if no value provided
         if (str == null || str.isEmpty())
             return null;
 
+        // Parse as integer
         return new Integer(str);
 
     }

--- a/guacamole-ext/src/main/java/org/glyptodon/guacamole/form/NumericField.java
+++ b/guacamole-ext/src/main/java/org/glyptodon/guacamole/form/NumericField.java
@@ -39,4 +39,46 @@ public class NumericField extends Field {
         super(name, Field.Type.NUMERIC);
     }
 
+    /**
+     * Formats the given integer in the format required by a numeric field.
+     *
+     * @param i
+     *     The integer to format, which may be null.
+     *
+     * @return
+     *     A string representation of the given integer, or null if the given
+     *     integer was null.
+     */
+    public static String format(Integer i) {
+
+        if (i == null)
+            return null;
+
+        return i.toString();
+
+    }
+
+    /**
+     * Parses the given string as an integer, where the given string is in the
+     * format required by a numeric field.
+     *
+     * @param str
+     *     The string to parse as an integer, which may be null.
+     *
+     * @return
+     *     The integer representation of the given string, or null if the given
+     *     string was null.
+     *
+     * @throws NumberFormatException
+     *     If the given string is not in a parseable format.
+     */
+    public static Integer parse(String str) throws NumberFormatException {
+
+        if (str == null || str.isEmpty())
+            return null;
+
+        return new Integer(str);
+
+    }
+
 }

--- a/guacamole-ext/src/main/java/org/glyptodon/guacamole/form/TimeField.java
+++ b/guacamole-ext/src/main/java/org/glyptodon/guacamole/form/TimeField.java
@@ -22,6 +22,11 @@
 
 package org.glyptodon.guacamole.form;
 
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 /**
  * Represents a time field. The field may contain only time values which
  * conform to a standard pattern, defined by TimeField.FORMAT.
@@ -43,6 +48,50 @@ public class TimeField extends Field {
      */
     public TimeField(String name) {
         super(name, Field.Type.TIME);
+    }
+
+    /**
+     * Parses the given string into a corresponding time. The string must
+     * follow the standard format used by time fields, as defined by
+     * FORMAT and as would be produced by format().
+     *
+     * @param timeString
+     *     The time string to parse, which may be null.
+     *
+     * @return
+     *     The time corresponding to the given time string, or null if the
+     *     provided time string was null or blank.
+     *
+     * @throws ParseException
+     *     If the given time string does not conform to the standard format
+     *     used by time fields.
+     */
+    public static Date parse(String timeString)
+            throws ParseException {
+
+        // Return null if no time provided
+        if (timeString == null || timeString.isEmpty())
+            return null;
+
+        // Parse time according to format
+        DateFormat timeFormat = new SimpleDateFormat(TimeField.FORMAT);
+        return timeFormat.parse(timeString);
+
+    }
+
+    /**
+     * Converts the given time into a string which follows the format used by
+     * time fields.
+     *
+     * @param time
+     *     The time value to format, which may be null.
+     *
+     * @return
+     *     The formatted time, or null if the provided time was null.
+     */
+    public static String format(Date time) {
+        DateFormat timeFormat = new SimpleDateFormat(TimeField.FORMAT);
+        return time == null ? null : timeFormat.format(time);
     }
 
 }

--- a/guacamole-ext/src/main/java/org/glyptodon/guacamole/form/TimeZoneField.java
+++ b/guacamole-ext/src/main/java/org/glyptodon/guacamole/form/TimeZoneField.java
@@ -40,4 +40,27 @@ public class TimeZoneField extends Field {
         super(name, Field.Type.TIMEZONE);
     }
 
+    /**
+     * Parses the given string into a time zone ID string. As these strings are
+     * equivalent, the only transformation currently performed by this function
+     * is to ensure that a blank time zone string is parsed into null.
+     *
+     * @param timeZone
+     *     The time zone string to parse, which may be null.
+     *
+     * @return
+     *     The ID of the time zone corresponding to the given string, or null
+     *     if the given time zone string was null or blank.
+     */
+    public static String parse(String timeZone) {
+
+        // Return null if no time zone provided
+        if (timeZone == null || timeZone.isEmpty())
+            return null;
+
+        // Otherwise, assume time zone is valid
+        return timeZone;
+
+    }
+
 }

--- a/guacamole/src/main/webapp/app/form/controllers/numberFieldController.js
+++ b/guacamole/src/main/webapp/app/form/controllers/numberFieldController.js
@@ -34,7 +34,7 @@ angular.module('form').controller('numberFieldController', ['$scope',
 
     // Update string value in model when typed value is changed
     $scope.$watch('typedValue', function typedValueChanged(typedValue) {
-        $scope.model = (typedValue ? typedValue.toString() : '');
+        $scope.model = ((typedValue || typedValue === 0) ? typedValue.toString() : '');
     });
 
 }]);


### PR DESCRIPTION
This change adds concurrency policy columns (max connections / max connections per user) to the schema for connections and connection groups, adds mappings for those columns to properties in the model objects, and exposes those values as attributes to the web application.

Additionally, the following bugs were noticed and fixed during testing:

1. One of the connection error messages which was copied from the connection group section still said "connection group" instead of "connection".
2. The logic of `tryAdd()` was flawed when the maximum is zero (unlimited), and would universally deny additional values.
3. The test for whether a numeric field is blank within the web application UI was overly broad, and considered "0" to be a blank value, as it's falsy.

Connections | Connection Groups
----------------|--------------------------
![connection-concurrency](https://cloud.githubusercontent.com/assets/4632905/9422116/8a1df8b8-483b-11e5-8ef1-c968e835a24c.png) | ![group-concurrency](https://cloud.githubusercontent.com/assets/4632905/9422104/328a7e5a-483b-11e5-9b02-e9461de53b73.png)
