### PR TITLE
GUAC-1334: Fix the horribly-broken location chooser

### DIFF
--- a/guacamole/src/main/webapp/app/manage/controllers/manageConnectionController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageConnectionController.js
@@ -62,7 +62,7 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
      *
      * @type String
      */
-    var dataSource = $routeParams.dataSource;
+    $scope.selectedDataSource = $routeParams.dataSource;
 
     /**
      * The identifier of the original connection from which this connection is
@@ -186,14 +186,14 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
     };
 
     // Pull connection attribute schema
-    schemaService.getConnectionAttributes(dataSource)
+    schemaService.getConnectionAttributes($scope.selectedDataSource)
     .success(function attributesReceived(attributes) {
         $scope.attributes = attributes;
     });
 
     // Pull connection group hierarchy
     connectionGroupService.getConnectionGroupTree(
-        dataSource,
+        $scope.selectedDataSource,
         ConnectionGroup.ROOT_IDENTIFIER,
         [PermissionSet.ObjectPermissionType.ADMINISTER]
     )
@@ -202,7 +202,7 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
     });
     
     // Query the user's permissions for the current connection
-    permissionService.getPermissions(dataSource, authenticationService.getCurrentUsername())
+    permissionService.getPermissions($scope.selectedDataSource, authenticationService.getCurrentUsername())
     .success(function permissionsReceived(permissions) {
                 
         $scope.permissions = permissions;
@@ -232,7 +232,7 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
     });
    
     // Get protocol metadata
-    schemaService.getProtocols(dataSource)
+    schemaService.getProtocols($scope.selectedDataSource)
     .success(function protocolsReceived(protocols) {
         $scope.protocols = protocols;
     });
@@ -246,13 +246,13 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
     if (identifier) {
 
         // Pull data from existing connection
-        connectionService.getConnection(dataSource, identifier)
+        connectionService.getConnection($scope.selectedDataSource, identifier)
         .success(function connectionRetrieved(connection) {
             $scope.connection = connection;
         });
 
         // Pull connection history
-        connectionService.getConnectionHistory(dataSource, identifier)
+        connectionService.getConnectionHistory($scope.selectedDataSource, identifier)
         .success(function historyReceived(historyEntries) {
 
             // Wrap all history entries for sake of display
@@ -264,7 +264,7 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
         });
 
         // Pull connection parameters
-        connectionService.getConnectionParameters(dataSource, identifier)
+        connectionService.getConnectionParameters($scope.selectedDataSource, identifier)
         .success(function parametersReceived(parameters) {
             $scope.parameters = parameters;
         });
@@ -274,7 +274,7 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
     else if (cloneSourceIdentifier) {
 
         // Pull data from cloned connection
-        connectionService.getConnection(dataSource, cloneSourceIdentifier)
+        connectionService.getConnection($scope.selectedDataSource, cloneSourceIdentifier)
         .success(function connectionRetrieved(connection) {
             $scope.connection = connection;
             
@@ -286,7 +286,7 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
         $scope.historyEntryWrappers = [];
         
         // Pull connection parameters from cloned connection
-        connectionService.getConnectionParameters(dataSource, cloneSourceIdentifier)
+        connectionService.getConnectionParameters($scope.selectedDataSource, cloneSourceIdentifier)
         .success(function parametersReceived(parameters) {
             $scope.parameters = parameters;
         });
@@ -350,7 +350,7 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
      * Cancels all pending edits, returning to the management page.
      */
     $scope.cancel = function cancel() {
-        $location.path('/settings/' + encodeURIComponent(dataSource) + '/connections');
+        $location.path('/settings/' + encodeURIComponent($scope.selectedDataSource) + '/connections');
     };
     
     /**
@@ -358,7 +358,7 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
      * which is prepopulated with the data from the connection currently being edited. 
      */
     $scope.cloneConnection = function cloneConnection() {
-        $location.path('/manage/' + encodeURIComponent(dataSource) + '/connections').search('clone', identifier);
+        $location.path('/manage/' + encodeURIComponent($scope.selectedDataSource) + '/connections').search('clone', identifier);
     };
             
     /**
@@ -370,9 +370,9 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
         $scope.connection.parameters = $scope.parameters;
 
         // Save the connection
-        connectionService.saveConnection(dataSource, $scope.connection)
+        connectionService.saveConnection($scope.selectedDataSource, $scope.connection)
         .success(function savedConnection() {
-            $location.path('/settings/' + encodeURIComponent(dataSource) + '/connections');
+            $location.path('/settings/' + encodeURIComponent($scope.selectedDataSource) + '/connections');
         })
 
         // Notify of any errors
@@ -420,9 +420,9 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
     var deleteConnectionImmediately = function deleteConnectionImmediately() {
 
         // Delete the connection
-        connectionService.deleteConnection(dataSource, $scope.connection)
+        connectionService.deleteConnection($scope.selectedDataSource, $scope.connection)
         .success(function deletedConnection() {
-            $location.path('/settings/' + encodeURIComponent(dataSource) + '/connections');
+            $location.path('/settings/' + encodeURIComponent($scope.selectedDataSource) + '/connections');
         })
 
         // Notify of any errors

--- a/guacamole/src/main/webapp/app/manage/controllers/manageConnectionGroupController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageConnectionGroupController.js
@@ -57,7 +57,7 @@ angular.module('manage').controller('manageConnectionGroupController', ['$scope'
      *
      * @type String
      */
