### PR TITLE
GUAC-1193: Fix the history sort order

### DIFF
--- a/guacamole/src/main/webapp/app/settings/directives/guacSettingsConnectionHistory.js
+++ b/guacamole/src/main/webapp/app/settings/directives/guacSettingsConnectionHistory.js
@@ -81,9 +81,9 @@ angular.module('settings').directive('guacSettingsConnectionHistory', [function 
              * @type SortOrder
              */
             $scope.order = new SortOrder([
+                '-startDate',
+                '-endDate',
                 'username',
-                'startDate',
-                'endDate',
                 'connectionName'
             ]);
 


### PR DESCRIPTION
Sorting mainly by username for historical records is just silly. The records should default to being sorted chronologically, with the most recent records first.