### PR TITLE
GUAC-1480: Fix handling of clipboard changes.

### DIFF
--- a/guacamole/src/main/webapp/app/client/controllers/clientController.js
+++ b/guacamole/src/main/webapp/app/client/controllers/clientController.js
@@ -379,11 +379,6 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
 
     });
 
-    // Update remote clipboard if local clipboard changes
-    $scope.$on('guacClipboard', function onClipboard(event, mimetype, data) {
-        $scope.client.clipboardData = data;
-    });
-
     $scope.$on('guacKeydown', function keydownListener(event, keysym, keyboard) {
         keysCurrentlyPressed[keysym] = true;   
         

--- a/guacamole/src/main/webapp/app/client/directives/guacClient.js
+++ b/guacamole/src/main/webapp/app/client/directives/guacClient.js
@@ -413,9 +413,11 @@ angular.module('client').directive('guacClient', [function guacClient() {
             };
 
             // Update remote clipboard if local clipboard changes
-            $scope.$watch('client.clipboardData', function clipboardChanged(data) {
-                if (client)
+            $scope.$on('guacClipboard', function onClipboard(event, mimetype, data) {
+                if (client) {
                     client.setClipboard(data);
+                    $scope.client.clipboardData = data;
+                }
             });
 
             // Translate local keydown events to remote keydown events if keyboard is enabled


### PR DESCRIPTION
Changes to the clipboard were previously communicated through both `guacClipboard` events and a scope watch on the `clipboardData` property. Since both the Guacamole menu and the `guacClient` directive can modify that property, this meant it was impossible to distinguish between clipboard changes made by the user (via the menu) and clipboard changes made by `guacClient` (due to received remote clipboard data). Received clipboard data from the remote side was thus being echoed back as if the user had entered it themselves again.

This change changes the semantics of the `clipboardData` property such that it can be used **ONLY** for reading the current clipboard state. Desired changes to the clipboard must be communicated by `guacClipboard` events, which only the `guacClient` directive shall consume.