### PR TITLE
GUAC-1407: Do not show "Clone" button if source user does not yet exist.

### DIFF
--- a/guacamole/src/main/webapp/app/manage/controllers/manageUserController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageUserController.js
@@ -404,7 +404,7 @@ angular.module('manage').controller('manageUserController', ['$scope', '$injecto
         dataSource = dataSource || selectedDataSource;
 
         // If we are not editing an existing user, we cannot clone
-        if (!username)
+        if (!$scope.userExists(selectedDataSource))
             return false;
 
         // The administrator can always clone users


### PR DESCRIPTION
Seems our logic was wrong after all. We should be checking `$scope.userExists()`, not whether `username` is defined.