### PR TITLE
GUAC-1452: Input streams must be invalidated when closed.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Client.js
+++ b/guacamole-common-js/src/main/webapp/modules/Client.js
@@ -899,13 +899,20 @@ Guacamole.Client = function(tunnel) {
 
         "end": function(parameters) {
 
-            // Get stream
             var stream_index = parseInt(parameters[0]);
-            var stream = streams[stream_index];
 
-            // Signal end of stream
-            if (stream && stream.onend)
-                stream.onend();
+            // Get stream
+            var stream = streams[stream_index];
+            if (stream) {
+
+                // Signal end of stream if handler defined
+                if (stream.onend)
+                    stream.onend();
+
+                // Invalidate stream
+                delete streams[stream_index];
+
+            }
 
         },
 


### PR DESCRIPTION
If we do not properly delete past streams when closed, future attempts to create streams having the same index may erroneously use the previous stream object, resulting in strange concatenation effects.