### PR TITLE
GUAC-1375: Use Guacamole.VideoPlayer.getSupportedTypes() instead of canPlayType()

### DIFF
--- a/guacamole/src/main/webapp/app/client/services/guacVideo.js
+++ b/guacamole/src/main/webapp/app/client/services/guacVideo.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Glyptodon LLC
+ * Copyright (C) 2015 Glyptodon LLC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,47 +30,10 @@ angular.module('client').factory('guacVideo', [function guacVideo() {
      */
     return new (function() {
 
-        var codecs = [
-            'video/ogg; codecs="theora, vorbis"',
-            'video/mp4; codecs="avc1.4D401E, mp4a.40.5"',
-            'video/webm; codecs="vp8.0, vorbis"'
-        ];
-
-        var probably_supported = [];
-        var maybe_supported = [];
-
         /**
-         * Array of all supported video mimetypes, ordered by liklihood of
-         * working.
+         * Array of all supported video mimetypes.
          */
-        this.supported = [];
-
-        // Build array of supported audio formats
-        codecs.forEach(function(mimetype) {
-
-            var video = document.createElement("video");
-            var support_level = video.canPlayType(mimetype);
-
-            // Trim semicolon and trailer
-            var semicolon = mimetype.indexOf(";");
-            if (semicolon != -1)
-                mimetype = mimetype.substring(0, semicolon);
-
-            // Partition by probably/maybe
-            if (support_level == "probably")
-                probably_supported.push(mimetype);
-            else if (support_level == "maybe")
-                maybe_supported.push(mimetype);
-
-        });
-
-        // Add probably supported types first
-        Array.prototype.push.apply(
-            this.supported, probably_supported);
-
-        // Prioritize "maybe" supported types second
-        Array.prototype.push.apply(
-            this.supported, maybe_supported);
+        this.supported = Guacamole.VideoPlayer.getSupportedTypes();
 
     })();
 


### PR DESCRIPTION
The handling of video has changed in Guacamole, and thus we no longer need to check `canPlayType(https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/canPlayType)` of [`HTMLVideoElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement). We can just use `Guacamole.VideoPlayer.getSupportedTypes()`.

Removing use of `canPlayType()` fixes [GUAC-1375](https://glyptodon.org/jira/browse/GUAC-1375) - a bug which surfaces when MS EDGE does not define `canPlayType` for the `video` element.

A similar change was made for audio via 324c800 (part of PR #272) for [GUAC-1354](https://glyptodon.org/jira/browse/GUAC-1354)