### PR TITLE
GUAC-1451: Add support for GUAC_DATE and GUAC_TIME tokens.

### DIFF
--- a/guacamole-ext/src/main/java/org/glyptodon/guacamole/token/StandardTokens.java
+++ b/guacamole-ext/src/main/java/org/glyptodon/guacamole/token/StandardTokens.java
@@ -37,24 +37,24 @@ public class StandardTokens {
     /**
      * The name of the username token added via addStandardTokens().
      */
-    private static final String USERNAME_TOKEN = "GUAC_USERNAME";
+    public static final String USERNAME_TOKEN = "GUAC_USERNAME";
 
     /**
      * The name of the password token added via addStandardTokens().
      */
-    private static final String PASSWORD_TOKEN = "GUAC_PASSWORD";
+    public static final String PASSWORD_TOKEN = "GUAC_PASSWORD";
 
     /**
      * The name of the date token (server-local time) added via
      * addStandardTokens().
      */
-    private static final String DATE_TOKEN = "GUAC_DATE";
+    public static final String DATE_TOKEN = "GUAC_DATE";
 
     /**
      * The name of the time token (server-local time) added via
      * addStandardTokens().
      */
-    private static final String TIME_TOKEN = "GUAC_TIME";
+    public static final String TIME_TOKEN = "GUAC_TIME";
 
     /**
      * The date format that should be used for the date token. This format must

--- a/guacamole-ext/src/main/java/org/glyptodon/guacamole/token/StandardTokens.java
+++ b/guacamole-ext/src/main/java/org/glyptodon/guacamole/token/StandardTokens.java
@@ -75,6 +75,23 @@ public class StandardTokens {
 
     /**
      * Adds tokens which are standardized by guacamole-ext to the given
+     * TokenFilter and which do not require a corresponding Credentials object.
+     * These the server date and time (GUAC_DATE and GUAC_TIME respectively).
+     *
+     * @param filter
+     *     The TokenFilter to add standard tokens to.
+     */
+    public static void addStandardTokens(TokenFilter filter) {
+
+        // Add date/time tokens (server-local time)
+        Date currentTime = new Date();
+        filter.setToken(DATE_TOKEN, new SimpleDateFormat(DATE_FORMAT).format(currentTime));
+        filter.setToken(TIME_TOKEN, new SimpleDateFormat(TIME_FORMAT).format(currentTime));
+
+    }
+
+    /**
+     * Adds tokens which are standardized by guacamole-ext to the given
      * TokenFilter using the values from the given Credentials object. These
      * standardized tokens include the current username (GUAC_USERNAME),
      * password (GUAC_PASSWORD), and the server date and time (GUAC_DATE and
@@ -83,10 +100,11 @@ public class StandardTokens {
      * unset.
      *
      * @param filter
-     *     The TokenFilter to add standard username/password tokens to.
+     *     The TokenFilter to add standard tokens to.
      *
      * @param credentials
-     *     The Credentials containing the username/password to add.
+     *     The Credentials to use when populating the GUAC_USERNAME and
+     *     GUAC_PASSWORD tokens.
      */
     public static void addStandardTokens(TokenFilter filter, Credentials credentials) {
 
@@ -100,10 +118,8 @@ public class StandardTokens {
         if (password != null)
             filter.setToken(PASSWORD_TOKEN, password);
 
-        // Add date/time tokens (server-local time)
-        Date currentTime = new Date();
-        filter.setToken(DATE_TOKEN, new SimpleDateFormat(DATE_FORMAT).format(currentTime));
-        filter.setToken(TIME_TOKEN, new SimpleDateFormat(TIME_FORMAT).format(currentTime));
+        // Add any tokens which do not require credentials
+        addStandardTokens(filter);
 
     }
 

--- a/guacamole-ext/src/main/java/org/glyptodon/guacamole/token/StandardTokens.java
+++ b/guacamole-ext/src/main/java/org/glyptodon/guacamole/token/StandardTokens.java
@@ -1,16 +1,16 @@
 /*
- * Copyright (C) 2015 Glyptodon LLC
- * 
+ * Copyright (C) 2016 Glyptodon LLC
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,6 +22,8 @@
 
 package org.glyptodon.guacamole.token;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import org.glyptodon.guacamole.net.auth.Credentials;
 
 /**
@@ -43,14 +45,40 @@ public class StandardTokens {
     private static final String PASSWORD_TOKEN = "GUAC_PASSWORD";
 
     /**
+     * The name of the date token (server-local time) added via
+     * addStandardTokens().
+     */
+    private static final String DATE_TOKEN = "GUAC_DATE";
+
+    /**
+     * The name of the time token (server-local time) added via
+     * addStandardTokens().
+     */
+    private static final String TIME_TOKEN = "GUAC_TIME";
+
+    /**
+     * The date format that should be used for the date token. This format must
+     * be compatible with Java's SimpleDateFormat.
+     */
+    private static final String DATE_FORMAT = "yyyyMMdd";
+
+    /**
+     * The date format that should be used for the time token. This format must
+     * be compatible with Java's SimpleDateFormat.
+     */
+    private static final String TIME_FORMAT = "HHmmss";
+
+    /**
      * This utility class should not be instantiated.
      */
     private StandardTokens() {}
 
     /**
-     * Adds the standard username (GUAC_USERNAME) and password (GUAC_PASSWORD)
-     * tokens to the given TokenFilter using the values from the given
-     * Credentials object. If either the username or password are not set
+     * Adds tokens which are standardized by guacamole-ext to the given
+     * TokenFilter using the values from the given Credentials object. These
+     * standardized tokens include the current username (GUAC_USERNAME),
+     * password (GUAC_PASSWORD), and the server date and time (GUAC_DATE and
+     * GUAC_TIME respectively). If either the username or password are not set
      * within the given credentials, the corresponding token(s) will remain
      * unset.
      *
@@ -59,7 +87,6 @@ public class StandardTokens {
      *
      * @param credentials
      *     The Credentials containing the username/password to add.
-     *
      */
     public static void addStandardTokens(TokenFilter filter, Credentials credentials) {
 
@@ -67,13 +94,17 @@ public class StandardTokens {
         String username = credentials.getUsername();
         if (username != null)
             filter.setToken(USERNAME_TOKEN, username);
-        
+
         // Add password token
         String password = credentials.getPassword();
         if (password != null)
             filter.setToken(PASSWORD_TOKEN, password);
-        
+
+        // Add date/time tokens (server-local time)
+        Date currentTime = new Date();
+        filter.setToken(DATE_TOKEN, new SimpleDateFormat(DATE_FORMAT).format(currentTime));
+        filter.setToken(TIME_TOKEN, new SimpleDateFormat(TIME_FORMAT).format(currentTime));
+
     }
-    
 
 }


### PR DESCRIPTION
As described in [GUAC-1451](https://glyptodon.org/jira/browse/GUAC-1451), this change adds the new `GUAC_DATE` and `GUAC_TIME` tokens which allow server-local timestamps to be inserted arbitrarily within connection parameter values. Since these tokens are handled within `addStandardTokens()`, any code using the `StandardTokens` class will automatically inherit support for these tokens, including all official authentication backends.

Additional changes were required to make `addStandardTokens()` reasonable in the case that a `Credentials` object does not apply, and to make `StandardTokens` match its own definition.