### PR TITLE
GUAC-1280: Bump version numbers to 0.9.8 where appropriate.

### DIFF
--- a/doc/guacamole-example/pom.xml
+++ b/doc/guacamole-example/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole-example</artifactId>
     <packaging>war</packaging>
-    <version>0.9.7</version>
+    <version>0.9.8</version>
     <name>guacamole-example</name>
     <url>http://guac-dev.org/</url>
 
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-common-js</artifactId>
-            <version>0.9.7</version>
+            <version>0.9.8</version>
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/pom.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.glyptodon.guacamole</groupId>
         <artifactId>guacamole-auth-jdbc</artifactId>
-        <version>0.9.7</version>
+        <version>0.9.8</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/pom.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.glyptodon.guacamole</groupId>
         <artifactId>guacamole-auth-jdbc</artifactId>
-        <version>0.9.7</version>
+        <version>0.9.8</version>
         <relativePath>../../</relativePath>
     </parent>
 
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-auth-jdbc-base</artifactId>
-            <version>0.9.7</version>
+            <version>0.9.8</version>
         </dependency>
 
     </dependencies>

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "0.9.7",
+    "guacamoleVersion" : "0.9.8",
 
     "name"      : "MySQL Authentication",
     "namespace" : "guac-mysql",

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/pom.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.glyptodon.guacamole</groupId>
         <artifactId>guacamole-auth-jdbc</artifactId>
-        <version>0.9.7</version>
+        <version>0.9.8</version>
         <relativePath>../../</relativePath>
     </parent>
 
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-auth-jdbc-base</artifactId>
-            <version>0.9.7</version>
+            <version>0.9.8</version>
         </dependency>
 
     </dependencies>

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "0.9.7",
+    "guacamoleVersion" : "0.9.8",
 
     "name"      : "PostgreSQL Authentication",
     "namespace" : "guac-postgresql",

--- a/extensions/guacamole-auth-jdbc/pom.xml
+++ b/extensions/guacamole-auth-jdbc/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole-auth-jdbc</artifactId>
     <packaging>pom</packaging>
-    <version>0.9.7</version>
+    <version>0.9.8</version>
     <name>guacamole-auth-jdbc</name>
     <url>http://guac-dev.org/</url>
 
@@ -62,7 +62,7 @@
             <dependency>
                 <groupId>org.glyptodon.guacamole</groupId>
                 <artifactId>guacamole-ext</artifactId>
-                <version>0.9.7</version>
+                <version>0.9.8</version>
                 <scope>provided</scope>
             </dependency>
 

--- a/extensions/guacamole-auth-ldap/pom.xml
+++ b/extensions/guacamole-auth-ldap/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole-auth-ldap</artifactId>
     <packaging>jar</packaging>
-    <version>0.9.7</version>
+    <version>0.9.8</version>
     <name>guacamole-auth-ldap</name>
     <url>http://guac-dev.org/</url>
 
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>0.9.7</version>
+            <version>0.9.8</version>
             <scope>provided</scope>
         </dependency>
 

--- a/extensions/guacamole-auth-ldap/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-ldap/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "0.9.7",
+    "guacamoleVersion" : "0.9.8",
 
     "name"      : "LDAP Authentication",
     "namespace" : "guac-ldap",

--- a/extensions/guacamole-auth-noauth/pom.xml
+++ b/extensions/guacamole-auth-noauth/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole-auth-noauth</artifactId>
     <packaging>jar</packaging>
-    <version>0.9.7</version>
+    <version>0.9.8</version>
     <name>guacamole-auth-noauth</name>
     <url>http://guacamole.sourceforge.net/</url>
 
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>0.9.7</version>
+            <version>0.9.8</version>
             <scope>provided</scope>
         </dependency>
 

--- a/extensions/guacamole-auth-noauth/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-noauth/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "0.9.7",
+    "guacamoleVersion" : "0.9.8",
 
     "name"      : "Disabled Authentication",
     "namespace" : "guac-noauth",

--- a/guacamole-common-js/pom.xml
+++ b/guacamole-common-js/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole-common-js</artifactId>
     <packaging>pom</packaging>
-    <version>0.9.7</version>
+    <version>0.9.8</version>
     <name>guacamole-common-js</name>
     <url>http://guac-dev.org/</url>
 

--- a/guacamole-ext/pom.xml
+++ b/guacamole-ext/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole-ext</artifactId>
     <packaging>jar</packaging>
-    <version>0.9.7</version>
+    <version>0.9.8</version>
     <name>guacamole-ext</name>
     <url>http://guac-dev.org/</url>
 

--- a/guacamole/pom.xml
+++ b/guacamole/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole</artifactId>
     <packaging>war</packaging>
-    <version>0.9.7</version>
+    <version>0.9.8</version>
     <name>guacamole</name>
     <url>http://guac-dev.org/</url>
 
@@ -227,14 +227,14 @@
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>0.9.7</version>
+            <version>0.9.8</version>
         </dependency>
 
         <!-- Guacamole JavaScript API -->
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-common-js</artifactId>
-            <version>0.9.7</version>
+            <version>0.9.8</version>
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>

--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/extension/ExtensionModule.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/extension/ExtensionModule.java
@@ -65,7 +65,7 @@ public class ExtensionModule extends ServletModule {
     private static final List<String> ALLOWED_GUACAMOLE_VERSIONS =
         Collections.unmodifiableList(Arrays.asList(
             "*",
-            "0.9.7"
+            "0.9.8"
         ));
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole-client</artifactId>
     <packaging>pom</packaging>
-    <version>0.9.7</version>
+    <version>0.9.8</version>
     <name>guacamole-client</name>
     <url>http://guac-dev.org/</url>
 


### PR DESCRIPTION
Bumping version for the 0.9.8 release. The only component that didn't change within guacamole-client is guacamole-common. The following should ALL be bumped:

1. guacamole-client
2. guacamole
3. guacamole-common-js
3. guacamole-ext
4. guacamole-auth-jdbc (MySQL and PostgreSQL modules, too)
5. guacamole-auth-ldap
6. guacamole-auth-noauth

With the recent changes in 0.9.7 regarding `guac-manifest.json` and the `guacamoleVersion` property, we have to bump the versions within each `guac-manifest.json`, not just `pom.xml`, as well as within `ExtensionModule` (the class that checks that value).