### PR TITLE
GUAC-1193: Improve history search usability

### DIFF
--- a/guacamole/src/main/webapp/app/navigation/services/userPageService.js
+++ b/guacamole/src/main/webapp/app/navigation/services/userPageService.js
@@ -211,8 +211,9 @@ angular.module('navigation').factory('userPageService', ['$injector',
 
                     // Permission to administer users
                     || PermissionSet.hasUserPermission(permissions, PermissionSet.ObjectPermissionType.ADMINISTER)
-            )
+            ) {
                 canManageUsers.push(dataSource);
+            }
 
             // Determine whether the current user needs access to the connection management UI
             if (
@@ -232,16 +233,18 @@ angular.module('navigation').factory('userPageService', ['$injector',
                     // Permission to administer connections or connection groups
                     || PermissionSet.hasConnectionPermission(permissions,      PermissionSet.ObjectPermissionType.ADMINISTER)
                     || PermissionSet.hasConnectionGroupPermission(permissions, PermissionSet.ObjectPermissionType.ADMINISTER)
-            )
+            ) {
                 canManageConnections.push(dataSource);
+            }
 
             // Determine whether the current user needs access to the session management UI or view connection history
             if (
                     // A user must be a system administrator to manage sessions
                     PermissionSet.hasSystemPermission(permissions, PermissionSet.SystemPermissionType.ADMINISTER)
-            )
+            ) {
                 canManageSessions.push(dataSource);
                 canViewConnectionRecords.push(dataSource);
+            }
 
         });
 

--- a/guacamole/src/main/webapp/app/settings/directives/guacSettingsConnectionHistory.js
+++ b/guacamole/src/main/webapp/app/settings/directives/guacSettingsConnectionHistory.js
@@ -110,7 +110,20 @@ angular.module('settings').directive('guacSettingsConnectionHistory', [function 
                 return $scope.historyRecords !== null
                     && $scope.dateFormat     !== null;
             };
-            
+
+            /**
+             * Returns whether the search has completed but contains no history
+             * records. This function will return false if there are history
+             * records in the results OR if the search has not yet completed.
+             *
+             * @returns {Boolean}
+             *     true if the search results have been loaded but no history
+             *     records are present, false otherwise.
+             */
+            $scope.isHistoryEmpty = function isHistoryEmpty() {
+                return $scope.isLoaded() && $scope.historyRecords.length === 0;
+            };
+
             /**
              * Query the API for the connection record history, filtered by 
              * searchString, and ordered by order.

--- a/guacamole/src/main/webapp/app/settings/templates/settingsConnectionHistory.html
+++ b/guacamole/src/main/webapp/app/settings/templates/settingsConnectionHistory.html
@@ -31,7 +31,7 @@
     </form>
 
     <!-- Search results -->
-    <div class="results" ng-class="{loading: !isLoaded()}">
+    <div class="results">
 
         <!-- List of matching history records -->
         <table class="sorted history-list">
@@ -51,7 +51,7 @@
                     </th>
                 </tr>
             </thead>
-            <tbody>
+            <tbody ng-class="{loading: !isLoaded()}">
                 <tr ng-repeat="historyRecord in historyRecordPage" class="history">
                     <td>{{historyRecord.username}}</td>
                     <td>{{historyRecord.startDate | date : dateFormat}}</td>
@@ -62,7 +62,7 @@
         </table>
 
         <!-- Text displayed if no history exists -->
-        <p class="placeholder" ng-hide="historyRecordPage.length">
+        <p class="placeholder" ng-show="isHistoryEmpty()">
             {{'SETTINGS_CONNECTION_HISTORY.INFO_NO_HISTORY' | translate}}
         </p>
 


### PR DESCRIPTION
This change fixes two usability issues with the new history search interface:

1. *ALL* users were given access to the history list, not only admins. This is technically fine from a security perspective, as visibility is always limited to only those records related to objects they can `READ`, but it's not what we meant.
2. The entire search table hides during searches. When the search takes a second or two, this is very disconcerting. It is better if only the table body is hidden - the header should remain.