### PR TITLE
GUAC-586: Services must not store stale auth data.

### DIFF
--- a/guacamole/src/main/webapp/app/navigation/services/userPageService.js
+++ b/guacamole/src/main/webapp/app/navigation/services/userPageService.js
@@ -54,14 +54,6 @@ angular.module('navigation').factory('userPageService', ['$injector',
     });
 
     /**
-     * The identifiers of all data sources currently available to the
-     * authenticated user.
-     *
-     * @type String[]
-     */
-    var dataSources = authenticationService.getAvailableDataSources();
-
-    /**
      * Returns an appropriate home page for the current user.
      *
      * @param {Object.<String, ConnectionGroup>} rootGroups
@@ -184,7 +176,7 @@ angular.module('navigation').factory('userPageService', ['$injector',
         var canManageSessions = [];
 
         // Inspect the contents of each provided permission set
-        angular.forEach(dataSources, function inspectPermissions(dataSource) {
+        angular.forEach(authenticationService.getAvailableDataSources(), function inspectPermissions(dataSource) {
 
             // Get permissions for current data source, skipping if non-existent
             var permissions = permissionSets[dataSource];


### PR DESCRIPTION
As `userPageService` is a service which is initialized possibly before the user even logs in, it is not valid to store the available data sources at the service level. They should instead be pulled as needed.