### PR TITLE
GUAC-1322: Fix Guacamole.Keyboard keyup fallback

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Keyboard.js
+++ b/guacamole-common-js/src/main/webapp/modules/Keyboard.js
@@ -933,13 +933,18 @@ Guacamole.Keyboard = function(element) {
         // Keyup event
         else if (first instanceof KeyupEvent) {
 
+            // Release specific key if known
             var keysym = first.keysym;
             if (keysym) {
                 guac_keyboard.release(keysym);
                 first.defaultPrevented = true;
             }
-            else
+
+            // Otherwise, fall back to releasing all keys
+            else {
                 guac_keyboard.reset();
+                return first;
+            }
 
             return eventLog.shift();
 


### PR DESCRIPTION
From [GUAC-1322](https://glyptodon.org/jira/browse/GUAC-1322):

> If a keyup event is received for an unknown key (no corresponding keysym), all keys are released as a fallback. This is good, but it also clears the event log, causing `interpret_event()` within `Guacamole.Keyboard` to return `undefined` instead of the handled event (or `null`), ultimately causing the event interpreter to throw an exception:
> 
> ![defaultprevented-error](https://cloud.githubusercontent.com/assets/4632905/9697721/22ff083e-534e-11e5-8f3d-25e3b89e319a.png)

This change fixes `interpret_event()` such that it always returns the interpreted event, as required by its definition, or `null` if no event is interpreted. It must *never* return `undefined`.