### PR TITLE
GUAC-1305: Add image mimetypes to Guacamole protocol handshake.

### DIFF
--- a/guacamole-common/src/main/java/org/glyptodon/guacamole/protocol/ConfiguredGuacamoleSocket.java
+++ b/guacamole-common/src/main/java/org/glyptodon/guacamole/protocol/ConfiguredGuacamoleSocket.java
@@ -183,6 +183,13 @@ public class ConfiguredGuacamoleSocket implements GuacamoleSocket {
                     info.getVideoMimetypes().toArray(new String[0])
                 ));
 
+        // Send supported image formats
+        writer.writeInstruction(
+                new GuacamoleInstruction(
+                    "image",
+                    info.getImageMimetypes().toArray(new String[0])
+                ));
+
         // Send args
         writer.writeInstruction(new GuacamoleInstruction("connect", arg_values));
 

--- a/guacamole-common/src/main/java/org/glyptodon/guacamole/protocol/GuacamoleClientInformation.java
+++ b/guacamole-common/src/main/java/org/glyptodon/guacamole/protocol/GuacamoleClientInformation.java
@@ -55,9 +55,14 @@ public class GuacamoleClientInformation {
     private final List<String> audioMimetypes = new ArrayList<String>();
 
     /**
-     * The list of audio mimetypes reported by the client to be supported.
+     * The list of video mimetypes reported by the client to be supported.
      */
     private final List<String> videoMimetypes = new ArrayList<String>();
+
+    /**
+     * The list of image mimetypes reported by the client to be supported.
+     */
+    private final List<String> imageMimetypes = new ArrayList<String>();
 
     /**
      * Returns the optimal screen width requested by the client, in pixels.
@@ -131,6 +136,18 @@ public class GuacamoleClientInformation {
      */
     public List<String> getVideoMimetypes() {
         return videoMimetypes;
+    }
+
+    /**
+     * Returns the list of image mimetypes supported by the client. To add or
+     * removed supported mimetypes, the list returned by this function can be
+     * modified.
+     *
+     * @return
+     *     The set of image mimetypes supported by the client.
+     */
+    public List<String> getImageMimetypes() {
+        return imageMimetypes;
     }
 
 }

--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/TunnelRequest.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/TunnelRequest.java
@@ -93,6 +93,13 @@ public abstract class TunnelRequest {
     public static final String VIDEO_PARAMETER = "GUAC_VIDEO";
 
     /**
+     * The name of the parameter specifying one supported image mimetype. This
+     * will normally appear multiple times within a single tunnel request -
+     * once for each mimetype.
+     */
+    public static final String IMAGE_PARAMETER = "GUAC_IMAGE";
+
+    /**
      * All supported object types that can be used as the destination of a
      * tunnel.
      */
@@ -348,6 +355,18 @@ public abstract class TunnelRequest {
      */
     public List<String> getVideoMimetypes() {
         return getParameterValues(VIDEO_PARAMETER);
+    }
+
+    /**
+     * Returns a list of all image mimetypes declared as supported within the
+     * tunnel request.
+     *
+     * @return
+     *     A list of all image mimetypes declared as supported within the
+     *     tunnel request, or null if no mimetypes were specified.
+     */
+    public List<String> getImageMimetypes() {
+        return getParameterValues(IMAGE_PARAMETER);
     }
 
 }

--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/TunnelRequestService.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/TunnelRequestService.java
@@ -114,6 +114,11 @@ public class TunnelRequestService {
         if (videoMimetypes != null)
             info.getVideoMimetypes().addAll(videoMimetypes);
 
+        // Add image mimetypes
+        List<String> imageMimetypes = request.getImageMimetypes();
+        if (imageMimetypes != null)
+            info.getImageMimetypes().addAll(imageMimetypes);
+
         return info;
     }
 

--- a/guacamole/src/main/webapp/app/client/services/guacImage.js
+++ b/guacamole/src/main/webapp/app/client/services/guacImage.js
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2015 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * A service for checking browser image support.
+ */
+angular.module('client').factory('guacImage', ['$injector', function guacImage($injector) {
+
+    // Required services
+    var $q = $injector.get('$q');
+
+    var service = {};
+
+    /**
+     * Map of possibly-supported image mimetypes to corresponding test images
+     * encoded with base64. If the image is correctly decoded, it will be a
+     * single pixel (1x1) image.
+     *
+     * @type Object.<String, String>
+     */
+    var testImages = {
+
+        /**
+         * Test JPEG image, encoded as base64.
+         */
+        'image/jpeg' :
+            '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoH'
+          + 'BwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/2wBDAQME'
+          + 'BAUEBQkFBQkUDQsNFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQU'
+          + 'FBQUFBQUFBQUFBQUFBT/wAARCAABAAEDAREAAhEBAxEB/8QAFAABAAAAAAAAAAA'
+          + 'AAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/xAAUAQEAAAAAAAAAAAAAAA'
+          + 'AAAAAA/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8AVMH/2Q==',
+
+        /**
+         * Test PNG image, encoded as base64.
+         */
+        'image/png' :
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEX///+nxBvI'
+          + 'AAAACklEQVQI12NgAAAAAgAB4iG8MwAAAABJRU5ErkJggg=='
+
+    };
+
+    /**
+     * Return a promise which resolves with to an array of image mimetypes
+     * supported by the browser, once those mimetypes are known. The returned
+     * promise is guaranteed to resolve successfully.
+     *
+     * @returns {Promise.<String[]>}
+     *     A promise which resolves with an array of image mimetypes supported
+     *     by the browser.
+     */
+    service.getSupportedMimetypes = function getSupportedMimetypes() {
+
+        var deferred = $q.defer();
+
+        var supported = [];
+        var pendingTests = [];
+
+        // Test each possibly-supported image
+        angular.forEach(testImages, function testImageSupport(data, mimetype) {
+
+            // Add promise for current image test
+            var imageTest = $q.defer();
+            pendingTests.push(imageTest.promise);
+
+            // Attempt to load image
+            var image = new Image();
+            image.src = 'data:' + mimetype + ';base64,' + data;
+
+            // Store as supported depending on whether load was successful
+            image.onload = image.onerror = function imageTestComplete() {
+
+                // Image format is supported if successfully decoded
+                if (image.width === 1 && image.height === 1)
+                    supported.push(mimetype);
+
+                // Test is complete
+                imageTest.resolve();
+
+            };
+
+        });
+
+        // When all image tests are complete, resolve promise with list of
+        // supported formats
+        $q.all(pendingTests).then(function imageTestsCompleted() {
+            deferred.resolve(supported);
+        });
+
+        return deferred.promise;
+
+    };
+
+    return service;
+
+}]);


### PR DESCRIPTION
This change adds a promise-based version of the `guacImage` service - a service which was originally introduced within #246, a PR which is being split into smaller pieces such that the WEBP-specific changes can be separate.