### PR TITLE
GUAC-830: Add new concurrency properties.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/net/sourceforge/guacamole/net/auth/mysql/MySQLAuthenticationProvider.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/net/sourceforge/guacamole/net/auth/mysql/MySQLAuthenticationProvider.java
@@ -91,11 +91,11 @@ public class MySQLAuthenticationProvider implements AuthenticationProvider {
 
             // Translate legacy property
             if (disallowSimultaneous) {
-                connectionDefaultMaxConnections = 1;
+                connectionDefaultMaxConnections      = 1;
                 connectionGroupDefaultMaxConnections = 0;
             }
             else {
-                connectionDefaultMaxConnections = 0;
+                connectionDefaultMaxConnections      = 0;
                 connectionGroupDefaultMaxConnections = 0;
             }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/net/sourceforge/guacamole/net/auth/mysql/MySQLAuthenticationProvider.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/net/sourceforge/guacamole/net/auth/mysql/MySQLAuthenticationProvider.java
@@ -34,6 +34,8 @@ import org.glyptodon.guacamole.auth.jdbc.tunnel.ConfigurableGuacamoleTunnelServi
 import org.glyptodon.guacamole.auth.jdbc.user.UserContextService;
 import org.glyptodon.guacamole.environment.Environment;
 import org.glyptodon.guacamole.environment.LocalEnvironment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Provides a MySQL based implementation of the AuthenticationProvider
@@ -43,6 +45,11 @@ import org.glyptodon.guacamole.environment.LocalEnvironment;
  * @author Michael Jumper
  */
 public class MySQLAuthenticationProvider implements AuthenticationProvider {
+
+    /**
+     * Logger for this class.
+     */
+    private static final Logger logger = LoggerFactory.getLogger(MySQLAuthenticationProvider.class);
 
     /**
      * Injector which will manage the object graph of this authentication
@@ -75,28 +82,75 @@ public class MySQLAuthenticationProvider implements AuthenticationProvider {
         int connectionGroupDefaultMaxConnectionsPerUser;
 
         // Read legacy concurrency-related properties
-        boolean disallowSimultaneous = environment.getProperty(MySQLGuacamoleProperties.MYSQL_DISALLOW_SIMULTANEOUS_CONNECTIONS, false);
-        boolean disallowDuplicate    = environment.getProperty(MySQLGuacamoleProperties.MYSQL_DISALLOW_DUPLICATE_CONNECTIONS, true);
-
-        // Legacy properties to not affect max connections per group
-        connectionGroupDefaultMaxConnections = 0;
+        Boolean disallowSimultaneous = environment.getProperty(MySQLGuacamoleProperties.MYSQL_DISALLOW_SIMULTANEOUS_CONNECTIONS);
+        Boolean disallowDuplicate    = environment.getProperty(MySQLGuacamoleProperties.MYSQL_DISALLOW_DUPLICATE_CONNECTIONS);
 
         // Legacy "simultaneous" property dictates only the maximum number of
         // connections per connection
-        if (disallowSimultaneous)
-            connectionDefaultMaxConnections = 1;
-        else
-            connectionDefaultMaxConnections = 0;
+        if (disallowSimultaneous != null) {
+
+            // Translate legacy property
+            if (disallowSimultaneous) {
+                connectionDefaultMaxConnections = 1;
+                connectionGroupDefaultMaxConnections = 0;
+            }
+            else {
+                connectionDefaultMaxConnections = 0;
+                connectionGroupDefaultMaxConnections = 0;
+            }
+
+            // Warn of deprecation
+            logger.warn("The \"{}\" property is deprecated. Use \"{}\" and \"{}\" instead.",
+                    MySQLGuacamoleProperties.MYSQL_DISALLOW_SIMULTANEOUS_CONNECTIONS.getName(),
+                    MySQLGuacamoleProperties.MYSQL_DEFAULT_MAX_CONNECTIONS.getName(),
+                    MySQLGuacamoleProperties.MYSQL_DEFAULT_MAX_GROUP_CONNECTIONS.getName());
+
+            // Inform of new equivalent
+            logger.info("To achieve the same result of setting \"{}\" to \"{}\", set \"{}\" to \"{}\" and \"{}\" to \"{}\".",
+                    MySQLGuacamoleProperties.MYSQL_DISALLOW_SIMULTANEOUS_CONNECTIONS.getName(), disallowSimultaneous,
+                    MySQLGuacamoleProperties.MYSQL_DEFAULT_MAX_CONNECTIONS.getName(),           connectionDefaultMaxConnections,
+                    MySQLGuacamoleProperties.MYSQL_DEFAULT_MAX_GROUP_CONNECTIONS.getName(),     connectionGroupDefaultMaxConnections);
+
+        }
+
+        // If legacy property is not specified, use new property
+        else {
+            connectionDefaultMaxConnections      = environment.getProperty(MySQLGuacamoleProperties.MYSQL_DEFAULT_MAX_CONNECTIONS, 0);
+            connectionGroupDefaultMaxConnections = environment.getProperty(MySQLGuacamoleProperties.MYSQL_DEFAULT_MAX_GROUP_CONNECTIONS, 0);
+        }
 
         // Legacy "duplicate" property dictates whether connections and groups
         // may be used concurrently only by different users
-        if (disallowDuplicate) {
-            connectionDefaultMaxConnectionsPerUser      = 1;
-            connectionGroupDefaultMaxConnectionsPerUser = 1;
+        if (disallowDuplicate != null) {
+
+            // Translate legacy property
+            if (disallowDuplicate) {
+                connectionDefaultMaxConnectionsPerUser      = 1;
+                connectionGroupDefaultMaxConnectionsPerUser = 1;
+            }
+            else {
+                connectionDefaultMaxConnectionsPerUser      = 0;
+                connectionGroupDefaultMaxConnectionsPerUser = 0;
+            }
+
+            // Warn of deprecation
+            logger.warn("The \"{}\" property is deprecated. Use \"{}\" and \"{}\" instead.",
+                    MySQLGuacamoleProperties.MYSQL_DISALLOW_DUPLICATE_CONNECTIONS.getName(),
+                    MySQLGuacamoleProperties.MYSQL_DEFAULT_MAX_CONNECTIONS_PER_USER.getName(),
+                    MySQLGuacamoleProperties.MYSQL_DEFAULT_MAX_GROUP_CONNECTIONS.getName());
+
+            // Inform of new equivalent
+            logger.info("To achieve the same result of setting \"{}\" to \"{}\", set \"{}\" to \"{}\" and \"{}\" to \"{}\".",
+                    MySQLGuacamoleProperties.MYSQL_DISALLOW_DUPLICATE_CONNECTIONS.getName(),         disallowDuplicate,
+                    MySQLGuacamoleProperties.MYSQL_DEFAULT_MAX_CONNECTIONS_PER_USER.getName(),       connectionDefaultMaxConnectionsPerUser,
+                    MySQLGuacamoleProperties.MYSQL_DEFAULT_MAX_GROUP_CONNECTIONS_PER_USER.getName(), connectionGroupDefaultMaxConnectionsPerUser);
+
         }
+
+        // If legacy property is not specified, use new property
         else {
-            connectionDefaultMaxConnectionsPerUser      = 0;
-            connectionGroupDefaultMaxConnectionsPerUser = 0;
+            connectionDefaultMaxConnectionsPerUser      = environment.getProperty(MySQLGuacamoleProperties.MYSQL_DEFAULT_MAX_CONNECTIONS_PER_USER, 1);
+            connectionGroupDefaultMaxConnectionsPerUser = environment.getProperty(MySQLGuacamoleProperties.MYSQL_DEFAULT_MAX_GROUP_CONNECTIONS_PER_USER, 1);
         }
 
         // Return service configured for specified default limits

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/net/sourceforge/guacamole/net/auth/mysql/MySQLGuacamoleProperties.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/net/sourceforge/guacamole/net/auth/mysql/MySQLGuacamoleProperties.java
@@ -106,6 +106,58 @@ public class MySQLGuacamoleProperties {
         public String getName() { return "mysql-disallow-duplicate-connections"; }
 
     };
-    
-    
+
+    /**
+     * The maximum number of concurrent connections to allow to any one
+     * connection. Zero denotes unlimited.
+     */
+    public static final IntegerGuacamoleProperty
+            MYSQL_DEFAULT_MAX_CONNECTIONS =
+            new IntegerGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "mysql-default-max-connections"; }
+
+    };
+
+    /**
+     * The maximum number of concurrent connections to allow to any one
+     * connection group. Zero denotes unlimited.
+     */
+    public static final IntegerGuacamoleProperty
+            MYSQL_DEFAULT_MAX_GROUP_CONNECTIONS =
+            new IntegerGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "mysql-default-max-group-connections"; }
+
+    };
+
+    /**
+     * The maximum number of concurrent connections to allow to any one
+     * connection by an individual user. Zero denotes unlimited.
+     */
+    public static final IntegerGuacamoleProperty
+            MYSQL_DEFAULT_MAX_CONNECTIONS_PER_USER =
+            new IntegerGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "mysql-default-max-connections-per-user"; }
+
+    };
+
+    /**
+     * The maximum number of concurrent connections to allow to any one
+     * connection group by an individual user. Zero denotes
+     * unlimited.
+     */
+    public static final IntegerGuacamoleProperty
+            MYSQL_DEFAULT_MAX_GROUP_CONNECTIONS_PER_USER =
+            new IntegerGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "mysql-default-max-group-connections-per-user"; }
+
+    };
+
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/glyptodon/guacamole/auth/postgresql/PostgreSQLAuthenticationProvider.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/glyptodon/guacamole/auth/postgresql/PostgreSQLAuthenticationProvider.java
@@ -34,6 +34,8 @@ import org.glyptodon.guacamole.auth.jdbc.tunnel.GuacamoleTunnelService;
 import org.glyptodon.guacamole.auth.jdbc.user.UserContextService;
 import org.glyptodon.guacamole.environment.Environment;
 import org.glyptodon.guacamole.environment.LocalEnvironment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Provides a PostgreSQL-based implementation of the AuthenticationProvider
