### PR TITLE
GUAC-1115: Add support for complex LDAP directory layouts

### DIFF
--- a/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/AuthenticationProviderService.java
@@ -95,8 +95,6 @@ public class AuthenticationProviderService {
 
         // Pull username attributes from properties
         List<String> usernameAttributes = confService.getUsernameAttributes();
-        if (usernameAttributes.isEmpty())
-            return null;
 
         // We need exactly one base DN to derive the user DN
         if (usernameAttributes.size() != 1)

--- a/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/AuthenticationProviderService.java
@@ -109,6 +109,12 @@ public class AuthenticationProviderService {
                 confService.getSearchBindPassword()
             );
 
+            // Warn of failure to find
+            if (searchConnection == null) {
+                logger.error("Unable to bind using search DN \"{}\"", searchBindDN);
+                return null;
+            }
+
             try {
 
                 // Retrieve all DNs associated with the given username

--- a/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/AuthenticationProviderService.java
@@ -97,8 +97,10 @@ public class AuthenticationProviderService {
         List<String> usernameAttributes = confService.getUsernameAttributes();
 
         // We need exactly one base DN to derive the user DN
-        if (usernameAttributes.size() != 1)
+        if (usernameAttributes.size() != 1) {
+            logger.warn("Cannot directly derive user DN when multiple username attributes are specified");
             return null;
+        }
 
         // Derive user DN from base DN
         return

--- a/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/AuthenticationProviderService.java
@@ -27,10 +27,10 @@ import com.google.inject.Provider;
 import com.novell.ldap.LDAPConnection;
 import com.novell.ldap.LDAPException;
 import java.io.UnsupportedEncodingException;
-import java.util.List;
 import org.glyptodon.guacamole.auth.ldap.user.AuthenticatedUser;
 import org.glyptodon.guacamole.auth.ldap.user.UserContext;
 import org.glyptodon.guacamole.GuacamoleException;
+import org.glyptodon.guacamole.auth.ldap.user.UserService;
 import org.glyptodon.guacamole.net.auth.Credentials;
 import org.glyptodon.guacamole.net.auth.credentials.CredentialsInfo;
 import org.glyptodon.guacamole.net.auth.credentials.GuacamoleInvalidCredentialsException;
@@ -51,16 +51,16 @@ public class AuthenticationProviderService {
     private final Logger logger = LoggerFactory.getLogger(AuthenticationProviderService.class);
 
     /**
-     * Service for escaping parts of LDAP queries.
-     */
-    @Inject
-    private EscapingService escapingService;
-
-    /**
      * Service for retrieving LDAP server configuration information.
      */
     @Inject
     private ConfigurationService confService;
+
+    /**
+     * Service for retrieving users and their corresponding LDAP DNs.
+     */
+    @Inject
+    private UserService userService;
 
     /**
      * Provider for AuthenticatedUser objects.
@@ -93,20 +93,8 @@ public class AuthenticationProviderService {
     private String getUserBindDN(String username)
             throws GuacamoleException {
 
-        // Pull username attributes from properties
-        List<String> usernameAttributes = confService.getUsernameAttributes();
-
-        // We need exactly one base DN to derive the user DN
-        if (usernameAttributes.size() != 1) {
-            logger.warn("Cannot directly derive user DN when multiple username attributes are specified");
-            return null;
-        }
-
         // Derive user DN from base DN
-        return
-                    escapingService.escapeDN(usernameAttributes.get(0))
-            + "=" + escapingService.escapeDN(username)
-            + "," + confService.getUserBaseDN();
+        return userService.deriveUserDN(username);
 
     }
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/AuthenticationProviderService.java
@@ -209,6 +209,7 @@ public class AuthenticationProviderService {
             catch (UnsupportedEncodingException e) {
                 logger.error("Unexpected lack of support for UTF-8: {}", e.getMessage());
                 logger.debug("Support for UTF-8 (as required by Java spec) not found.", e);
+                disconnect(ldapConnection);
                 return null;
             }
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/ConfigurationService.java
@@ -117,18 +117,19 @@ public class ConfigurationService {
 
     /**
      * Returns the base DN under which all Guacamole configurations
-     * (connections) will be stored within the LDAP directory.
+     * (connections) will be stored within the LDAP directory. If Guacamole
+     * configurations will not be stored within LDAP, null is returned.
      *
      * @return
      *     The base DN under which all Guacamole configurations will be stored
-     *     within the LDAP directory.
+     *     within the LDAP directory, or null if no Guacamole configurations
+     *     will be stored within the LDAP directory.
      *
      * @throws GuacamoleException
-     *     If guacamole.properties cannot be parsed, or if the configuration
-     *     base DN property is not specified.
+     *     If guacamole.properties cannot be parsed.
      */
     public String getConfigurationBaseDN() throws GuacamoleException {
-        return environment.getRequiredProperty(
+        return environment.getProperty(
             LDAPGuacamoleProperties.LDAP_CONFIG_BASE_DN
         );
     }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/ConfigurationService.java
@@ -23,6 +23,8 @@
 package org.glyptodon.guacamole.auth.ldap;
 
 import com.google.inject.Inject;
+import java.util.Collections;
+import java.util.List;
 import org.glyptodon.guacamole.GuacamoleException;
 import org.glyptodon.guacamole.environment.Environment;
 
@@ -77,21 +79,21 @@ public class ConfigurationService {
     }
 
     /**
-     * Returns the username attribute which should be used to query and bind
+     * Returns all username attributes which should be used to query and bind
      * users using the LDAP directory. By default, this will be "uid" - a
      * common attribute used for this purpose.
      *
      * @return
-     *     The username attribute which should be used to query and bind users
+     *     The username attributes which should be used to query and bind users
      *     using the LDAP directory.
      *
      * @throws GuacamoleException
      *     If guacamole.properties cannot be parsed.
      */
-    public String getUsernameAttribute() throws GuacamoleException {
+    public List<String> getUsernameAttributes() throws GuacamoleException {
         return environment.getProperty(
             LDAPGuacamoleProperties.LDAP_USERNAME_ATTRIBUTE,
-            "uid"
+            Collections.singletonList("uid")
         );
     }
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/ConfigurationService.java
@@ -133,4 +133,42 @@ public class ConfigurationService {
         );
     }
 
+    /**
+     * Returns the DN that should be used when searching for the DNs of users
+     * attempting to authenticate. If no such search should be performed, null
+     * is returned.
+     *
+     * @return
+     *     The DN that should be used when searching for the DNs of users
+     *     attempting to authenticate, or null if no such search should be
+     *     performed.
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed.
+     */
+    public String getSearchBindDN() throws GuacamoleException {
+        return environment.getProperty(
+            LDAPGuacamoleProperties.LDAP_SEARCH_BIND_DN
+        );
+    }
+
+    /**
+     * Returns the password that should be used when binding to the LDAP server
+     * using the DN returned by getSearchBindDN(). If no password should be
+     * used, null is returned.
+     *
+     * @return
+     *     The password that should be used when binding to the LDAP server
+     *     using the DN returned by getSearchBindDN(), or null if no password
+     *     should be used.
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed.
+     */
+    public String getSearchBindPassword() throws GuacamoleException {
+        return environment.getProperty(
+            LDAPGuacamoleProperties.LDAP_SEARCH_BIND_PASSWORD
+        );
+    }
+
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/LDAPAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/LDAPAuthenticationProviderModule.java
@@ -81,6 +81,7 @@ public class LDAPAuthenticationProviderModule extends AbstractModule {
         bind(ConfigurationService.class);
         bind(ConnectionService.class);
         bind(EscapingService.class);
+        bind(LDAPConnectionService.class);
         bind(UserService.class);
 
     }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/LDAPConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/LDAPConnectionService.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2015 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.glyptodon.guacamole.auth.ldap;
+
+import com.google.inject.Inject;
+import com.novell.ldap.LDAPConnection;
+import com.novell.ldap.LDAPException;
+import java.io.UnsupportedEncodingException;
+import org.glyptodon.guacamole.GuacamoleException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Service for creating and managing connections to LDAP servers.
+ *
+ * @author Michael Jumper
+ */
+public class LDAPConnectionService {
+
+    /**
+     * Logger for this class.
+     */
+    private final Logger logger = LoggerFactory.getLogger(LDAPConnectionService.class);
+
+    /**
+     * Service for retrieving LDAP server configuration information.
+     */
+    @Inject
+    private ConfigurationService confService;
+
+    /**
+     * Binds to the LDAP server using the provided user DN and password.
+     *
+     * @param userDN
+     *     The DN of the user to bind as, or null to bind anonymously.
+     *
+     * @param password
+     *     The password to use when binding as the specified user, or null to
+     *     attempt to bind without a password.
+     *
+     * @return
+     *     A bound LDAP connection, or null if the connection could not be
+     *     bound.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while binding to the LDAP server.
+     */
+    public LDAPConnection bindAs(String userDN, String password)
+            throws GuacamoleException {
+
+        LDAPConnection ldapConnection;
+
+        // Connect to LDAP server
+        try {
+            ldapConnection = new LDAPConnection();
+            ldapConnection.connect(
+                confService.getServerHostname(),
+                confService.getServerPort()
+            );
+        }
+        catch (LDAPException e) {
+            logger.error("Unable to connect to LDAP server: {}", e.getMessage());
+            logger.debug("Failed to connect to LDAP server.", e);
+            return null;
+        }
+
+        // Bind using provided credentials
+        try {
+
+            byte[] passwordBytes;
+            try {
+
+                // Convert password into corresponding byte array
+                if (password != null)
+                    passwordBytes = password.getBytes("UTF-8");
+                else
+                    passwordBytes = null;
+
+            }
+            catch (UnsupportedEncodingException e) {
+                logger.error("Unexpected lack of support for UTF-8: {}", e.getMessage());
+                logger.debug("Support for UTF-8 (as required by Java spec) not found.", e);
+                disconnect(ldapConnection);
+                return null;
+            }
+
+            // Bind as user
+            ldapConnection.bind(LDAPConnection.LDAP_V3, userDN, passwordBytes);
+
+        }
+
+        // Disconnect if an error occurs during bind
+        catch (LDAPException e) {
+            logger.debug("LDAP bind failed.", e);
+            disconnect(ldapConnection);
+            return null;
+        }
+
+        return ldapConnection;
+
+    }
+
+    /**
+     * Disconnects the given LDAP connection, logging any failure to do so
+     * appropriately.
+     *
+     * @param ldapConnection
+     *     The LDAP connection to disconnect.
+     */
+    public void disconnect(LDAPConnection ldapConnection) {
+
+        // Attempt disconnect
+        try {
+            ldapConnection.disconnect();
+        }
+
+        // Warn if disconnect unexpectedly fails
+        catch (LDAPException e) {
+            logger.warn("Unable to disconnect from LDAP server: {}", e.getMessage());
+            logger.debug("LDAP disconnect failed.", e);
+        }
+
+    }
+
+}

--- a/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/LDAPGuacamoleProperties.java
@@ -62,11 +62,14 @@ public class LDAPGuacamoleProperties {
     };
 
     /**
-     * The attribute which identifies users. This attribute must be part of
-     * each user's DN such that the concatenation of this attribute and
-     * LDAP_USER_BASE_DN equals the users full DN.
+     * The attribute or attributes which identify users. One of these
+     * attributes must be present within the each Guacamole user's record in
+     * the LDAP directory. If the LDAP authentication will not be given its own
+     * credentials for querying other LDAP users, this list may contain only
+     * one attribute, and the concatenation of that attribute and the value of
+     * LDAP_USER_BASE_DN must equal the user's full DN.
      */
-    public static final StringGuacamoleProperty LDAP_USERNAME_ATTRIBUTE = new StringGuacamoleProperty() {
+    public static final StringListProperty LDAP_USERNAME_ATTRIBUTE = new StringListProperty() {
 
         @Override
         public String getName() { return "ldap-username-attribute"; }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/LDAPGuacamoleProperties.java
@@ -65,8 +65,8 @@ public class LDAPGuacamoleProperties {
 
     /**
      * The attribute or attributes which identify users. One of these
-     * attributes must be present within the each Guacamole user's record in
-     * the LDAP directory. If the LDAP authentication will not be given its own
+     * attributes must be present within each Guacamole user's record in the
+     * LDAP directory. If the LDAP authentication will not be given its own
      * credentials for querying other LDAP users, this list may contain only
      * one attribute, and the concatenation of that attribute and the value of
      * LDAP_USER_BASE_DN must equal the user's full DN.

--- a/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/LDAPGuacamoleProperties.java
@@ -98,4 +98,30 @@ public class LDAPGuacamoleProperties {
 
     };
 
+    /**
+     * The DN of the user that the LDAP authentication should bind as when
+     * searching for the user accounts of users attempting to log in. If not
+     * specified, the DNs of users attempting to log in will be derived from
+     * the LDAP_BASE_DN and LDAP_USERNAME_ATTRIBUTE directly.
+     */
+    public static final StringGuacamoleProperty LDAP_SEARCH_BIND_DN = new StringGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "ldap-search-bind-dn"; }
+
+    };
+
+    /**
+     * The password to provide to the LDAP server when binding as
+     * LDAP_SEARCH_BIND_DN. If LDAP_SEARCH_BIND_DN is not specified, this
+     * property has no effect. If this property is not specified, no password
+     * will be provided when attempting to bind as LDAP_SEARCH_BIND_DN.
+     */
+    public static final StringGuacamoleProperty LDAP_SEARCH_BIND_PASSWORD = new StringGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "ldap-search-bind-password"; }
+
+    };
+
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/LDAPGuacamoleProperties.java
@@ -51,8 +51,10 @@ public class LDAPGuacamoleProperties {
     };
 
     /**
-     * The base DN of users. All users must be direct children of this DN,
-     * varying only by LDAP_USERNAME_ATTRIBUTE.
+     * The base DN of users. All users must be contained somewhere within the
+     * subtree of this DN. If the LDAP authentication will not be given its own
+     * credentials for querying other LDAP users, all users must be direct
+     * children of this base DN, varying only by LDAP_USERNAME_ATTRIBUTE.
      */
     public static final StringGuacamoleProperty LDAP_USER_BASE_DN = new StringGuacamoleProperty() {
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/StringListProperty.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/StringListProperty.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2015 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.glyptodon.guacamole.auth.ldap;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.glyptodon.guacamole.GuacamoleException;
+import org.glyptodon.guacamole.properties.GuacamoleProperty;
+
+/**
+ * A GuacamoleProperty whose value is a List of Strings. The string value
+ * parsed to produce this list is a comma-delimited list. Duplicate values are
+ * ignored, as is any whitespace following delimiters. To maintain
+ * compatibility with the behavior of Java properties in general, only
+ * whitespace at the beginning of each value is ignored; trailing whitespace
+ * becomes part of the value.
+ *
+ * @author Michael Jumper
+ */
+public abstract class StringListProperty implements GuacamoleProperty<List<String>> {
+
+    /**
+     * A pattern which matches against the delimiters between values. This is
+     * currently simply a comma and any following whitespace. Parts of the
+     * input string which match this pattern will not be included in the parsed
+     * result.
+     */
+    private static final Pattern DELIMITER_PATTERN = Pattern.compile(",\\s*");
+
+    @Override
+    public List<String> parseValue(String values) throws GuacamoleException {
+
+        // If no property provided, return null.
+        if (values == null)
+            return null;
+
+        // Split string into a list of individual values
+        return Arrays.asList(DELIMITER_PATTERN.split(values));
+
+    }
+
+}

--- a/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/StringListProperty.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/StringListProperty.java
@@ -56,7 +56,11 @@ public abstract class StringListProperty implements GuacamoleProperty<List<Strin
             return null;
 
         // Split string into a list of individual values
-        return Arrays.asList(DELIMITER_PATTERN.split(values));
+        List<String> stringValues = Arrays.asList(DELIMITER_PATTERN.split(values));
+        if (stringValues.isEmpty())
+            return null;
+
+        return stringValues;
 
     }
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/connection/ConnectionService.java
@@ -28,6 +28,7 @@ import com.novell.ldap.LDAPConnection;
 import com.novell.ldap.LDAPEntry;
 import com.novell.ldap.LDAPException;
 import com.novell.ldap.LDAPSearchResults;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
@@ -86,6 +87,11 @@ public class ConnectionService {
     public Map<String, Connection> getConnections(LDAPConnection ldapConnection)
             throws GuacamoleException {
 
+        // Do not return any connections if base DN is not specified
+        String configurationBaseDN = confService.getConfigurationBaseDN();
+        if (configurationBaseDN == null)
+            return Collections.<String, Connection>emptyMap();
+
         try {
 
             // Pull the current user DN from the LDAP connection
@@ -98,7 +104,7 @@ public class ConnectionService {
 
             // Find all Guacamole connections for the given user
             LDAPSearchResults results = ldapConnection.search(
-                confService.getConfigurationBaseDN(),
+                configurationBaseDN,
                 LDAPConnection.SCOPE_SUB,
                 "(&(objectClass=guacConfigGroup)(member=" + escapingService.escapeLDAPSearchFilter(userDN) + "))",
                 null,

--- a/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/user/UserService.java
@@ -211,6 +211,9 @@ public class UserService {
         if (usernameAttributes.size() > 1)
             ldapQuery.append(")");
 
+        // Close overall query (AND clause)
+        ldapQuery.append(")");
+
         return ldapQuery.toString();
 
     }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/user/UserService.java
@@ -143,8 +143,21 @@ public class UserService {
 
         // Build map of users by querying each username attribute separately
         Map<String, User> users = new HashMap<String, User>();
-        for (String usernameAttribute : confService.getUsernameAttributes())
-            putAllUsers(users, ldapConnection, usernameAttribute);
+        for (String usernameAttribute : confService.getUsernameAttributes()) {
+
+            // Attempt to pull all users with given attribute
+            try {
+                putAllUsers(users, ldapConnection, usernameAttribute);
+            }
+
+            // Log any errors non-fatally
+            catch (GuacamoleException e) {
+                logger.warn("Could not query list of all users for attribute \"{}\": {}",
+                        usernameAttribute, e.getMessage());
+                logger.debug("Error querying list of all users.", e);
+            }
+
+        }
 
         // Return map of all users
         return users;

--- a/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/user/UserService.java
@@ -269,4 +269,40 @@ public class UserService {
 
     }
 
+    /**
+     * Determines the DN which corresponds to the user having the given
+     * username. The DN will either be derived directly from the user base DN,
+     * or queried from the LDAP server, depending on how LDAP authentication
+     * has been configured.
+     *
+     * @param username
+     *     The username of the user whose corresponding DN should be returned.
+     *
+     * @return
+     *     The DN which corresponds to the user having the given username.
+     *
+     * @throws GuacamoleException
+     *     If required properties are missing, and thus the user DN cannot be
+     *     determined.
+     */
+    public String deriveUserDN(String username)
+            throws GuacamoleException {
+
+        // Pull username attributes from properties
+        List<String> usernameAttributes = confService.getUsernameAttributes();
+
+        // We need exactly one base DN to derive the user DN
+        if (usernameAttributes.size() != 1) {
+            logger.warn("Cannot directly derive user DN when multiple username attributes are specified");
+            return null;
+        }
+
+        // Derive user DN from base DN
+        return
+                    escapingService.escapeDN(usernameAttributes.get(0))
+            + "=" + escapingService.escapeDN(username)
+            + "," + confService.getUserBaseDN();
+
+    }
+
 }


### PR DESCRIPTION
The current Guacamole LDAP integration relies on being able to directly derive the a user's DN from their username. This will not work if the user's username is not part of their DN, as is often the case with Active Directory, or if users are not all within the same base DN.

This change alters the DN derivation algorithm such that the user DN can be determined through a search against the LDAP directory, in the case that service credentials are provided for Guacamole to do so (via `ldap-search-bind-dn` and `ldap-search-bind-password`).

The semantics of the existing `ldap-username-attribute` property have also been altered such that a comma-separated list of attributes can be specified. If multiple username attributes are provided, each will be used by Guacamole when determining possible user DNs.

As it is now possible for an LDAP directory to contain multiple entries for the same username, attempting to login with such an ambiguous account will fail as if the account does not exist, and a warning regarding ambiguity will be logged.