### PR TITLE
GUAC-1378: Allow modification of HTML via extensions

### DIFF
--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/extension/Extension.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/extension/Extension.java
@@ -90,6 +90,12 @@ public class Extension {
     private final Map<String, Resource> cssResources;
 
     /**
+     * Map of all HTML patch resources defined within the extension, where each
+     * key is the path to that resource within the extension.
+     */
+    private final Map<String, Resource> htmlResources;
+
+    /**
      * Map of all translation resources defined within the extension, where
      * each key is the path to that resource within the extension.
      */
@@ -352,6 +358,7 @@ public class Extension {
         // Define static resources
         cssResources = getClassPathResources("text/css", manifest.getCSSPaths());
         javaScriptResources = getClassPathResources("text/javascript", manifest.getJavaScriptPaths());
+        htmlResources = getClassPathResources("text/html", manifest.getHTMLPaths());
         translationResources = getClassPathResources("application/json", manifest.getTranslationPaths());
         staticResources = getClassPathResources(manifest.getResourceTypes());
 
@@ -429,6 +436,19 @@ public class Extension {
      */
     public Map<String, Resource> getCSSResources() {
         return cssResources;
+    }
+
+    /**
+     * Returns a map of all declared HTML patch resources associated with this
+     * extension, where the key of each entry in the map is the path to that
+     * resource within the extension .jar. HTML patch resources are declared
+     * within the extension manifest.
+     *
+     * @return
+     *     All declared HTML patch resources associated with this extension.
+     */
+    public Map<String, Resource> getHTMLResources() {
+        return htmlResources;
     }
 
     /**

--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/extension/ExtensionManifest.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/extension/ExtensionManifest.java
@@ -68,6 +68,12 @@ public class ExtensionManifest {
     private Collection<String> cssPaths;
 
     /**
+     * The paths of all HTML patch resources within the .jar of the extension
+     * associated with this manifest.
+     */
+    private Collection<String> htmlPaths;
+
+    /**
      * The paths of all translation JSON files within this extension, if any.
      */
     private Collection<String> translationPaths;
@@ -230,6 +236,36 @@ public class ExtensionManifest {
     @JsonProperty("css")
     public void setCSSPaths(Collection<String> cssPaths) {
         this.cssPaths = cssPaths;
+    }
+
+    /**
+     * Returns the paths to all HTML patch resources within the extension. These
+     * paths are defined within the manifest by the "html" property as an array
+     * of strings, where each string is a path relative to the root of the
+     * extension .jar.
+     *
+     * @return
+     *     A collection of paths to all HTML patch resources within the
+     *     extension.
+     */
+    @JsonProperty("html")
+    public Collection<String> getHTMLPaths() {
+        return htmlPaths;
+    }
+
+    /**
+     * Sets the paths to all HTML patch resources within the extension. These
+     * paths are defined within the manifest by the "html" property as an array
+     * of strings, where each string is a path relative to the root of the
+     * extension .jar.
+     *
+     * @param htmlPatchPaths
+     *     A collection of paths to all HTML patch resources within the
+     *     extension.
+     */
+    @JsonProperty("html")
+    public void setHTMLPaths(Collection<String> htmlPatchPaths) {
+        this.htmlPaths = htmlPatchPaths;
     }
 
     /**

--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/extension/PatchResourceService.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/extension/PatchResourceService.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2016 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.glyptodon.guacamole.net.basic.extension;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import org.glyptodon.guacamole.net.basic.resource.Resource;
+
+/**
+ * Service which provides access to all HTML patches as resources, and allows
+ * other patch resources to be added.
+ *
+ * @author Michael Jumper
+ */
+public class PatchResourceService {
+
+    /**
+     * A list of all HTML patch resources currently defined, in the order they
+     * should be applied.
+     */
+    private final List<Resource> resources = new ArrayList<Resource>();
+
+    /**
+     * Adds the given HTML patch resource such that it will apply to the
+     * Guacamole UI. The patch will be applied by the JavaScript side of the
+     * web application in the order that addPatchResource() is invoked.
+     *
+     * @param resource
+     *     The HTML patch resource to add. This resource must have the mimetype
+     *     "text/html".
+     */
+    public void addPatchResource(Resource resource) {
+        resources.add(resource);
+    }
+
+    /**
+     * Adds the given HTML patch resources such that they will apply to the
+     * Guacamole UI. The patches will be applied by the JavaScript side of the
+     * web application in the order provided.
+     *
+     * @param resources
+     *     The HTML patch resources to add. Each resource must have the
+     *     mimetype "text/html".
+     */
+    public void addPatchResources(Collection<Resource> resources) {
+        for (Resource resource : resources)
+            addPatchResource(resource);
+    }
+
+    /**
+     * Returns a list of all HTML patches currently associated with this
+     * service, in the order they should be applied. The returned list cannot
+     * be modified.
+     *
+     * @return
+     *     A list of all HTML patches currently associated with this service.
+     */
+    public List<Resource> getPatchResources() {
+        return Collections.unmodifiableList(resources);
+    }
+
+}

--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/RESTServiceModule.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/RESTServiceModule.java
@@ -38,6 +38,7 @@ import org.glyptodon.guacamole.net.basic.rest.auth.SecureRandomAuthTokenGenerato
 import org.glyptodon.guacamole.net.basic.rest.auth.TokenSessionMap;
 import org.glyptodon.guacamole.net.basic.rest.history.HistoryRESTService;
 import org.glyptodon.guacamole.net.basic.rest.language.LanguageRESTService;
+import org.glyptodon.guacamole.net.basic.rest.patch.PatchRESTService;
 import org.glyptodon.guacamole.net.basic.rest.schema.SchemaRESTService;
 import org.glyptodon.guacamole.net.basic.rest.user.UserRESTService;
 
@@ -91,6 +92,7 @@ public class RESTServiceModule extends ServletModule {
         bind(ConnectionRESTService.class);
         bind(HistoryRESTService.class);
         bind(LanguageRESTService.class);
+        bind(PatchRESTService.class);
         bind(SchemaRESTService.class);
         bind(TokenRESTService.class);
         bind(UserRESTService.class);

--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/patch/PatchRESTService.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/patch/PatchRESTService.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2016 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.glyptodon.guacamole.net.basic.rest.patch;
+
+import com.google.inject.Inject;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import org.glyptodon.guacamole.GuacamoleException;
+import org.glyptodon.guacamole.GuacamoleServerException;
+import org.glyptodon.guacamole.net.basic.extension.PatchResourceService;
+import org.glyptodon.guacamole.net.basic.resource.Resource;
+
+/**
+ * A REST Service for handling the listing of HTML patches.
+ *
+ * @author Michael Jumper
+ */
+@Path("/patches")
+@Produces(MediaType.APPLICATION_JSON)
+public class PatchRESTService {
+
+    /**
+     * Service for retrieving information regarding available HTML patch
+     * resources.
+     */
+    @Inject
+    private PatchResourceService patchResourceService;
+
+    /**
+     * Reads the entire contents of the given resource as a String. The
+     * resource is assumed to be encoded in UTF-8.
+     *
+     * @param resource
+     *     The resource to read as a new String.
+     *
+     * @return
+     *     A new String containing the contents of the given resource.
+     *
+     * @throws IOException
+     *     If an I/O error prevents reading the resource.
+     */
+    private String readResourceAsString(Resource resource) throws IOException {
+
+        StringBuilder contents = new StringBuilder();
+
+        char buffer[] = new char[8192];
+        int length;
+
+        // Read entire resource into StringBuilder one chunk at a time
+        Reader reader = new InputStreamReader(resource.asStream(), "UTF-8");
+        while ((length = reader.read(buffer)) != -1) {
+            contents.append(buffer, 0, length);
+        }
+
+        return contents.toString();
+
+    }
+
+    /**
+     * Returns a list of all available HTML patches, in the order they should
+     * be applied. Each patch is raw HTML containing additional meta tags
+     * describing how and where the patch should be applied.
+     *
+     * @return
+     *     A list of all HTML patches defined in the system, in the order they
+     *     should be applied.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs preventing any HTML patch from being read.
+     */
+    @GET
+    public List<String> getPatches() throws GuacamoleException {
+
+        try {
+
+            // Allocate a list of equal size to the total number of patches
+            List<Resource> resources = patchResourceService.getPatchResources();
+            List<String> patches = new ArrayList<String>(resources.size());
+
+            // Convert each patch resource to a string
+            for (Resource resource : resources) {
+                patches.add(readResourceAsString(resource));
+            }
+
+            // Return all patches in string form
+            return patches;
+
+        }
+
+        // Bail out entirely on error
+        catch (IOException e) {
+            throw new GuacamoleServerException("Unable to read HTML patches.", e);
+        }
+
+    }
+
+}

--- a/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/patch/package-info.java
+++ b/guacamole/src/main/java/org/glyptodon/guacamole/net/basic/rest/patch/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2016 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * Classes related to the HTML patch retrieval aspect of the Guacamole REST API.
+ */
+package org.glyptodon.guacamole.net.basic.rest.patch;
+

--- a/guacamole/src/main/webapp/app/index/config/templateRequestDecorator.js
+++ b/guacamole/src/main/webapp/app/index/config/templateRequestDecorator.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2016 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * Overrides $templateRequest such that HTML patches defined within Guacamole
+ * extensions are automatically applied to template contents.
+ */
+angular.module('index').config(['$provide', function($provide) {
+    $provide.decorator('$templateRequest', ['$delegate', '$injector',
+            function decorateTemplateRequest($delegate, $injector) {
+
+        // Required services
+        var $q = $injector.get('$q');
+
+        /**
+         * Invokes $templateRequest() with all arguments exactly as provided,
+         * applying all HTML patches from any installed Guacamole extensions
+         * to the HTML of the requested template.
+         *
+         * @returns {Promise.<String>}
+         *     A Promise which resolves with the patched HTML contents of the
+         *     requested template if retrieval of the template is successful.
+         */
+        var decoratedTemplateRequest = function decoratedTemplateRequest() {
+            
+            var deferred = $q.defer();
+
+            // Resolve promise with patched template HTML
+            $delegate.apply(this, arguments).then(function patchTemplate(data) {
+
+                // Parse HTML into DOM tree
+                var root = $('<div></div>').html(data);
+
+                // STUB: Apply HTML patches
+                root.find('a').after('<p>HELLO</p>');
+
+                // Transform back into HTML
+                deferred.resolve.call(this, root.html());
+
+            }, deferred.reject);
+
+            return deferred.promise;
+
+        };
+
+        return decoratedTemplateRequest;
+
+    }]);
+}]);

--- a/guacamole/src/main/webapp/app/index/config/templateRequestDecorator.js
+++ b/guacamole/src/main/webapp/app/index/config/templateRequestDecorator.js
@@ -32,16 +32,192 @@ angular.module('index').config(['$provide', function($provide) {
         var $q = $injector.get('$q');
 
         /**
-         * Array of the root elements of all patches which should be applied to
-         * the HTML of retrieved templates.
+         * Array of the raw HTML of all patches which should be applied to the
+         * HTML of retrieved templates.
          *
-         * @type Element[]
+         * @type String[]
          */
         var patches = [
-            $('<guac-patch before="a"><p>HELLO BEFORE</p></guac-patch>')[0],
-            $('<guac-patch after="a"><p>HELLO AFTER</p></guac-patch>')[0],
-            $('<guac-patch replace="div.protocol"><div class="protocol">:-)</div></guac-patch>')[0]
+            '<meta name="before" content="a"><p>HELLO BEFORE</p>',
+            '<meta name="after" content="a"><p>HELLO AFTER</p>',
+            '<meta name="replace" content="div.protocol"><div class="protocol">:-)</div>'
         ];
+
+        /**
+         * Represents a single HTML patching operation which will be applied
+         * to the raw HTML of a template. The name of the patching operation
+         * MUST be one of the valid names defined within
+         * PatchOperation.Operations.
+         *
+         * @contructor
+         * @param {String} name
+         *     The name of the patching operation that will be applied. Valid
+         *     names are defined within PatchOperation.Operations.
+         *
+         * @param {String} selector
+         *     The CSS selector which determines which elements within a
+         *     template will be affected by the patch operation.
+         */
+        var PatchOperation = function PatchOperation(name, selector) {
+
+            /**
+             * Applies this patch operation to the template defined by the
+             * given root element, which must be a single element wrapped by
+             * JQuery.
+             *
+             * @param {Element[]} root
+             *     The JQuery-wrapped root element of the template to which
+             *     this patch operation should be applied.
+             *
+             * @param {Element[]} elements
+             *     The elements which should be applied by the patch
+             *     operation. For example, if the patch operation is inserting
+             *     elements, these are the elements that will be inserted.
+             */
+            this.apply = function apply(root, elements) {
+                PatchOperation.Operations[name](root, selector, elements);
+            };
+
+        };
+
+        /**
+         * Mapping of all valid patch operation names to their corresponding
+         * implementations. Each implementation accepts the same three
+         * parameters: the root element of the template being patched, the CSS
+         * selector determining which elements within the template are patched,
+         * and an array of elements which make up the body of the patch.
+         *
+         * @type Object.<String, Function>
+         */
+        PatchOperation.Operations = {
+
+            /**
+             * Inserts the given elements before the elements matched by the
+             * provided CSS selector.
+             *
+             * @param {Element[]} root
+             *     The JQuery-wrapped root element of the template being
+             *     patched.
+             *
+             * @param {String} selector
+             *     The CSS selector which determines where this patch operation
+             *     should be applied within the template defined by root.
+             *
+             * @param {Element[]} elements
+             *     The contents of the patch which should be applied to the
+             *     template defined by root at the locations selected by the
+             *     given CSS selector.
+             */
+            'before' : function before(root, selector, elements) {
+                root.find(selector).before(elements);
+            },
+
+            /**
+             * Inserts the given elements after the elements matched by the
+             * provided CSS selector.
+             *
+             * @param {Element[]} root
+             *     The JQuery-wrapped root element of the template being
+             *     patched.
+             *
+             * @param {String} selector
+             *     The CSS selector which determines where this patch operation
+             *     should be applied within the template defined by root.
+             *
+             * @param {Element[]} elements
+             *     The contents of the patch which should be applied to the
+             *     template defined by root at the locations selected by the
+             *     given CSS selector.
+             */
+            'after' : function after(root, selector, elements) {
+                root.find(selector).after(elements);
+            },
+
+            /**
+             * Replaces the elements matched by the provided CSS selector with
+             * the given elements.
+             *
+             * @param {Element[]} root
+             *     The JQuery-wrapped root element of the template being
+             *     patched.
+             *
+             * @param {String} selector
+             *     The CSS selector which determines where this patch operation
+             *     should be applied within the template defined by root.
+             *
+             * @param {Element[]} elements
+             *     The contents of the patch which should be applied to the
+             *     template defined by root at the locations selected by the
+             *     given CSS selector.
+             */
+            'replace' : function replace(root, selector, elements) {
+                root.find(selector).replaceWith(elements);
+            },
+
+            /**
+             * Inserts the given elements within the elements matched by the
+             * provided CSS selector, before any existing children.
+             *
+             * @param {Element[]} root
+             *     The JQuery-wrapped root element of the template being
+             *     patched.
+             *
+             * @param {String} selector
+             *     The CSS selector which determines where this patch operation
+             *     should be applied within the template defined by root.
+             *
+             * @param {Element[]} elements
+             *     The contents of the patch which should be applied to the
+             *     template defined by root at the locations selected by the
+             *     given CSS selector.
+             */
+            'before-children' : function beforeChildren(root, selector, elements) {
+                root.find(selector).prepend(elements);
+            },
+
+            /**
+             * Inserts the given elements within the elements matched by the
+             * provided CSS selector, after any existing children.
+             *
+             * @param {Element[]} root
+             *     The JQuery-wrapped root element of the template being
+             *     patched.
+             *
+             * @param {String} selector
+             *     The CSS selector which determines where this patch operation
+             *     should be applied within the template defined by root.
+             *
+             * @param {Element[]} elements
+             *     The contents of the patch which should be applied to the
+             *     template defined by root at the locations selected by the
+             *     given CSS selector.
+             */
+            'after-children' : function afterChildren(root, selector, elements) {
+                root.find(selector).append(elements);
+            },
+
+            /**
+             * Inserts the given elements within the elements matched by the
+             * provided CSS selector, replacing any existing children.
+             *
+             * @param {Element[]} root
+             *     The JQuery-wrapped root element of the template being
+             *     patched.
+             *
+             * @param {String} selector
+             *     The CSS selector which determines where this patch operation
+             *     should be applied within the template defined by root.
+             *
+             * @param {Element[]} elements
+             *     The contents of the patch which should be applied to the
+             *     template defined by root at the locations selected by the
+             *     given CSS selector.
+             */
+            'replace-children' : function replaceChildren(root, selector, elements) {
+                root.find(selector).empty().append(elements);
+            }
+
+        };
 
         /**
          * Invokes $templateRequest() with all arguments exactly as provided,
@@ -65,29 +241,38 @@ angular.module('index').config(['$provide', function($provide) {
                 // Apply all defined patches
                 angular.forEach(patches, function applyPatch(patch) {
 
-                    // Ignore any patches which are malformed
-                    if (patch.tagName !== 'GUAC-PATCH')
-                        return;
+                    var elements = $(patch);
 
-                    // Insert after any elements which match the "after"
-                    // selector (if defined)
-                    var after = patch.getAttribute('after');
-                    if (after)
-                        root.find(after).after(patch.innerHTML);
+                    // Filter out and parse all applicable meta tags
+                    var operations = [];
+                    elements = elements.filter(function filterMetaTags(index, element) {
 
-                    // Insert before any elements which match the "before"
-                    // selector (if defined)
-                    var before = patch.getAttribute('before');
-                    if (before)
-                        root.find(before).before(patch.innerHTML);
+                        // Leave non-meta tags untouched
+                        if (element.tagName !== 'META')
+                            return true;
 
-                    // Replace any elements which match the "replace" selector
-                    // (if defined)
-                    var replace = patch.getAttribute('replace');
-                    if (replace)
-                        root.find(replace).html(patch.innerHTML);
+                        // Only meta tags having a valid "name" attribute need
+                        // to be filtered
+                        var name = element.getAttribute('name');
+                        if (!name || !(name in PatchOperation.Operations))
+                            return true;
 
-                    // Ignore all other attributes
+                        // The "content" attribute must be present for any
+                        // valid "name" meta tag
+                        var content = element.getAttribute('content');
+                        if (!content)
+                            return true;
+
+                        // Filter out and parse meta tag
+                        operations.push(new PatchOperation(name, content));
+                        return false;
+
+                    });
+
+                    // Apply each operation implied by the meta tags
+                    angular.forEach(operations, function applyOperation(operation) {
+                        operation.apply(root, elements);
+                    });
 
                 });
 

--- a/guacamole/src/main/webapp/app/index/config/templateRequestDecorator.js
+++ b/guacamole/src/main/webapp/app/index/config/templateRequestDecorator.js
@@ -49,7 +49,7 @@ angular.module('index').config(['$provide', function($provide) {
          * MUST be one of the valid names defined within
          * PatchOperation.Operations.
          *
-         * @contructor
+         * @constructor
          * @param {String} name
          *     The name of the patching operation that will be applied. Valid
          *     names are defined within PatchOperation.Operations.

--- a/guacamole/src/main/webapp/app/rest/services/cacheService.js
+++ b/guacamole/src/main/webapp/app/rest/services/cacheService.js
@@ -49,6 +49,13 @@ angular.module('rest').factory('cacheService', ['$injector',
     service.languages = $cacheFactory('API-LANGUAGES');
 
     /**
+     * Cache used by patchService.
+     *
+     * @type $cacheFactory.Cache
+     */
+    service.patches = $cacheFactory('API-PATCHES');
+
+    /**
      * Cache used by schemaService.
      *
      * @type $cacheFactory.Cache

--- a/guacamole/src/main/webapp/app/rest/services/patchService.js
+++ b/guacamole/src/main/webapp/app/rest/services/patchService.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2016 Glyptodon LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * Service for operating on HTML patches via the REST API.
+ */
+angular.module('rest').factory('patchService', ['$injector',
+        function patchService($injector) {
+
+    // Required services
+    var $http                 = $injector.get('$http');
+    var authenticationService = $injector.get('authenticationService');
+    var cacheService          = $injector.get('cacheService');
+
+    var service = {};
+    
+    /**
+     * Makes a request to the REST API to get the list of patches, returning
+     * a promise that provides the array of all applicable patches if
+     * successful. Each patch is a string of raw HTML with meta information
+     * describing the patch operation stored within meta tags.
+     *                          
+     * @returns {Promise.<String[]>}
+     *     A promise which will resolve with an array of HTML patches upon
+     *     success.
+     */
+    service.getPatches = function getPatches() {
+
+        // Build HTTP parameters set
+        var httpParameters = {
+            token : authenticationService.getCurrentToken()
+        };
+
+        // Retrieve all applicable HTML patches
+        return $http({
+            cache   : cacheService.patches,
+            method  : 'GET',
+            url     : 'api/patches',
+            params  : httpParameters
+        });
+
+    };
+    
+    return service;
+
+}]);


### PR DESCRIPTION
This change allows HTML "patches" to be specified within `guac-manifest.json` under the `html` property, similar to the existing `css` and `js` properties already used for CSS and JavaScript files respectively.

Each specified HTML file within `guac-manifest.json` is automatically exposed to the JavaScript side of the web application through a REST service. The JavaScript driving the UI then automatically applies these patches to the HTML as it is loaded.

The HTML patches are simply HTML fragments containing additional `meta` tags that dictate how the patch is to be applied. Each tag is of the form `<meta name="NAME" content="SELECTOR">` where `NAME` is one of the names listed below and `SELECTOR` is a CSS selector:

Name Attribute      | Description
-------------------|-----------------
`before`           | Inserts the HTML fragment before any element which matches the CSS selector `SELECTOR`. 
`after`            | Inserts the HTML fragment after any element which matches the CSS selector `SELECTOR`.
`replace`          | Replaces any element which matches the CSS selector `SELECTOR` with the HTML fragment.
`before-children`  | Inserts the HTML fragment before the children (contents) of any element which matches the CSS selector `SELECTOR`.
`after-children`   | Inserts the HTML fragment after the children (contents) of any element which matches the CSS selector `SELECTOR`.
`replace-children` | Replaces the children (contents) of any element which matches the CSS selector `SELECTOR` with the HTML fragment.

Such HTML patches are listed by their filename within an array in `guac-manifest.json` under the `html` property:

```javascript
{
    ...

    "html" : [
        "web/patch1.html",
        "web/patch2.html",
        "web/patch3.html"
    ],

    ...
}
```