### PR TITLE
GUAC-1489 Enable HTTP Basic Authentication

### DIFF
--- a/guacamole-ext/src/main/java/org/glyptodon/guacamole/environment/Environment.java
+++ b/guacamole-ext/src/main/java/org/glyptodon/guacamole/environment/Environment.java
@@ -70,6 +70,16 @@ public interface Environment {
 
     };
 
+    /*
+     * Whether HTTP Basic Authentication is enabled.
+     */
+    public static final BooleanGuacamoleProperty ENABLE_HTTP_BASIC_AUTH = new BooleanGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "enable-http-basic-auth"; }
+
+    };
+
     /**
      * Returns the Guacamole home directory as determined when this Environment
      * object was created. The Guacamole home directory is found by checking, in

--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/APIError.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/APIError.java
@@ -25,6 +25,9 @@ package org.glyptodon.guacamole.net.basic.rest;
 import java.util.Collection;
 import javax.ws.rs.core.Response;
 import org.glyptodon.guacamole.form.Field;
+import org.glyptodon.guacamole.GuacamoleException;
+import org.glyptodon.guacamole.environment.Environment;
+import org.glyptodon.guacamole.environment.LocalEnvironment;
 
 /**
  * Describes an error that occurred within a REST endpoint.
@@ -63,7 +66,7 @@ public class APIError {
         /**
          * The credentials provided were invalid.
          */
-        INVALID_CREDENTIALS(Response.Status.FORBIDDEN),
+        INVALID_CREDENTIALS(Response.Status.UNAUTHORIZED),
 
         /**
          * The credentials provided were not necessarily invalid, but were not
@@ -108,6 +111,20 @@ public class APIError {
          *     The HTTP status associated with this error type.
          */
         public Response.Status getStatus() {
+
+            /* Unless HTTP Basic Auth is enabled,
+             * override UNAUTHORIZED with FORBIDDEN */
+            if (status == Response.Status.UNAUTHORIZED) {
+                try {
+                    Environment env = new LocalEnvironment();
+
+                    if (env.getProperty(Environment.ENABLE_HTTP_BASIC_AUTH, false))
+                        return status;
+                } catch (GuacamoleException e) { }
+
+                return Response.Status.FORBIDDEN;
+            }
+
             return status;
         }
 

--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/APIException.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/APIException.java
@@ -37,6 +37,19 @@ import org.glyptodon.guacamole.form.Field;
  */
 public class APIException extends WebApplicationException {
 
+    /* Build a Response with necessary headers according to given APIError */
+    private static Response getResponse(APIError error) {
+        Response.Status status = error.getType().getStatus();
+
+        /* Add WWW-Authenticate to 401 Unauthorized response as required */
+        if (status == Response.Status.UNAUTHORIZED) {
+            return Response.status(status).header("WWW-Authenticate",
+                      "Basic realm=\"Guacamole\"").entity(error).build();
+        }
+
+        return Response.status(status).entity(error).build();
+    }
+
     /**
      * Construct a new APIException with the given error. All information
      * associated with this new exception will be extracted from the given
@@ -46,7 +59,7 @@ public class APIException extends WebApplicationException {
      *     The error that occurred.
      */
     public APIException(APIError error) {
-        super(Response.status(error.getType().getStatus()).entity(error).build());
+        super(getResponse(error));
     }
 
     /**


### PR DESCRIPTION
Some reverse proxies support SSO via HTTP Basic authentication if
the server requests it with 401 Unauthorized response.

Add a guacamole.properties option "enable-http-basic-auth" to tell
Guacamole to request HTTP Basic authentication (instead of forbidden).

The handling of Authorization header to do the actual authentication
is currently already implemented within Guacamole.

Signed-off-by: Isaac Boukris <iboukris@gmail.com>