### PR TITLE
GUAC-1410: Add parameter and value translation string for Japanese keymap.

### DIFF
--- a/guacamole-ext/src/main/resources/org/glyptodon/guacamole/protocols/rdp.json
+++ b/guacamole-ext/src/main/resources/org/glyptodon/guacamole/protocols/rdp.json
@@ -69,6 +69,7 @@
                         "fr-fr-azerty",
                         "de-de-qwertz",
                         "it-it-qwerty",
+                        "ja-jp-qwerty",
                         "sv-se-qwerty",
                         "failsafe"
                     ]

--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -330,6 +330,7 @@
         "FIELD_OPTION_SERVER_LAYOUT_FAILSAFE"     : "Unicode",
         "FIELD_OPTION_SERVER_LAYOUT_FR_FR_AZERTY" : "French (Azerty)",
         "FIELD_OPTION_SERVER_LAYOUT_IT_IT_QWERTY" : "Italian (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_JA_JP_QWERTY" : "Japanese (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_SV_SE_QWERTY" : "Swedish (Qwerty)",
 
         "NAME" : "RDP",


### PR DESCRIPTION
Corresponding parameter and value declaration for the keymap added via glyptodon/guacamole-server#98.