### PR TITLE
GUAC-1342: Restore use of parameter tokens within LDAP

### DIFF
--- a/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/user/UserContext.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/user/UserContext.java
@@ -134,7 +134,7 @@ public class UserContext implements org.glyptodon.guacamole.net.auth.UserContext
 
         // Query all accessible connections
         connectionDirectory = new SimpleDirectory<Connection>(
-            connectionService.getConnections(ldapConnection)
+            connectionService.getConnections(user, ldapConnection)
         );
 
         // Root group contains only connections

--- a/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/glyptodon/guacamole/auth/ldap/user/UserService.java
@@ -36,6 +36,7 @@ import org.glyptodon.guacamole.auth.ldap.ConfigurationService;
 import org.glyptodon.guacamole.auth.ldap.EscapingService;
 import org.glyptodon.guacamole.GuacamoleException;
 import org.glyptodon.guacamole.GuacamoleServerException;
+import org.glyptodon.guacamole.auth.ldap.LDAPGuacamoleProperties;
 import org.glyptodon.guacamole.net.auth.User;
 import org.glyptodon.guacamole.net.auth.simple.SimpleUser;
 import org.slf4j.Logger;
@@ -296,7 +297,11 @@ public class UserService {
 
         // We need exactly one base DN to derive the user DN
         if (usernameAttributes.size() != 1) {
-            logger.warn("Cannot directly derive user DN when multiple username attributes are specified");
+            logger.warn(String.format("Cannot directly derive user DN when "
+                      + "multiple username attributes are specified. Please "
+                      + "define an LDAP search DN using the \"%s\" property "
+                      + "in your \"guacamole.properties\".",
+                      LDAPGuacamoleProperties.LDAP_SEARCH_BIND_DN.getName()));
             return null;
         }
 


### PR DESCRIPTION
Guacamole 0.9.8 was released with a regression in its LDAP support, where parameter tokens would not be handled for connections defined within LDAP. They are, however, properly handled if those connections are stored within MySQL or PostgreSQL. This change restores the use of parameter tokens within LDAP.

During testing, I configured my LDAP directory within `guacamole.properties` incorrectly, and ran across the following warning: "Cannot directly derive user DN when multiple username attributes are specified". The way to resolve this is to specify a search DN, but that is not obvious from the warning, and there is no reason the warning should not be more specific. I went ahead and clarified that warning before creating this PR.