@@ -43,6 +45,11 @@ import org.glyptodon.guacamole.environment.LocalEnvironment;
  * @author Michael Jumper
  */
 public class PostgreSQLAuthenticationProvider implements AuthenticationProvider {
+
+    /**
+     * Logger for this class.
+     */
+    private static final Logger logger = LoggerFactory.getLogger(PostgreSQLAuthenticationProvider.class);
 
     /**
      * Injector which will manage the object graph of this authentication
@@ -75,28 +82,75 @@ public class PostgreSQLAuthenticationProvider implements AuthenticationProvider 
         int connectionGroupDefaultMaxConnectionsPerUser;
 
         // Read legacy concurrency-related properties
-        boolean disallowSimultaneous = environment.getProperty(PostgreSQLGuacamoleProperties.POSTGRESQL_DISALLOW_SIMULTANEOUS_CONNECTIONS, false);
-        boolean disallowDuplicate    = environment.getProperty(PostgreSQLGuacamoleProperties.POSTGRESQL_DISALLOW_DUPLICATE_CONNECTIONS, true);
-
-        // Legacy properties to not affect max connections per group
-        connectionGroupDefaultMaxConnections = 0;
+        Boolean disallowSimultaneous = environment.getProperty(PostgreSQLGuacamoleProperties.POSTGRESQL_DISALLOW_SIMULTANEOUS_CONNECTIONS);
+        Boolean disallowDuplicate    = environment.getProperty(PostgreSQLGuacamoleProperties.POSTGRESQL_DISALLOW_DUPLICATE_CONNECTIONS);
 
         // Legacy "simultaneous" property dictates only the maximum number of
         // connections per connection
-        if (disallowSimultaneous)
-            connectionDefaultMaxConnections = 1;
-        else
-            connectionDefaultMaxConnections = 0;
+        if (disallowSimultaneous != null) {
+
+            // Translate legacy property
+            if (disallowSimultaneous) {
+                connectionDefaultMaxConnections = 1;
+                connectionGroupDefaultMaxConnections = 0;
+            }
+            else {
+                connectionDefaultMaxConnections = 0;
+                connectionGroupDefaultMaxConnections = 0;
+            }
+
+            // Warn of deprecation
+            logger.warn("The \"{}\" property is deprecated. Use \"{}\" and \"{}\" instead.",
+                    PostgreSQLGuacamoleProperties.POSTGRESQL_DISALLOW_SIMULTANEOUS_CONNECTIONS.getName(),
+                    PostgreSQLGuacamoleProperties.POSTGRESQL_DEFAULT_MAX_CONNECTIONS.getName(),
+                    PostgreSQLGuacamoleProperties.POSTGRESQL_DEFAULT_MAX_GROUP_CONNECTIONS.getName());
+
+            // Inform of new equivalent
+            logger.info("To achieve the same result of setting \"{}\" to \"{}\", set \"{}\" to \"{}\" and \"{}\" to \"{}\".",
+                    PostgreSQLGuacamoleProperties.POSTGRESQL_DISALLOW_SIMULTANEOUS_CONNECTIONS.getName(), disallowSimultaneous,
+                    PostgreSQLGuacamoleProperties.POSTGRESQL_DEFAULT_MAX_CONNECTIONS.getName(),           connectionDefaultMaxConnections,
+                    PostgreSQLGuacamoleProperties.POSTGRESQL_DEFAULT_MAX_GROUP_CONNECTIONS.getName(),     connectionGroupDefaultMaxConnections);
+
+        }
+
+        // If legacy property is not specified, use new property
+        else {
+            connectionDefaultMaxConnections      = environment.getProperty(PostgreSQLGuacamoleProperties.POSTGRESQL_DEFAULT_MAX_CONNECTIONS, 0);
+            connectionGroupDefaultMaxConnections = environment.getProperty(PostgreSQLGuacamoleProperties.POSTGRESQL_DEFAULT_MAX_GROUP_CONNECTIONS, 0);
+        }
 
         // Legacy "duplicate" property dictates whether connections and groups
         // may be used concurrently only by different users
-        if (disallowDuplicate) {
-            connectionDefaultMaxConnectionsPerUser      = 1;
-            connectionGroupDefaultMaxConnectionsPerUser = 1;
+        if (disallowDuplicate != null) {
+
+            // Translate legacy property
+            if (disallowDuplicate) {
+                connectionDefaultMaxConnectionsPerUser      = 1;
+                connectionGroupDefaultMaxConnectionsPerUser = 1;
+            }
+            else {
+                connectionDefaultMaxConnectionsPerUser      = 0;
+                connectionGroupDefaultMaxConnectionsPerUser = 0;
+            }
+
+            // Warn of deprecation
+            logger.warn("The \"{}\" property is deprecated. Use \"{}\" and \"{}\" instead.",
+                    PostgreSQLGuacamoleProperties.POSTGRESQL_DISALLOW_DUPLICATE_CONNECTIONS.getName(),
+                    PostgreSQLGuacamoleProperties.POSTGRESQL_DEFAULT_MAX_CONNECTIONS_PER_USER.getName(),
+                    PostgreSQLGuacamoleProperties.POSTGRESQL_DEFAULT_MAX_GROUP_CONNECTIONS.getName());
+
+            // Inform of new equivalent
+            logger.info("To achieve the same result of setting \"{}\" to \"{}\", set \"{}\" to \"{}\" and \"{}\" to \"{}\".",
+                    PostgreSQLGuacamoleProperties.POSTGRESQL_DISALLOW_DUPLICATE_CONNECTIONS.getName(),         disallowDuplicate,
+                    PostgreSQLGuacamoleProperties.POSTGRESQL_DEFAULT_MAX_CONNECTIONS_PER_USER.getName(),       connectionDefaultMaxConnectionsPerUser,
+                    PostgreSQLGuacamoleProperties.POSTGRESQL_DEFAULT_MAX_GROUP_CONNECTIONS_PER_USER.getName(), connectionGroupDefaultMaxConnectionsPerUser);
+
         }
+
+        // If legacy property is not specified, use new property
         else {
-            connectionDefaultMaxConnectionsPerUser      = 0;
-            connectionGroupDefaultMaxConnectionsPerUser = 0;
+            connectionDefaultMaxConnectionsPerUser      = environment.getProperty(PostgreSQLGuacamoleProperties.POSTGRESQL_DEFAULT_MAX_CONNECTIONS_PER_USER, 1);
+            connectionGroupDefaultMaxConnectionsPerUser = environment.getProperty(PostgreSQLGuacamoleProperties.POSTGRESQL_DEFAULT_MAX_GROUP_CONNECTIONS_PER_USER, 1);
         }
 
         // Return service configured for specified default limits

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/glyptodon/guacamole/auth/postgresql/PostgreSQLAuthenticationProvider.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/glyptodon/guacamole/auth/postgresql/PostgreSQLAuthenticationProvider.java
@@ -91,11 +91,11 @@ public class PostgreSQLAuthenticationProvider implements AuthenticationProvider 
 
             // Translate legacy property
             if (disallowSimultaneous) {
-                connectionDefaultMaxConnections = 1;
+                connectionDefaultMaxConnections      = 1;
                 connectionGroupDefaultMaxConnections = 0;
             }
             else {
-                connectionDefaultMaxConnections = 0;
+                connectionDefaultMaxConnections      = 0;
                 connectionGroupDefaultMaxConnections = 0;
             }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/glyptodon/guacamole/auth/postgresql/PostgreSQLGuacamoleProperties.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/glyptodon/guacamole/auth/postgresql/PostgreSQLGuacamoleProperties.java
@@ -123,5 +123,58 @@ public class PostgreSQLGuacamoleProperties {
         public String getName() { return "postgresql-disallow-duplicate-connections"; }
 
     };
-    
+
+    /**
+     * The maximum number of concurrent connections to allow to any one
+     * connection. Zero denotes unlimited.
+     */
+    public static final IntegerGuacamoleProperty
+            POSTGRESQL_DEFAULT_MAX_CONNECTIONS =
+            new IntegerGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "postgresql-default-max-connections"; }
+
+    };
+
+    /**
+     * The maximum number of concurrent connections to allow to any one
+     * connection group. Zero denotes unlimited.
+     */
+    public static final IntegerGuacamoleProperty
+            POSTGRESQL_DEFAULT_MAX_GROUP_CONNECTIONS =
+            new IntegerGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "postgresql-default-max-group-connections"; }
+
+    };
+
+    /**
+     * The maximum number of concurrent connections to allow to any one
+     * connection by an individual user. Zero denotes unlimited.
+     */
+    public static final IntegerGuacamoleProperty
+            POSTGRESQL_DEFAULT_MAX_CONNECTIONS_PER_USER =
+            new IntegerGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "postgresql-default-max-connections-per-user"; }
+
+    };
+
+    /**
+     * The maximum number of concurrent connections to allow to any one
+     * connection group by an individual user. Zero denotes
+     * unlimited.
+     */
+    public static final IntegerGuacamoleProperty
+            POSTGRESQL_DEFAULT_MAX_GROUP_CONNECTIONS_PER_USER =
+            new IntegerGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "postgresql-default-max-group-connections-per-user"; }
+
+    };
+
 }


### PR DESCRIPTION
This change adds four new concurrency properties for the database auth, replacing the old "duplicate" and "simultaneous" properties. The old properties are still supported, but using them will result in warnings in the logs, along with suggestions for replacing them.

##### New properties for MySQL

1. `mysql-default-max-connections`
2. `mysql-default-max-group-connections`
3. `mysql-default-max-connections-per-user`
4. `mysql-default-max-group-connections-per-user`

##### New properties for PostgreSQL

1. `postgresql-default-max-connections`
2. `postgresql-default-max-group-connections`
3. `postgresql-default-max-connections-per-user`
4. `postgresql-default-max-group-connections-per-user`

For example, if you set `postgresql-disallow-simultaneous-connections: false` within `guacamole.properties`, you will now see the following log messages:

```
WARN  o.g.g.a.p.PostgreSQLAuthenticationProvider - The "postgresql-disallow-simultaneous-connections" property is deprecated. Use "postgresql-default-max-connections" and "postgresql-default-max-group-connections" instead.
INFO  o.g.g.a.p.PostgreSQLAuthenticationProvider - To achieve the same result of setting "postgresql-disallow-simultaneous-connections" to "false", set "postgresql-default-max-connections" to "0" and "postgresql-default-max-group-connections" to "0".
```
