### PR TITLE
GUAC-1345: Restrict available languages if explicitly configured

### DIFF
--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/extension/ExtensionModule.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/extension/ExtensionModule.java
@@ -100,7 +100,7 @@ public class ExtensionModule extends ServletModule {
     /**
      * Service for adding and retrieving language resources.
      */
-    private final LanguageResourceService languageResourceService = new LanguageResourceService();
+    private final LanguageResourceService languageResourceService;
     
     /**
      * Returns the classloader that should be used as the parent classloader
@@ -139,6 +139,7 @@ public class ExtensionModule extends ServletModule {
      */
     public ExtensionModule(Environment environment) {
         this.environment = environment;
+        this.languageResourceService = new LanguageResourceService(environment);
     }
 
     /**

--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/properties/BasicGuacamoleProperties.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/properties/BasicGuacamoleProperties.java
@@ -24,6 +24,7 @@ package org.glyptodon.guacamole.net.basic.properties;
 
 import org.glyptodon.guacamole.properties.FileGuacamoleProperty;
 import org.glyptodon.guacamole.properties.IntegerGuacamoleProperty;
+import org.glyptodon.guacamole.properties.StringGuacamoleProperty;
 
 /**
  * Properties used by the default Guacamole web application.
@@ -70,6 +71,19 @@ public class BasicGuacamoleProperties {
 
         @Override
         public String getName() { return "api-session-timeout"; }
+
+    };
+
+    /**
+     * Comma-separated list of all allowed languages, where each language is
+     * represented by a language key, such as "en" or "en_US". If specified,
+     * only languages within this list will be listed as available by the REST
+     * service.
+     */
+    public static final StringSetProperty ALLOWED_LANGUAGES = new StringSetProperty() {
+
+        @Override
+        public String getName() { return "allowed-languages"; }
 
     };
 

--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/properties/StringSetProperty.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/properties/StringSetProperty.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2015 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.glyptodon.guacamole.net.basic.properties;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.glyptodon.guacamole.GuacamoleException;
+import org.glyptodon.guacamole.properties.GuacamoleProperty;
+
+/**
+ * A GuacamoleProperty whose value is a Set of unique Strings. The string value
+ * parsed to produce this set is a comma-delimited list. Duplicate values are
+ * ignored, as is any whitespace following delimiters. To maintain
+ * compatibility with the behavior of Java properties in general, only
+ * whitespace at the beginning of each value is ignored; trailing whitespace
+ * becomes part of the value.
+ *
+ * @author Michael Jumper
+ */
+public abstract class StringSetProperty implements GuacamoleProperty<Set<String>> {
+
+    /**
+     * A pattern which matches against the delimiters between values. This is
+     * currently simply a comma and any following whitespace. Parts of the
+     * input string which match this pattern will not be included in the parsed
+     * result.
+     */
+    private static final Pattern DELIMITER_PATTERN = Pattern.compile(",\\s*");
+
+    @Override
+    public Set<String> parseValue(String values) throws GuacamoleException {
+
+        // If no property provided, return null.
+        if (values == null)
+            return null;
+
+        // Split string into a set of individual values
+        List<String> valueList = Arrays.asList(DELIMITER_PATTERN.split(values));
+        return new HashSet<String>(valueList);
+
+    }
+
+}


### PR DESCRIPTION
This change adds a new `allowed-languages` property which restricts the languages used within the web application. The value of this property is a comma-separated list of language keys.

If specified, languages whose keys are not within the `allowed-languages` list will not be used by the translation service (even if explicitly requested), and will not be listed as choices within the preferences screen, though the original JSON will remain accessible via direct HTTP.