### PR TITLE
GUAC-1392: Bump Guacamole version to 0.9.9.

### DIFF
--- a/doc/guacamole-example/pom.xml
+++ b/doc/guacamole-example/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole-example</artifactId>
     <packaging>war</packaging>
-    <version>0.9.8</version>
+    <version>0.9.9</version>
     <name>guacamole-example</name>
     <url>http://guac-dev.org/</url>
 
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-common</artifactId>
-            <version>0.9.7</version>
+            <version>0.9.9</version>
             <scope>compile</scope>
         </dependency>
 
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-common-js</artifactId>
-            <version>0.9.8</version>
+            <version>0.9.9</version>
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/pom.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.glyptodon.guacamole</groupId>
         <artifactId>guacamole-auth-jdbc</artifactId>
-        <version>0.9.8</version>
+        <version>0.9.9</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/pom.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.glyptodon.guacamole</groupId>
         <artifactId>guacamole-auth-jdbc</artifactId>
-        <version>0.9.8</version>
+        <version>0.9.9</version>
         <relativePath>../../</relativePath>
     </parent>
 
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-auth-jdbc-base</artifactId>
-            <version>0.9.8</version>
+            <version>0.9.9</version>
         </dependency>
 
     </dependencies>

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "0.9.8",
+    "guacamoleVersion" : "0.9.9",
 
     "name"      : "MySQL Authentication",
     "namespace" : "guac-mysql",

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/pom.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.glyptodon.guacamole</groupId>
         <artifactId>guacamole-auth-jdbc</artifactId>
-        <version>0.9.8</version>
+        <version>0.9.9</version>
         <relativePath>../../</relativePath>
     </parent>
 
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-auth-jdbc-base</artifactId>
-            <version>0.9.8</version>
+            <version>0.9.9</version>
         </dependency>
 
     </dependencies>

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "0.9.8",
+    "guacamoleVersion" : "0.9.9",
 
     "name"      : "PostgreSQL Authentication",
     "namespace" : "guac-postgresql",

--- a/extensions/guacamole-auth-jdbc/pom.xml
+++ b/extensions/guacamole-auth-jdbc/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole-auth-jdbc</artifactId>
     <packaging>pom</packaging>
-    <version>0.9.8</version>
+    <version>0.9.9</version>
     <name>guacamole-auth-jdbc</name>
     <url>http://guac-dev.org/</url>
 
@@ -62,7 +62,7 @@
             <dependency>
                 <groupId>org.glyptodon.guacamole</groupId>
                 <artifactId>guacamole-ext</artifactId>
-                <version>0.9.8</version>
+                <version>0.9.9</version>
                 <scope>provided</scope>
             </dependency>
 

--- a/extensions/guacamole-auth-ldap/pom.xml
+++ b/extensions/guacamole-auth-ldap/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole-auth-ldap</artifactId>
     <packaging>jar</packaging>
-    <version>0.9.8</version>
+    <version>0.9.9</version>
     <name>guacamole-auth-ldap</name>
     <url>http://guac-dev.org/</url>
 
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-common</artifactId>
-            <version>0.9.7</version>
+            <version>0.9.9</version>
             <scope>provided</scope>
         </dependency>
 
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>0.9.8</version>
+            <version>0.9.9</version>
             <scope>provided</scope>
         </dependency>
 

--- a/extensions/guacamole-auth-ldap/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-ldap/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "0.9.8",
+    "guacamoleVersion" : "0.9.9",
 
     "name"      : "LDAP Authentication",
     "namespace" : "guac-ldap",

--- a/extensions/guacamole-auth-noauth/pom.xml
+++ b/extensions/guacamole-auth-noauth/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole-auth-noauth</artifactId>
     <packaging>jar</packaging>
-    <version>0.9.8</version>
+    <version>0.9.9</version>
     <name>guacamole-auth-noauth</name>
     <url>http://guacamole.sourceforge.net/</url>
 
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-common</artifactId>
-            <version>0.9.7</version>
+            <version>0.9.9</version>
             <scope>provided</scope>
         </dependency>
 
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>0.9.8</version>
+            <version>0.9.9</version>
             <scope>provided</scope>
         </dependency>
 

--- a/extensions/guacamole-auth-noauth/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-noauth/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "0.9.8",
+    "guacamoleVersion" : "0.9.9",
 
     "name"      : "Disabled Authentication",
     "namespace" : "guac-noauth",

--- a/guacamole-common-js/pom.xml
+++ b/guacamole-common-js/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole-common-js</artifactId>
     <packaging>pom</packaging>
-    <version>0.9.8</version>
+    <version>0.9.9</version>
     <name>guacamole-common-js</name>
     <url>http://guac-dev.org/</url>
 

--- a/guacamole-common-js/src/main/webapp/modules/Version.js
+++ b/guacamole-common-js/src/main/webapp/modules/Version.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Glyptodon LLC
+ * Copyright (C) 2015 Glyptodon LLC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,4 +30,4 @@ var Guacamole = Guacamole || {};
  *
  * @type {String}
  */
-Guacamole.API_VERSION = "0.9.5";
+Guacamole.API_VERSION = "0.9.9";

--- a/guacamole-common/pom.xml
+++ b/guacamole-common/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole-common</artifactId>
     <packaging>jar</packaging>
-    <version>0.9.7</version>
+    <version>0.9.9</version>
     <name>guacamole-common</name>
     <url>http://guac-dev.org/</url>
 

--- a/guacamole-ext/pom.xml
+++ b/guacamole-ext/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole-ext</artifactId>
     <packaging>jar</packaging>
-    <version>0.9.8</version>
+    <version>0.9.9</version>
     <name>guacamole-ext</name>
     <url>http://guac-dev.org/</url>
 
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-common</artifactId>
-            <version>0.9.7</version>
+            <version>0.9.9</version>
             <scope>compile</scope>
         </dependency>
 

--- a/guacamole/pom.xml
+++ b/guacamole/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole</artifactId>
     <packaging>war</packaging>
-    <version>0.9.8</version>
+    <version>0.9.9</version>
     <name>guacamole</name>
     <url>http://guac-dev.org/</url>
 
@@ -220,21 +220,21 @@
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-common</artifactId>
-            <version>0.9.7</version>
+            <version>0.9.9</version>
         </dependency>
 
         <!-- Guacamole Extension API -->
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>0.9.8</version>
+            <version>0.9.9</version>
         </dependency>
 
         <!-- Guacamole JavaScript API -->
         <dependency>
             <groupId>org.glyptodon.guacamole</groupId>
             <artifactId>guacamole-common-js</artifactId>
-            <version>0.9.8</version>
+            <version>0.9.9</version>
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>

--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/extension/ExtensionModule.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/extension/ExtensionModule.java
@@ -65,7 +65,7 @@ public class ExtensionModule extends ServletModule {
     private static final List<String> ALLOWED_GUACAMOLE_VERSIONS =
         Collections.unmodifiableList(Arrays.asList(
             "*",
-            "0.9.8"
+            "0.9.9"
         ));
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.glyptodon.guacamole</groupId>
     <artifactId>guacamole-client</artifactId>
     <packaging>pom</packaging>
-    <version>0.9.8</version>
+    <version>0.9.9</version>
     <name>guacamole-client</name>
     <url>http://guac-dev.org/</url>
 


### PR DESCRIPTION
This time, **all projects were modified**, thus everything gets bumped. Absolutely all `pom.xml` should now say `0.9.9` for their versions. Same goes for `guacamoleVersion` within `guac-manifest.json` and `Guacamole.API_VERSION` within guacamole-common-js.