-    var dataSource = $routeParams.dataSource;
+    $scope.selectedDataSource = $routeParams.dataSource;
 
     /**
      * The identifier of the connection group being edited. If a new connection
@@ -131,13 +131,13 @@ angular.module('manage').controller('manageConnectionGroupController', ['$scope'
     };
     
     // Pull connection group attribute schema
-    schemaService.getConnectionGroupAttributes(dataSource)
+    schemaService.getConnectionGroupAttributes($scope.selectedDataSource)
     .success(function attributesReceived(attributes) {
         $scope.attributes = attributes;
     });
 
     // Query the user's permissions for the current connection group
-    permissionService.getPermissions(dataSource, authenticationService.getCurrentUsername())
+    permissionService.getPermissions($scope.selectedDataSource, authenticationService.getCurrentUsername())
     .success(function permissionsReceived(permissions) {
                 
         $scope.permissions = permissions;
@@ -160,7 +160,7 @@ angular.module('manage').controller('manageConnectionGroupController', ['$scope'
 
     // Pull connection group hierarchy
     connectionGroupService.getConnectionGroupTree(
-        dataSource,
+        $scope.selectedDataSource,
         ConnectionGroup.ROOT_IDENTIFIER,
         [PermissionSet.ObjectPermissionType.ADMINISTER]
     )
@@ -170,7 +170,7 @@ angular.module('manage').controller('manageConnectionGroupController', ['$scope'
 
     // If we are editing an existing connection group, pull its data
     if (identifier) {
-        connectionGroupService.getConnectionGroup(dataSource, identifier)
+        connectionGroupService.getConnectionGroup($scope.selectedDataSource, identifier)
         .success(function connectionGroupReceived(connectionGroup) {
             $scope.connectionGroup = connectionGroup;
         });
@@ -201,7 +201,7 @@ angular.module('manage').controller('manageConnectionGroupController', ['$scope'
      * Cancels all pending edits, returning to the management page.
      */
     $scope.cancel = function cancel() {
-        $location.path('/settings/' + encodeURIComponent(dataSource) + '/connections');
+        $location.path('/settings/' + encodeURIComponent($scope.selectedDataSource) + '/connections');
     };
    
     /**
@@ -211,9 +211,9 @@ angular.module('manage').controller('manageConnectionGroupController', ['$scope'
     $scope.saveConnectionGroup = function saveConnectionGroup() {
 
         // Save the connection
-        connectionGroupService.saveConnectionGroup(dataSource, $scope.connectionGroup)
+        connectionGroupService.saveConnectionGroup($scope.selectedDataSource, $scope.connectionGroup)
         .success(function savedConnectionGroup() {
-            $location.path('/settings/' + encodeURIComponent(dataSource) + '/connections');
+            $location.path('/settings/' + encodeURIComponent($scope.selectedDataSource) + '/connections');
         })
 
         // Notify of any errors
@@ -261,9 +261,9 @@ angular.module('manage').controller('manageConnectionGroupController', ['$scope'
     var deleteConnectionGroupImmediately = function deleteConnectionGroupImmediately() {
 
         // Delete the connection group
-        connectionGroupService.deleteConnectionGroup(dataSource, $scope.connectionGroup)
+        connectionGroupService.deleteConnectionGroup($scope.selectedDataSource, $scope.connectionGroup)
         .success(function deletedConnectionGroup() {
-            $location.path('/settings/' + encodeURIComponent(dataSource) + '/connections');
+            $location.path('/settings/' + encodeURIComponent($scope.selectedDataSource) + '/connections');
         })
 
         // Notify of any errors

--- a/guacamole/src/main/webapp/app/manage/directives/locationChooser.js
+++ b/guacamole/src/main/webapp/app/manage/directives/locationChooser.js
@@ -34,6 +34,14 @@ angular.module('manage').directive('locationChooser', [function locationChooser(
         scope: {
 
             /**
+             * The identifier of the data source from which the given root
+             * connection group was retrieved.
+             *
+             * @type String
+             */
+            dataSource : '=',
+
+            /**
              * The root connection group of the connection group hierarchy to
              * display.
              *
@@ -104,6 +112,19 @@ angular.module('manage').directive('locationChooser', [function locationChooser(
             $scope.toggleMenu = function toggleMenu() {
                 $scope.menuOpen = !$scope.menuOpen;
             };
+
+            // Update the root group map when data source or root group change
+            $scope.$watchGroup(['dataSource', 'rootGroup'], function updateRootGroups() {
+
+                // Abort if the root group is not set
+                if (!$scope.dataSource || !$scope.rootGroup)
+                    return null;
+
+                // Wrap root group in map
+                $scope.rootGroups = {};
+                $scope.rootGroups[$scope.dataSource] = $scope.rootGroup;
+
+            });
 
             // Expose selection function to group list template
             $scope.groupListContext = {

--- a/guacamole/src/main/webapp/app/manage/templates/locationChooser.html
+++ b/guacamole/src/main/webapp/app/manage/templates/locationChooser.html
@@ -29,7 +29,7 @@
         <guac-group-list
             context="groupListContext"
             show-root-group="true"
-            connection-group="rootGroup"
+            connection-groups="rootGroups"
             connection-group-template="'app/manage/templates/locationChooserConnectionGroup.html'"/>
     </div>
 

--- a/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
@@ -42,7 +42,9 @@ THE SOFTWARE.
                 <th>{{'MANAGE_CONNECTION.FIELD_HEADER_LOCATION' | translate}}</th>
               
                 <td>
-                    <location-chooser value="connection.parentIdentifier" root-group="rootGroup"></location-chooser>
+                    <location-chooser
+                        data-data-source="selectedDataSource" root-group="rootGroup"
+                        value="connection.parentIdentifier"></location-chooser>
                 </td>
             </tr>
             

--- a/guacamole/src/main/webapp/app/manage/templates/manageConnectionGroup.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageConnectionGroup.html
@@ -42,7 +42,9 @@ THE SOFTWARE.
                 <th>{{'MANAGE_CONNECTION_GROUP.FIELD_HEADER_LOCATION' | translate}}</th>
                           
                 <td>
-                    <location-chooser value="connectionGroup.parentIdentifier" root-group="rootGroup"/>
+                    <location-chooser
+                        data-data-source="selectedDataSource" root-group="rootGroup"
+                        value="connectionGroup.parentIdentifier"></location-chooser>
                 </td>
             </tr>
                         


### PR DESCRIPTION
The location chooser directive was not updated to use the updated `guacGroupList`. This fixes it.