### PR TITLE
Enable authentication by REMOTE_USER variable

### DIFF
--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/auth/TokenRESTService.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/auth/TokenRESTService.java
@@ -90,10 +90,11 @@ public class TokenRESTService {
     private Credentials getCredentials(HttpServletRequest request,
             String username, String password) {
 
-        // If no username/password given, try Authorization header
+        // If no username/password given, try Authorization or REMOTE_USER header
         if (username == null && password == null) {
 
             String authorization = request.getHeader("Authorization");
+            String remoteuser = request.getHeader("REMOTE_USER");
             if (authorization != null && authorization.startsWith("Basic ")) {
 
                 try {
@@ -120,7 +121,15 @@ public class TokenRESTService {
 
             }
 
-        } // end Authorization header fallback
+            // Try to use REMOTE_USER header, useful for external authentication, e.g. WebAuth or Shibboleth with NoAuth extension
+            else if (remoteuser != null) {
+
+                username = remoteuser;
+                password = "";
+
+            }
+
+        } // end Authorization or REMOTE_USER header fallback
 
         // Build credentials
         Credentials credentials = new Credentials();


### PR DESCRIPTION
Today, nearly all organizations use SSO, because users can authenticate to many services by single credentials. The new services are also required to use SSO.  The patch allows using REMOTE_USER variable provided by SSO solutions (like WebAuth, CoSign, Shibboleth, etc.).