### PR TITLE
GUAC-1407: Do not show irrelevant account tabs when cloning.

### DIFF
--- a/guacamole/src/main/webapp/app/manage/controllers/manageUserController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageUserController.js
@@ -492,6 +492,10 @@ angular.module('manage').controller('manageUserController', ['$scope', '$injecto
             if (!linked && readOnly)
                 return;
 
+            // Only the selected data source is relevant when cloning
+            if (cloneSourceUsername && dataSource !== selectedDataSource)
+                return;
+
             // Determine class name based on read-only / linked status
             var className;
             if (readOnly)    className = 'read-only';


### PR DESCRIPTION
As established in the existing account page logic ([lines 490 - 493 of `manageUserController.js`](https://github.com/glyptodon/guacamole-client/blob/9b933b75203c2f3dc9a81f07671bf09d2dbd5fdb/guacamole/src/main/webapp/app/manage/controllers/manageUserController.js#L490-L493)):

```javascript
// Account is not relevant if it does not exist and cannot be
// created
if (!linked && readOnly)
    return;
```

we should only add account pages which are relevant. In the case of a cloned user, only the selected data source is relevant. Restricting the account pages to a single possibility effectively hides the account tabs due to the logic built into the `<guac-page-list>` directive.