### PR TITLE
French translation updates and fixes + improved on-screen AZERTY keyboard

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/fr.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/fr.json
@@ -3,10 +3,55 @@
     "LOGIN" : {
 
         "ERROR_PASSWORD_BLANK"    : "@:APP.ERROR_PASSWORD_BLANK",
+        "ERROR_PASSWORD_SAME"     : "Le nouveau mot de passe doit être différent de celui expiré.",
         "ERROR_PASSWORD_MISMATCH" : "@:APP.ERROR_PASSWORD_MISMATCH",
+        "ERROR_NOT_VALID"         : "Ce compte utilisateur n’est actuellement pas valable.",
+        "ERROR_NOT_ACCESSIBLE"    : "L’accès à ce compte n’est actuellement pas autorisé. Veuillez réessayer plus tard.",
 
-        "FIELD_HEADER_NEW_PASSWORD"         : "Mot de passe",
-        "FIELD_HEADER_CONFIRM_NEW_PASSWORD" : "Répéter mot de passe"
+        "INFO_PASSWORD_EXPIRED" : "Votre mot de passe a expiré et doit être mis à jour. Veuillez saisir un nouveau mot de passe pour continuer.",
+
+        "FIELD_HEADER_NEW_PASSWORD"         : "Nouveau mot de passe",
+        "FIELD_HEADER_CONFIRM_NEW_PASSWORD" : "Retapez le mot de passe"
+
+    },
+
+    "CONNECTION_ATTRIBUTES" : {
+
+        "FIELD_HEADER_MAX_CONNECTIONS"          : "Nombre maximum de connexions :",
+        "FIELD_HEADER_MAX_CONNECTIONS_PER_USER" : "Nombre maximum de connexions par utilisateur :",
+
+        "SECTION_HEADER_CONCURRENCY" : "Limites de concurrence"
+
+    },
+
+    "CONNECTION_GROUP_ATTRIBUTES" : {
+
+        "FIELD_HEADER_MAX_CONNECTIONS"          : "Nombre maximum de connexions :",
+        "FIELD_HEADER_MAX_CONNECTIONS_PER_USER" : "Nombre maximum de connexions par utilisateur :",
+
+        "SECTION_HEADER_CONCURRENCY" : "Limites de concurrence (groupes d’équilibrage)"
+
+    },
+
+    "DATA_SOURCE_MYSQL" : {
+        "NAME" : "MySQL"
+    },
+
+    "DATA_SOURCE_POSTGRESQL" : {
+        "NAME" : "PostgreSQL"
+    },
+
+    "USER_ATTRIBUTES" : {
+
+        "FIELD_HEADER_DISABLED"            : "Compte désactivé :",
+        "FIELD_HEADER_EXPIRED"             : "Mot de passe expiré :",
+        "FIELD_HEADER_ACCESS_WINDOW_END"   : "Interdire l’accès après :",
+        "FIELD_HEADER_ACCESS_WINDOW_START" : "Autoriser l’accès à partir de :",
+        "FIELD_HEADER_TIMEZONE"            : "Fuseau horaire de l’utilisateur :",
+        "FIELD_HEADER_VALID_FROM"          : "Activer le compte après :",
+        "FIELD_HEADER_VALID_UNTIL"         : "Désactiver le compte après :",
+
+        "SECTION_HEADER_RESTRICTIONS" : "Restrictions de compte"
 
     }
 

--- a/guacamole/src/main/webapp/app/index/config/indexTranslationConfig.js
+++ b/guacamole/src/main/webapp/app/index/config/indexTranslationConfig.js
@@ -36,7 +36,8 @@ angular.module('index').config(['$injector', function($injector) {
     $translateProvider.preferredLanguage(preferenceServiceProvider.preferences.language);
 
     // Escape any HTML in translation strings
-    $translateProvider.useSanitizeValueStrategy('escape');
+	// D² Note: disabled because it breaks non breaking spaces
+    // $translateProvider.useSanitizeValueStrategy('escape');
 
     // Load translations via translationLoader service
     $translateProvider.useLoader('translationLoader');

--- a/guacamole/src/main/webapp/layouts/fr-fr-azerty.json
+++ b/guacamole/src/main/webapp/layouts/fr-fr-azerty.json
@@ -6,6 +6,46 @@
 
     "keys" : {
 
+        "Back"  : {
+            "title"  : "⟵",
+            "keysym" : 65288
+        },
+        "Tab"   : {
+            "title"  : "↹",
+            "keysym" : 65289
+        },
+        "Enter"  : {
+            "title"  : "Entrée",
+            "keysym" : 65293
+        },
+        "Enter2"  : {
+            "title"  : "⭶",
+            "keysym" : 65293
+        },
+        "Esc" : {
+            "title"  : "Échap",
+            "keysym" : 65307
+        },
+        "Home" : {
+            "title"  : "⭮",
+            "keysym" : 65360
+        },
+        "PgUp" : {
+            "title"  : "⇞",
+            "keysym" : 65365
+        },
+        "PgDn" : {
+            "title"  : "⇟",
+            "keysym" : 65366
+        },
+        "End" : {
+            "title"  : "Fin",
+            "keysym" : 65367
+        },
+        "Ins" : {
+            "title"  : "Inser",
+            "keysym" : 65379
+        },
         "F1"    : 65470,
         "F2"    : 65471,
         "F3"    : 65472,
@@ -19,63 +59,27 @@
         "F11"   : 65480,
         "F12"   : 65481,
 
-        "Space" : " ",
-
-        "Esc" : [{
-            "title"  : "Echap",
-            "keysym" : 65307
-        }],
-        "Back" : [{
-            "title"  : "⟵",
-            "keysym" : 65288
-        }],
-        "Tab" : [{
-            "title"  : "↹",
-            "keysym" : 65289
-        }],
-        "Enter" : [{
-            "title"  : "Entrée",
-            "keysym" : 65293
-        }],
-        "Home" : [{
-            "title"  : "Origine",
-            "keysym" : 65360
-        }],
-        "PgUp" : [{
-            "title"  : "Pg préc.",
-            "keysym" : 65365
-        }],
-        "PgDn" : [{
-            "title"  : "Pg suiv.",
-            "keysym" : 65366
-        }],
-        "End" : [{
-            "title"  : "Fin",
-            "keysym" : 65367
-        }],
-        "Ins" : [{
-            "title"  : "Inser",
-            "keysym" : 65379
-        }],
-        "Del" : [{
+        "Del" : {
             "title"  : "Suppr",
             "keysym" : 65535
-        }],
+        },
+
+        "Space" : " ",
 
         "Left" : [{
-            "title"  : "←",
+            "title"  : "🠠",
             "keysym" : 65361
         }],
         "Up" : [{
-            "title"  : "↑",
+            "title"  : "🠢",
             "keysym" : 65362
         }],
         "Right" : [{
-            "title"  : "→",
+            "title"  : "🠡",
             "keysym" : 65363
         }],
         "Down" : [{
-            "title"  : "↓",
+            "title"  : "🠣",
             "keysym" : 65364
         }],
 
@@ -84,12 +88,12 @@
             "keysym"   : 65383
         }],
         "LShift" : [{
-            "title"    : "Shift",
+            "title"    : "🢂",
             "modifier" : "shift",
             "keysym"   : 65505
         }],
         "RShift" : [{
-            "title"    : "Shift",
+            "title"    : "🢂",
             "modifier" : "shift",
             "keysym"   : 65506
         }],
@@ -104,87 +108,114 @@
             "keysym"   : 65508
         }],
         "Caps" : [{
-            "title"    : "Caps",
+            "title"    : "🔒",
             "modifier" : "caps",
             "keysym"   : 65509
         }],
-        "LAlt" : [{
+        "Alt" : [{
             "title"    : "Alt",
             "modifier" : "alt",
             "keysym"   : 65513
         }],
-        "AltGr" : [{
-            "title"    : "AltGr",
-            "modifier" : "alt-gr",
+        "Altgr" : [{
+            "title"    : "Alt Gr",
+            "modifier" : "altgr",
             "keysym"   : 65027
         }],
-        "Super" : [{
+        "LSuper" : [{
             "title"    : "Super",
             "modifier" : "super",
             "keysym"   : 65515
         }],
+        "RSuper" : [{
+            "title"    : "Super",
+            "modifier" : "super",
+            "keysym"   : 65312
+        }],
 
         "²" : [
-            { "title" : "²", "requires" : [         ] }
+            { "title" : "²", "requires" : [         ] },
+            { "title" : "~", "requires" : [ "shift" ] },
+            { "title" : "¬", "requires" : [ "altgr" ] }
         ],
         "&" : [
             { "title" : "&", "requires" : [         ] },
-            { "title" : "1", "requires" : [ "shift" ] }
+            { "title" : "1", "requires" : [ "shift" ] },
+            { "title" : "¹", "requires" : [ "altgr" ] },
+            { "title" : "¡", "requires" : [ "altgr","shift" ] }
         ],
         "é" : [
             { "title" : "é", "requires" : [         ] },
+            { "title" : "É", "requires" : [ "caps"  ] },
             { "title" : "2", "requires" : [ "shift" ] },
-            { "title" : "~", "requires" : [ "alt-gr" ] }
+            { "title" : "2", "requires" : [ "caps","shift" ] },
+            { "title" : "~", "requires" : [ "altgr" ] },
+            { "title" : "⅛", "requires" : [ "altgr","shift" ] }
         ],
         "\"" : [
-            { "title" : "\"", "requires" : [         ] },
+            { "title" : "\"","requires" : [         ] },
             { "title" : "3", "requires" : [ "shift" ] },
-            { "title" : "#", "requires" : [ "alt-gr" ] }
+            { "title" : "#", "requires" : [ "altgr" ] },
+            { "title" : "£", "requires" : [ "altgr","shift" ] }
         ],
         "'" : [
             { "title" : "'", "requires" : [         ] },
             { "title" : "4", "requires" : [ "shift" ] },
-            { "title" : "{", "requires" : [ "alt-gr" ] }
+            { "title" : "{", "requires" : [ "altgr" ] },
+            { "title" : "$", "requires" : [ "altgr","shift" ] }
         ],
         "(" : [
             { "title" : "(", "requires" : [         ] },
             { "title" : "5", "requires" : [ "shift" ] },
-            { "title" : "[", "requires" : [ "alt-gr" ] }
+            { "title" : "[", "requires" : [ "altgr" ] },
+            { "title" : "⅜", "requires" : [ "altgr","shift" ] }
         ],
         "-" : [
             { "title" : "-", "requires" : [         ] },
             { "title" : "6", "requires" : [ "shift" ] },
-            { "title" : "|", "requires" : [ "alt-gr" ] }
+            { "title" : "|", "requires" : [ "altgr" ] },
+            { "title" : "⅝", "requires" : [ "altgr","shift" ] }
         ],
         "è" : [
             { "title" : "è", "requires" : [         ] },
+            { "title" : "È", "requires" : [ "caps"  ] },
             { "title" : "7", "requires" : [ "shift" ] },
-            { "title" : "`", "requires" : [ "alt-gr" ] }
+            { "title" : "7", "requires" : [ "caps","shift" ] },
+            { "title" : "`", "requires" : [ "altgr" ] },
+            { "title" : "⅞", "requires" : [ "altgr","shift" ] }
         ],
         "_" : [
             { "title" : "_", "requires" : [         ] },
             { "title" : "8", "requires" : [ "shift" ] },
-            { "title" : "\\", "requires" : [ "alt-gr" ] }
+            { "title" : "\\","requires" : [ "altgr" ] },
+            { "title" : "™", "requires" : [ "altgr","shift" ] }
         ],
         "ç" : [
             { "title" : "ç", "requires" : [         ] },
+            { "title" : "Ç", "requires" : [ "caps"  ] },
             { "title" : "9", "requires" : [ "shift" ] },
-            { "title" : "^", "requires" : [ "alt-gr" ] }
+            { "title" : "9", "requires" : [ "caps","shift" ] },
+            { "title" : "^", "requires" : [ "altgr" ] },
+            { "title" : "±", "requires" : [ "altgr","shift" ] }
         ],
         "à" : [
             { "title" : "à", "requires" : [         ] },
+            { "title" : "À", "requires" : [ "caps"  ] },
             { "title" : "0", "requires" : [ "shift" ] },
-            { "title" : "@", "requires" : [ "alt-gr" ] }
+            { "title" : "0", "requires" : [ "caps","shift" ] },
+            { "title" : "@", "requires" : [ "altgr" ] },
+            { "title" : "°", "requires" : [ "altgr","shift" ] }
         ],
         ")" : [
             { "title" : ")", "requires" : [         ] },
             { "title" : "°", "requires" : [ "shift" ] },
-            { "title" : "]", "requires" : [ "alt-gr" ] }
+            { "title" : "]", "requires" : [ "altgr" ] },
+            { "title" : "¿", "requires" : [ "altgr","shift" ] }
         ],
         "=" : [
             { "title" : "=", "requires" : [         ] },
             { "title" : "+", "requires" : [ "shift" ] },
-            { "title" : "}", "requires" : [ "alt-gr" ] }
+            { "title" : "}", "requires" : [ "altgr" ] }
         ],
         "^" : [
             { "title" : "^", "requires" : [         ] },
@@ -193,11 +224,13 @@
         "$" : [
             { "title" : "$", "requires" : [         ] },
             { "title" : "£", "requires" : [ "shift" ] },
-            { "title" : "¤", "requires" : [ "alt-gr" ] }
+            { "title" : "¤", "requires" : [ "altgr" ] }
         ],
         "ù" : [
             { "title" : "ù", "requires" : [         ] },
-            { "title" : "%", "requires" : [ "shift" ] }
+            { "title" : "Ù", "requires" : [ "caps"  ] },
+            { "title" : "%", "requires" : [ "shift" ] },
+            { "title" : "%", "requires" : [ "caps","shift" ] }
         ],
         "*" : [
             { "title" : "*", "requires" : [         ] },
@@ -205,7 +238,9 @@
         ],
         "<" : [
             { "title" : "<", "requires" : [         ] },
-            { "title" : ">", "requires" : [ "shift" ] }
+            { "title" : ">", "requires" : [ "shift" ] },
+            { "title" : "|", "requires" : [ "altgr" ] },
+            { "title" : "¦", "requires" : [ "altgr","shift" ] }
         ],
         "," : [
             { "title" : ",", "requires" : [         ] },
@@ -213,14 +248,18 @@
         ],
         ";" : [
             { "title" : ";", "requires" : [         ] },
-            { "title" : ".", "requires" : [ "shift" ] }
+            { "title" : ".", "requires" : [ "shift" ] },
+            { "title" : "─", "requires" : [ "altgr" ] },
+            { "title" : "×", "requires" : [ "altgr","shift" ] }
         ],
         ":" : [
-            { "title" : ":",  "requires" : [         ] },
-            { "title" : "/", "requires" : [ "shift" ] }
+            { "title" : ":", "requires" : [         ] },
+            { "title" : "/", "requires" : [ "shift" ] },
+            { "title" : "·", "requires" : [ "altgr" ] },
+            { "title" : "÷", "requires" : [ "altgr","shift" ] }
         ],
         "!" : [
-            { "title" : "!",  "requires" : [         ] },
+            { "title" : "!", "requires" : [         ] },
             { "title" : "§", "requires" : [ "shift" ] }
         ],
 
@@ -228,98 +267,129 @@
             { "title" : "a", "requires" : [                 ] },
             { "title" : "A", "requires" : [ "caps"          ] },
             { "title" : "A", "requires" : [ "shift"         ] },
-            { "title" : "a", "requires" : [ "caps", "shift" ] }
+            { "title" : "a", "requires" : [ "caps", "shift" ] },
+            { "title" : "æ", "requires" : [ "altgr"         ] },
+            { "title" : "Æ", "requires" : [ "altgr","shift" ] }
         ],
         "z" : [
             { "title" : "z", "requires" : [                 ] },
             { "title" : "Z", "requires" : [ "caps"          ] },
             { "title" : "Z", "requires" : [ "shift"         ] },
-            { "title" : "z", "requires" : [ "caps", "shift" ] }
+            { "title" : "z", "requires" : [ "caps", "shift" ] },
+            { "title" : "«", "requires" : [ "altgr"         ] },
+            { "title" : "<", "requires" : [ "altgr","shift" ] }
         ],
         "e" : [
             { "title" : "e", "requires" : [                 ] },
             { "title" : "E", "requires" : [ "caps"          ] },
             { "title" : "E", "requires" : [ "shift"         ] },
             { "title" : "e", "requires" : [ "caps", "shift" ] },
-            { "title" : "€", "requires" : [ "alt-gr"        ] }
+            { "title" : "€", "requires" : [ "altgr"         ] },
+            { "title" : "¢", "requires" : [ "altgr","shift" ] }
         ],
         "r" : [
             { "title" : "r", "requires" : [                 ] },
             { "title" : "R", "requires" : [ "caps"          ] },
             { "title" : "R", "requires" : [ "shift"         ] },
-            { "title" : "r", "requires" : [ "caps", "shift" ] }
+            { "title" : "r", "requires" : [ "caps", "shift" ] },
+            { "title" : "¶", "requires" : [ "altgr"         ] },
+            { "title" : "®", "requires" : [ "altgr","shift" ] }
         ],
         "t" : [
             { "title" : "t", "requires" : [                 ] },
             { "title" : "T", "requires" : [ "caps"          ] },
             { "title" : "T", "requires" : [ "shift"         ] },
-            { "title" : "t", "requires" : [ "caps", "shift" ] }
+            { "title" : "t", "requires" : [ "caps", "shift" ] },
+            { "title" : "ŧ", "requires" : [ "altgr"         ] },
+            { "title" : "Ŧ", "requires" : [ "altgr","shift" ] }
         ],
         "y" : [
             { "title" : "y", "requires" : [                 ] },
             { "title" : "Y", "requires" : [ "caps"          ] },
             { "title" : "Y", "requires" : [ "shift"         ] },
-            { "title" : "y", "requires" : [ "caps", "shift" ] }
+            { "title" : "y", "requires" : [ "caps", "shift" ] },
+            { "title" : "←", "requires" : [ "altgr"         ] },
+            { "title" : "¥", "requires" : [ "altgr","shift" ] }
         ],
         "u" : [
             { "title" : "u", "requires" : [                 ] },
             { "title" : "U", "requires" : [ "caps"          ] },
             { "title" : "U", "requires" : [ "shift"         ] },
-            { "title" : "u", "requires" : [ "caps", "shift" ] }
+            { "title" : "u", "requires" : [ "caps", "shift" ] },
+            { "title" : "↓", "requires" : [ "altgr"         ] },
+            { "title" : "↑", "requires" : [ "altgr","shift" ] }
         ],
         "i" : [
             { "title" : "i", "requires" : [                 ] },
             { "title" : "I", "requires" : [ "caps"          ] },
             { "title" : "I", "requires" : [ "shift"         ] },
-            { "title" : "i", "requires" : [ "caps", "shift" ] }
+            { "title" : "i", "requires" : [ "caps", "shift" ] },
+            { "title" : "→", "requires" : [ "altgr"         ] },
+            { "title" : "ı", "requires" : [ "altgr","shift" ] }
         ],
         "o" : [
             { "title" : "o", "requires" : [                 ] },
             { "title" : "O", "requires" : [ "caps"          ] },
             { "title" : "O", "requires" : [ "shift"         ] },
-            { "title" : "o", "requires" : [ "caps", "shift" ] }
+            { "title" : "o", "requires" : [ "caps", "shift" ] },
+            { "title" : "œ", "requires" : [ "altgr"         ] },
+            { "title" : "Œ", "requires" : [ "altgr","shift" ] }
         ],
         "p" : [
             { "title" : "p", "requires" : [                 ] },
             { "title" : "P", "requires" : [ "caps"          ] },
             { "title" : "P", "requires" : [ "shift"         ] },
-            { "title" : "p", "requires" : [ "caps", "shift" ] }
+            { "title" : "p", "requires" : [ "caps", "shift" ] },
+            { "title" : "þ", "requires" : [ "altgr"         ] },
+            { "title" : "Þ", "requires" : [ "altgr","shift" ] }
         ],
         "q" : [
             { "title" : "q", "requires" : [                 ] },
             { "title" : "Q", "requires" : [ "caps"          ] },
             { "title" : "Q", "requires" : [ "shift"         ] },
-            { "title" : "q", "requires" : [ "caps", "shift" ] }
+            { "title" : "q", "requires" : [ "caps", "shift" ] },
+            { "title" : "@", "requires" : [ "altgr"         ] },
+            { "title" : "Ω", "requires" : [ "altgr","shift" ] }
         ],
         "s" : [
             { "title" : "s", "requires" : [                 ] },
             { "title" : "S", "requires" : [ "caps"          ] },
             { "title" : "S", "requires" : [ "shift"         ] },
-            { "title" : "s", "requires" : [ "caps", "shift" ] }
+            { "title" : "s", "requires" : [ "caps", "shift" ] },
+            { "title" : "ß", "requires" : [ "altgr"         ] },
+            { "title" : "§", "requires" : [ "altgr","shift" ] }
         ],
         "d" : [
             { "title" : "d", "requires" : [                 ] },
             { "title" : "D", "requires" : [ "caps"          ] },
             { "title" : "D", "requires" : [ "shift"         ] },
-            { "title" : "d", "requires" : [ "caps", "shift" ] }
+            { "title" : "d", "requires" : [ "caps", "shift" ] },
+            { "title" : "ð", "requires" : [ "altgr"         ] },
+            { "title" : "Ð", "requires" : [ "altgr","shift" ] }
         ],
         "f" : [
             { "title" : "f", "requires" : [                 ] },
             { "title" : "F", "requires" : [ "caps"          ] },
             { "title" : "F", "requires" : [ "shift"         ] },
-            { "title" : "f", "requires" : [ "caps", "shift" ] }
+            { "title" : "f", "requires" : [ "caps", "shift" ] },
+            { "title" : "đ", "requires" : [ "altgr"         ] },
+            { "title" : "ª", "requires" : [ "altgr","shift" ] }
         ],
         "g" : [
             { "title" : "g", "requires" : [                 ] },
             { "title" : "G", "requires" : [ "caps"          ] },
             { "title" : "G", "requires" : [ "shift"         ] },
-            { "title" : "g", "requires" : [ "caps", "shift" ] }
+            { "title" : "g", "requires" : [ "caps", "shift" ] },
+            { "title" : "ŋ", "requires" : [ "altgr"         ] },
+            { "title" : "Ŋ", "requires" : [ "altgr","shift" ] }
         ],
         "h" : [
             { "title" : "h", "requires" : [                 ] },
             { "title" : "H", "requires" : [ "caps"          ] },
             { "title" : "H", "requires" : [ "shift"         ] },
-            { "title" : "h", "requires" : [ "caps", "shift" ] }
+            { "title" : "h", "requires" : [ "caps", "shift" ] },
+            { "title" : "ħ", "requires" : [ "altgr"         ] },
+            { "title" : "Ħ", "requires" : [ "altgr","shift" ] }
         ],
         "j" : [
             { "title" : "j", "requires" : [                 ] },
@@ -331,49 +401,65 @@
             { "title" : "k", "requires" : [                 ] },
             { "title" : "K", "requires" : [ "caps"          ] },
             { "title" : "K", "requires" : [ "shift"         ] },
-            { "title" : "k", "requires" : [ "caps", "shift" ] }
+            { "title" : "k", "requires" : [ "caps", "shift" ] },
+            { "title" : "ĸ", "requires" : [ "altgr"         ] },
+            { "title" : "&", "requires" : [ "altgr","shift" ] }
         ],
         "l" : [
             { "title" : "l", "requires" : [                 ] },
             { "title" : "L", "requires" : [ "caps"          ] },
             { "title" : "L", "requires" : [ "shift"         ] },
-            { "title" : "l", "requires" : [ "caps", "shift" ] }
+            { "title" : "l", "requires" : [ "caps", "shift" ] },
+            { "title" : "ł", "requires" : [ "altgr"         ] },
+            { "title" : "Ł", "requires" : [ "altgr","shift" ] }
         ],
         "m" : [
             { "title" : "m", "requires" : [                 ] },
             { "title" : "M", "requires" : [ "caps"          ] },
             { "title" : "M", "requires" : [ "shift"         ] },
-            { "title" : "m", "requires" : [ "caps", "shift" ] }
+            { "title" : "m", "requires" : [ "caps", "shift" ] },
+            { "title" : "µ", "requires" : [ "altgr"         ] },
+            { "title" : "º", "requires" : [ "altgr","shift" ] }
         ],
         "w" : [
             { "title" : "w", "requires" : [                 ] },
             { "title" : "W", "requires" : [ "caps"          ] },
             { "title" : "W", "requires" : [ "shift"         ] },
-            { "title" : "w", "requires" : [ "caps", "shift" ] }
+            { "title" : "w", "requires" : [ "caps", "shift" ] },
+            { "title" : "ł", "requires" : [ "altgr"         ] },
+            { "title" : "Ł", "requires" : [ "altgr","shift" ] }
         ],
         "x" : [
             { "title" : "x", "requires" : [                 ] },
             { "title" : "X", "requires" : [ "caps"          ] },
             { "title" : "X", "requires" : [ "shift"         ] },
-            { "title" : "x", "requires" : [ "caps", "shift" ] }
+            { "title" : "x", "requires" : [ "caps", "shift" ] },
+            { "title" : "»", "requires" : [ "altgr"         ] },
+            { "title" : ">", "requires" : [ "altgr","shift" ] }
         ],
         "c" : [
             { "title" : "c", "requires" : [                 ] },
             { "title" : "C", "requires" : [ "caps"          ] },
             { "title" : "C", "requires" : [ "shift"         ] },
-            { "title" : "c", "requires" : [ "caps", "shift" ] }
+            { "title" : "c", "requires" : [ "caps", "shift" ] },
+            { "title" : "¢", "requires" : [ "altgr"         ] },
+            { "title" : "©", "requires" : [ "altgr","shift" ] }
         ],
         "v" : [
             { "title" : "v", "requires" : [                 ] },
             { "title" : "V", "requires" : [ "caps"          ] },
             { "title" : "V", "requires" : [ "shift"         ] },
-            { "title" : "v", "requires" : [ "caps", "shift" ] }
+            { "title" : "v", "requires" : [ "caps", "shift" ] },
+            { "title" : "“", "requires" : [ "altgr"         ] },
+            { "title" : "‘", "requires" : [ "altgr","shift" ] }
         ],
         "b" : [
             { "title" : "b", "requires" : [                 ] },
             { "title" : "B", "requires" : [ "caps"          ] },
             { "title" : "B", "requires" : [ "shift"         ] },
-            { "title" : "b", "requires" : [ "caps", "shift" ] }
+            { "title" : "b", "requires" : [ "caps", "shift" ] },
+            { "title" : "”", "requires" : [ "altgr"         ] },
+            { "title" : "’", "requires" : [ "altgr","shift" ] }
         ],
         "n" : [
             { "title" : "n", "requires" : [                 ] },
@@ -386,21 +472,19 @@
 
     "layout" : [
 
-        [ "Esc", 0.5, "F1", "F2",  "F3",  "F4",
-                 0.7, "F5", "F6",  "F7",  "F8",
-                 0.7, "F9", "F10", "F11", "F12" ],
+        [ "Esc", 1.05, "F1", "F2", "F3", "F4", 0.55, "F5", "F6", "F7", "F8", 0.55, "F9", "F10", "F11", "F12" ],
 
-        [ 0.1 ],
+        [ 0.2 ],
 
         {
             "main" : {
                 "alpha" : [
 
-                    [ "²", "&", "é", "\"", "'", "(", "-", "è", "_", "ç", "à", ")", "=", "Back" ],
-                    [ "Tab", "a", "z", "e", "r", "t", "y", "u", "i", "o", "p", "^", "$", 1, 0.8 ],
-                    [ "Caps",  "q", "s", "d", "f", "g", "h", "j", "k", "l", "m", "ù", "*", "Enter" ],
-                    [ "LShift", "<", "w", "x", "c", "v",  "b", "n", ",", ";", ":", "!", "RShift" ],
-                    [ "LCtrl", "Super", "LAlt",       "Space",        "AltGr", "Menu", "RCtrl" ]
+                    [ "²", "&", "é", "\"", "'", "(", "-", "è", "_", "ç", "à", ")", "=",   "Back"  ],
+                    [ "Tab",  "a", "z", "e", "r", "t", "y", "u", "i", "o", "p", "^", "$", "Enter" ],
+                    [ "Caps", "q", "s", "d", "f", "g", "h", "j", "k", "l", "m", "ù", "*", "Enter2"],
+                    [ "LShift", "<", "w", "x", "c", "v",  "b", "n", ",", ";", ":", "!",  "RShift" ],
+                    [ "LCtrl", "LSuper", "Alt",    "Space",   "Altgr", "RSuper", "Menu", "RCtrl"  ]
 
                 ],
 
@@ -418,28 +502,22 @@
 
     "keyWidths" : {
 
-        "Esc"    : 1.2,
-        "Back"   : 2,
-        "Tab"    : 1.3,
-        "Caps"   : 1.3,
-        "Enter"  : 1.7,
-        "LShift" : 2,
-        "RShift" : 2.1,
+        "Back"   : 2.1,
+        "Tab"    : 1.55,
+        "Caps"   : 1.80,
+        "Enter"  : 1.55,
+        "Enter2" : 1.275,
+        "LShift" : 1.275,
+        "RShift" : 2.925,
 
-        "LCtrl" : 1.6,
-        "Super" : 1.6,
-        "LAlt"  : 1.6,
-        "Space" : 6.1,
-        "AltGr" : 1.6,
-        "Menu"  : 1.6,
-        "RCtrl" : 1.6,
-
-        "Ins"  : 1.6,
-        "Home" : 1.6,
-        "PgUp" : 1.6,
-        "Del"  : 1.6,
-        "End"  : 1.6,
-        "PgDn" : 1.6
+        "LCtrl"  : 1.275,
+        "LSuper" : 1.275,
+        "Alt"    : 1.275,
+        "Space"  : 6.775,
+        "Altgr"  : 1.275,
+        "RSuper" : 1.275,
+        "Menu"   : 1.275,
+        "RCtrl"  : 1.275
 
     }
 

--- a/guacamole/src/main/webapp/translations/fr.json
+++ b/guacamole/src/main/webapp/translations/fr.json
@@ -9,36 +9,36 @@
         "ACTION_CLONE"              : "Cloner",
         "ACTION_CONTINUE"           : "Continuer",
         "ACTION_DELETE"             : "Supprimer",
-        "ACTION_DELETE_SESSIONS"    : "Fermer les Sessions",
+        "ACTION_DELETE_SESSIONS"    : "Clore les sessions",
         "ACTION_LOGIN"              : "Se connecter",
         "ACTION_LOGOUT"             : "Se déconnecter",
         "ACTION_MANAGE_CONNECTIONS" : "Connexions",
         "ACTION_MANAGE_PREFERENCES" : "Préférences",
         "ACTION_MANAGE_SETTINGS"    : "Paramètres",
-        "ACTION_MANAGE_SESSIONS"    : "Sessions Actives",
+        "ACTION_MANAGE_SESSIONS"    : "Sessions actives",
         "ACTION_MANAGE_USERS"       : "Utilisateurs",
         "ACTION_NAVIGATE_BACK"      : "Retour",
         "ACTION_NAVIGATE_HOME"      : "Accueil",
         "ACTION_SAVE"               : "Enregistrer",
         "ACTION_SEARCH"             : "Rechercher",
-        "ACTION_UPDATE_PASSWORD"    : "Mettre à jour mot de passe",
+        "ACTION_UPDATE_PASSWORD"    : "Modifier le mot de passe",
         "ACTION_VIEW_HISTORY"       : "Historique",
 
         "DIALOG_HEADER_ERROR" : "Erreur",
 
         "ERROR_PASSWORD_BLANK"    : "Votre mot de passe ne peut pas être vide.",
-        "ERROR_PASSWORD_MISMATCH" : "Le mot de passe ne correspond pas.",
+        "ERROR_PASSWORD_MISMATCH" : "Les mots de passe ne correspondent pas.",
         
-        "FIELD_HEADER_PASSWORD"       : "Mot de passe:",
-        "FIELD_HEADER_PASSWORD_AGAIN" : "Répéter mot de passe:",
+        "FIELD_HEADER_PASSWORD"       : "Mot de passe :",
+        "FIELD_HEADER_PASSWORD_AGAIN" : "Veuillez retaper le mot de passe :",
 
         "FIELD_PLACEHOLDER_FILTER" : "Filtre",
 
-        "FORMAT_DATE_TIME_PRECISE" : "dd-MM-yyyy HH:mm:ss",
+        "FORMAT_DATE_TIME_PRECISE" : "dd/MM/yyyy HH:mm:ss",
 
         "INFO_ACTIVE_USER_COUNT" : "Actuellement utilisé par {USERS} {USERS, plural, one{utilisateur} other{utilisateurs}}.",
 
-        "NAME" : "Guacamole ${project.version}",
+        "NAME" : "Guacamole 0.9.9",
 
         "TEXT_HISTORY_DURATION" : "{VALUE} {UNIT, select, second{{VALUE, plural, one{seconde} other{secondes}}} minute{{VALUE, plural, one{minute} other{minutes}}} hour{{VALUE, plural, one{heure} other{heures}}} day{{VALUE, plural, one{jour} other{jours}}} other{}}"
 
@@ -54,95 +54,95 @@
         "ACTION_NAVIGATE_HOME"             : "@:APP.ACTION_NAVIGATE_HOME",
         "ACTION_RECONNECT"                 : "Reconnecter",
         "ACTION_SAVE_FILE"                 : "@:APP.ACTION_SAVE",
-        "ACTION_UPLOAD_FILES"              : "Envoyer Fichiers",
+        "ACTION_UPLOAD_FILES"              : "Envoyer des fichiers",
 
         "DIALOG_HEADER_CONNECTING"       : "Connexion",
         "DIALOG_HEADER_CONNECTION_ERROR" : "Erreur de connexion",
         "DIALOG_HEADER_DISCONNECTED"     : "Déconnecté",
 
-        "ERROR_CLIENT_201"     : "Cette connexion a été fermée car le serveur est occupé. Merci d'attendre quelques minutes et de réessayer.",
-        "ERROR_CLIENT_202"     : "Le serveur Guacamole a fermé cette connexion car l'ordinateur distant a mis trop de temps à répondre. Merci de réessayer ou de contacter l'administrateur.",
-        "ERROR_CLIENT_203"     : "Le serveur distant a rencontré une erreur et a fermé la connexion. Merci de réessayer ou de contacter l'administrateur.",
-        "ERROR_CLIENT_205"     : "Cette connexion a été fermée car elle est en conflit avec une autre. Merci de réessayer plus tard.", 
-        "ERROR_CLIENT_301"     : "Connexion echouée. Merci d'essayer encore.", 
-        "ERROR_CLIENT_303"     : "Vous ne disposez pas des permissions pour accéder à cette connexion. Si vous avez besoin de ces droits demandez à l'administrateur qu'il vous ajoute à la lise des utilisateurs autorisés, ou de vérifier les paramètres système.", 
-        "ERROR_CLIENT_308"     : "Le serveur Guacamole a fermé la connexion car il n'y avait pas de réponse de votre navigateur Internet et qu'il l'a considéré comme déconnecté. Cela se produit à cause de problèmes réseaux (mauvais signal Wi-Fi ou réseau très lent). Merci de vérifier votre réseau et de réessayer.", 
-        "ERROR_CLIENT_31D"     : "Le serveur Guacamole interdit les connexions car vous avez dépassé la limite de connexion simultanée par utilisateur. Merci de fermer une ou plusieurs connexions et de reéssayer.", 
-        "ERROR_CLIENT_DEFAULT" : "Une erreur interne est apparue dans le serveur Guacamole et la connexion a été fermée. Si le problème persiste, merci de notifier l'administrateur ou de regarder les journaux système.", 
+        "ERROR_CLIENT_201"     : "Cette connexion a été fermée car le serveur est occupé. Merci d’attendre quelques minutes et de réessayer.",
+        "ERROR_CLIENT_202"     : "Le serveur Guacamole a fermé cette connexion car l’ordinateur distant a mis trop de temps à répondre. Merci de réessayer ou de contacter l’administrateur.",
+        "ERROR_CLIENT_203"     : "Le serveur distant a rencontré une erreur et a fermé la connexion. Merci de réessayer ou de contacter l’administrateur.",
+        "ERROR_CLIENT_205"     : "Cette connexion a été fermée car elle est en conflit avec une autre. Merci de réessayer plus tard.",
+        "ERROR_CLIENT_301"     : "La tentative de connexion a échoué. Veuillez réessayer.",
+        "ERROR_CLIENT_303"     : "Vous ne disposez pas des permissions pour accéder à cette connexion. Si vous avez besoin de ces droits, demandez à l’administrateur qu’il vous ajoute à la lise des utilisateurs autorisés ou de vérifier les paramètres système.",
+        "ERROR_CLIENT_308"     : "Le serveur Guacamole a fermé la connexion car il n’y avait pas de réponse de votre navigateur Internet et qu’il l’a considéré comme déconnecté. Cela se produit à cause de problèmes réseau (mauvais signal Wi‐Fi ou réseau très lent). Merci de vérifier votre réseau et de réessayer.",
+        "ERROR_CLIENT_31D"     : "Le serveur Guacamole interdit les connexions car vous avez dépassé la limite de connexion simultanée par utilisateur. Merci de fermer une ou plusieurs connexions et de réessayer.",
+        "ERROR_CLIENT_DEFAULT" : "Une erreur interne est survenue dans le serveur Guacamole et la connexion a été fermée. Si le problème persiste, merci de notifier l’administrateur ou de regarder les journaux système.",
 
-        "ERROR_TUNNEL_201"     : "Le serveur Guacamole a rejeté cette tentative de connexion car il y a trop de connexions ouvertes. Merci d'attendre quelques minutes et de réessayer.", 
-        "ERROR_TUNNEL_202"     : "La connexion a été fermée car le serveur met trop de temps à répondre. En général, il s'agit de problème réseau comme un réseau Wi-Fi trop lent ou un réseau très lent. Merci de vérifier votre réseau ou de contacter l'administrateur.", 
-        "ERROR_TUNNEL_203"     : "Le serveur a rencontré une erreur et a fermé la connexion. Merci de réessayer ou de contacter l'administrateur.", 
-        "ERROR_TUNNEL_204"     : "Le connexion demandée n'existe pas. Merci de vérifier le nom et de réessayer.",
-        "ERROR_TUNNEL_205"     : "Cette connexion est actuellement utilisée et les connexions multiples ne sont pas autorisées. Merci de réeassyer plus tard.", 
-        "ERROR_TUNNEL_301"     : "Vous n'avez pas le droit d'accéder à cette connexion car vous n'êtes pas connecté. Merci de vous connecter et de réessayer.", 
-        "ERROR_TUNNEL_303"     : "Vous n'avez pas le droit d'accéder à cette connexion. Si vous souhaitez y avoir accès, merci de demander à l'administrateur de vous ajouter dans la liste des utilisateurs autorisés ou de vérifier les paramètres système.",
-        "ERROR_TUNNEL_308"     : "Le serveur Guacamole a fermé la connexion car il n'y avait pas de réponse de votre navigateur Internet et qu'il l'a considéré comme déconnecté. Cela se produit à cause de problèmes réseaux (mauvais signal Wi-Fi ou réseau très lent). Merci de vérifier votre réseau et de réessayer.",
-        "ERROR_TUNNEL_31D"     : "Le serveur Guacamole interdit cette connexion car vous avez dépassé la limite de connexions simultanées par utilisateur. Merci de fermer une ou plusieurs connexions et de reéssayer.",
-        "ERROR_TUNNEL_DEFAULT" : "Une erreur interne est apparue dans le serveur Guacamole et la connexion a été fermée. Si le problème persiste, merci de notifier l'administrateur ou de regarder les journaux système.",
+        "ERROR_TUNNEL_201"     : "Le serveur Guacamole a rejeté cette tentative de connexion car il y a trop de connexions ouvertes. Merci d’attendre quelques minutes et de réessayer.",
+        "ERROR_TUNNEL_202"     : "La connexion a été fermée car le serveur met trop de temps à répondre. En général, il s’agit de problème réseau comme un réseau Wi‐Fi trop lent ou un réseau très lent. Merci de vérifier votre réseau ou de contacter l’administrateur.",
+        "ERROR_TUNNEL_203"     : "Le serveur a rencontré une erreur et a fermé la connexion. Merci de réessayer ou de contacter l’administrateur.",
+        "ERROR_TUNNEL_204"     : "Le connexion demandée n’existe pas. Merci de vérifier le nom et de réessayer.",
+        "ERROR_TUNNEL_205"     : "Cette connexion est actuellement utilisée et les connexions multiples ne sont pas autorisées. Merci de réessayer plus tard.",
+        "ERROR_TUNNEL_301"     : "Vous n’avez pas le droit d’accéder à cette connexion car vous êtes actuellement déconnecté. Merci de vous connecter et de réessayer.",
+        "ERROR_TUNNEL_303"     : "Vous n’avez pas le droit d’accéder à cette connexion. Si vous souhaitez y avoir accès, merci de demander à l’administrateur de vous ajouter dans la liste des utilisateurs autorisés ou de vérifier les paramètres système.",
+        "ERROR_TUNNEL_308"     : "Le serveur Guacamole a fermé la connexion car il n’y avait pas de réponse de votre navigateur Internet et qu’il l’a considéré comme déconnecté. Cela se produit à cause de problèmes réseau (mauvais signal Wi‐Fi ou réseau très lent). Merci de vérifier votre réseau et de réessayer.",
+        "ERROR_TUNNEL_31D"     : "Le serveur Guacamole interdit cette connexion car vous avez dépassé la limite de connexions simultanées par utilisateur. Merci de fermer une ou plusieurs connexions et de réessayer.",
+        "ERROR_TUNNEL_DEFAULT" : "Une erreur interne est survenue dans le serveur Guacamole et la connexion a été fermée. Si le problème persiste, merci de notifier l’administrateur ou de regarder les journaux système.",
 
-        "ERROR_UPLOAD_100"     : "Le transfert de fichier n'est pas activé ou supporté. Merci de contacter l'administrateur ou de vérifier les journaux système.",
-        "ERROR_UPLOAD_201"     : "Trop de fichiers sont transférés. Merci d'attendre que les transferts en cours se terminent et réessayer.",
+        "ERROR_UPLOAD_100"     : "Le transfert de fichiers n’est pas activé ou pris en charge. Merci de contacter l’administrateur ou de vérifier les journaux système.",
+        "ERROR_UPLOAD_201"     : "Trop de fichiers sont transférés. Merci d’attendre que les transferts en cours se terminent et réessayer.",
         "ERROR_UPLOAD_202"     : "Le fichier ne peut être transféré car le serveur distant met trop de temps à répondre. Merci de réessayer ou de contacter votre administrateur.",
-        "ERROR_UPLOAD_203"     : "Le serveur distant a rencontré une erreur durant le transfert. Merci de reéssayer et de contacter l'administrateur.",
-        "ERROR_UPLOAD_204"     : "La destination du transfert de fichier n'existe pas. Merci de vérifier que la destination existe et de réessayer.",
-        "ERROR_UPLOAD_205"     : "La destination du transfert de fichier est actuellement verouillée. Merci de patienter la fin des tâches en cours et de réessayer.",
-        "ERROR_UPLOAD_301"     : "Vous n'avez pas la permission d'envoyer ce fichier car vous n'êtes pas connecté. Merci de vous connecter et de réessayer.",
-        "ERROR_UPLOAD_303"     : "Vous n'avez pas la permission d'envoyer le fichier. Si vous avez besoin de cet accès, merci de vérifier vos paramètres system ou de valider avec votre administrateur.", 
-        "ERROR_UPLOAD_308"     : "Le transfert de fichier s'est bloqué. En général, il s'agit d'un problème réseau comme un signal Wi-Fi faible ou un réseau très lent. Merci de vérifier votre réseau et de réessayer.",
-        "ERROR_UPLOAD_31D"     : "Trop de fichiers sont actuellement transférés. Merci d'attendre que les transferts en cours soient terminés et de réessayer plus tard.", 
-        "ERROR_UPLOAD_DEFAULT" : "Une erreur interne est apparue dans le serveur Guacamole et la connexion a été fermée. Si le problème persiste, merci de notifier l'administrateur ou de regarder les journaux système.",
+        "ERROR_UPLOAD_203"     : "Le serveur distant a rencontré une erreur durant le transfert. Merci de réessayer et de contacter l’administrateur.",
+        "ERROR_UPLOAD_204"     : "La destination du transfert de fichiers n’existe pas. Merci de vérifier la destination et de réessayer.",
+        "ERROR_UPLOAD_205"     : "La destination du transfert de fichiers est actuellement verrouillée. Merci de patienter jusqu’à la fin des tâches en cours et de réessayer.",
+        "ERROR_UPLOAD_301"     : "Vous n’avez pas la permission d’envoyer ce fichier car vous n’êtes pas connecté. Merci de vous connecter et de réessayer.",
+        "ERROR_UPLOAD_303"     : "Vous n’avez pas la permission d’envoyer le fichier. Si vous avez besoin de cet accès, merci de vérifier vos paramètres système ou de les valider avec votre administrateur.",
+        "ERROR_UPLOAD_308"     : "Le transfert de fichiers s’est bloqué. En général, il s’agit d’un problème réseau comme un signal Wi‐Fi faible ou un réseau très lent. Merci de vérifier votre réseau et de réessayer.",
+        "ERROR_UPLOAD_31D"     : "Trop de fichiers sont actuellement transférés. Merci d’attendre que les transferts en cours soient terminés et de réessayer plus tard.",
+        "ERROR_UPLOAD_DEFAULT" : "Une erreur interne est survenue dans le serveur Guacamole et la connexion a été fermée. Si le problème persiste, merci de prévenir l’administrateur ou de regarder les journaux système.",
 
-        "HELP_CLIPBOARD"           : "Texte copié/coupé dans Guacamole apparaîtra ici. Changer le texte ci dessous affectera le presse-papiers distant.",
-        "HELP_INPUT_METHOD_NONE"   : "Aucune méthode de saisie utilisée. Clavier accepté depuis un clavier physique connecté.",
-        "HELP_INPUT_METHOD_OSK"    : "Affiche et utilise la saisie du clavier virtuel intégré dans Guacamole. Le clavier virtuel permet d'utiliser des combinaisons de touches autrement impossibles (comme Ctrl-Alt-Supp).",
-        "HELP_INPUT_METHOD_TEXT"   : "Affiche et utilise la saisie du clavier virtuel intégré dans Guacamole. Ceci est nécessaire pou les périphériques mobiles ne disposant pas de clavier physique.",
-        "HELP_MOUSE_MODE"          : "Détermine comment la souris distante se comporte selon les événements.", 
-        "HELP_MOUSE_MODE_ABSOLUTE" : "Appuyer pour cliquer. Le clique s'effectue à l'endroit de l'appui.",
-        "HELP_MOUSE_MODE_RELATIVE" : "Glisser pour déplacer le pointeur de la souris et appuyer opur cliquer. Le clique s'effectue à l'endroit du pointeur.", 
+        "HELP_CLIPBOARD"           : "Le texte copié ou coupé dans Guacamole apparaîtra ici. Changer le texte ci‐dessous affectera le presse‐papiers distant.",
+        "HELP_INPUT_METHOD_NONE"   : "Aucune méthode de saisie utilisée. Les entrées clavier sont acceptées depuis un clavier physique connecté.",
+        "HELP_INPUT_METHOD_OSK"    : "Affiche et utilise la saisie du clavier virtuel intégré dans Guacamole. Le clavier virtuel permet d’utiliser des combinaisons de touches autrement impossibles (comme Ctrl-Alt-Suppr).",
+        "HELP_INPUT_METHOD_TEXT"   : "Affiche et utilise la saisie du clavier virtuel intégré dans Guacamole. Ceci est nécessaire pour les périphériques mobiles ne disposant pas de clavier physique.",
+        "HELP_MOUSE_MODE"          : "Détermine comment la souris distante se comporte selon les événements.",
+        "HELP_MOUSE_MODE_ABSOLUTE" : "Appuyer pour cliquer. Le clic s’effectue à l’endroit de l’appui.",
+        "HELP_MOUSE_MODE_RELATIVE" : "Glisser pour déplacer le pointeur de la souris et appuyer pour cliquer. Le clic s’effectue à l’endroit du pointeur.",
 
-        "INFO_NO_FILE_TRANSFERS" : "Pas de transfert de fichier.",
+        "INFO_NO_FILE_TRANSFERS" : "Aucun transfert de fichiers.",
 
-        "NAME_INPUT_METHOD_NONE"   : "Aucune",
-        "NAME_INPUT_METHOD_OSK"    : "Clavier virtuel",
-        "NAME_INPUT_METHOD_TEXT"   : "Clavier",
+        "NAME_INPUT_METHOD_NONE"   : "aucune",
+        "NAME_INPUT_METHOD_OSK"    : "clavier virtuel",
+        "NAME_INPUT_METHOD_TEXT"   : "clavier",
         "NAME_KEY_CTRL"            : "Ctrl",
         "NAME_KEY_ALT"             : "Alt",
-        "NAME_KEY_ESC"             : "Echap",
+        "NAME_KEY_ESC"             : "Échap",
         "NAME_KEY_TAB"             : "Tab",
         "NAME_MOUSE_MODE_ABSOLUTE" : "Écran tactile",
         "NAME_MOUSE_MODE_RELATIVE" : "Pavé tactile",
 
-        "SECTION_HEADER_CLIPBOARD"      : "Presse-papiers",
-        "SECTION_HEADER_DEVICES"        : "Appareils",
+        "SECTION_HEADER_CLIPBOARD"      : "Presse‐papiers",
+        "SECTION_HEADER_DEVICES"        : "Périphériques",
         "SECTION_HEADER_DISPLAY"        : "Affichage",
-        "SECTION_HEADER_FILE_TRANSFERS" : "Transfers de fichiers",
+        "SECTION_HEADER_FILE_TRANSFERS" : "Transferts de fichiers",
         "SECTION_HEADER_INPUT_METHOD"   : "Méthode de saisie",
-        "SECTION_HEADER_MOUSE_MODE"     : "Mode émulation souris",
+        "SECTION_HEADER_MOUSE_MODE"     : "Mode d’émulation de la souris",
 
         "TEXT_ZOOM_AUTO_FIT"              : "Adapté à la fenêtre du navigateur",
         "TEXT_CLIENT_STATUS_IDLE"         : "Inactif.",
-        "TEXT_CLIENT_STATUS_CONNECTING"   : "Connexion à Guacamole...",
-        "TEXT_CLIENT_STATUS_DISCONNECTED" : "Vous avez été deconnecté.",
-        "TEXT_CLIENT_STATUS_WAITING"      : "Connecté à Guacamole. En attente de réponse...",
-        "TEXT_RECONNECT_COUNTDOWN"        : "Reconnexion dans {REMAINING} {REMAINING, plural, one{seconde} other{secondes}}...",
-        "TEXT_FILE_TRANSFER_PROGRESS"     : "{PROGRESS} {UNIT, select, b{B} kb{KB} mb{MB} gb{GB} other{}}",
+        "TEXT_CLIENT_STATUS_CONNECTING"   : "Connexion à Guacamole…",
+        "TEXT_CLIENT_STATUS_DISCONNECTED" : "Vous avez été deconnecté !",
+        "TEXT_CLIENT_STATUS_WAITING"      : "Connecté à Guacamole. En attente de réponse…",
+        "TEXT_RECONNECT_COUNTDOWN"        : "Reconnexion dans {REMAINING} {REMAINING, plural, one{seconde} other{secondes}}…",
+        "TEXT_FILE_TRANSFER_PROGRESS"     : "{PROGRESS} {UNIT, select, b{octets} kb{Kio} mb{Mio} gb{Gio} other{}}",
 
-        "URL_OSK_LAYOUT" : "layouts/fr-fr-azerty.json" 
+        "URL_OSK_LAYOUT" : "layouts/fr-fr-azerty.json"
 
     },
 
     "DATA_SOURCE_DEFAULT" : {
-        "NAME" : "Standard (XML)"
+        "NAME" : "Par défaut (XML)"
     },
 
     "FORM" : {
 
-        "FIELD_PLACEHOLDER_DATE" : "AAAA-MM-JJ",
+        "FIELD_PLACEHOLDER_DATE" : "YYYY-MM-DD",
         "FIELD_PLACEHOLDER_TIME" : "HH:MM:SS",
 
-        "HELP_SHOW_PASSWORD" : "Cliquer pour afficher le mot de passe",
-        "HELP_HIDE_PASSWORD" : "Cliquer pour masquer le mot de passe"
+        "HELP_SHOW_PASSWORD" : "Cliquez pour afficher le mot de passe.",
+        "HELP_HIDE_PASSWORD" : "Cliquez pour masquer le mot de passe."
 
     },
 
@@ -152,11 +152,11 @@
 
         "INFO_ACTIVE_USER_COUNT" : "@:APP.INFO_ACTIVE_USER_COUNT",
 
-        "INFO_NO_RECENT_CONNECTIONS" : "Pas de connexion récente.",
+        "INFO_NO_RECENT_CONNECTIONS" : "Aucune connexion récente.",
         
-        "PASSWORD_CHANGED" : "Mot de passe changé.",
+        "PASSWORD_CHANGED" : "Mot de passe modifié.",
 
-        "SECTION_HEADER_ALL_CONNECTIONS"    : "Toutes les Connexions",
+        "SECTION_HEADER_ALL_CONNECTIONS"    : "Toutes les connexions",
         "SECTION_HEADER_RECENT_CONNECTIONS" : "Connexions récentes"
 
     },
@@ -169,7 +169,7 @@
 
         "DIALOG_HEADER_ERROR" : "@:APP.DIALOG_HEADER_ERROR",
 
-        "ERROR_INVALID_LOGIN" : "Identifiant Incorrect",
+        "ERROR_INVALID_LOGIN" : "Authentification incorrecte",
 
         "FIELD_HEADER_USERNAME" : "Identifiant",
         "FIELD_HEADER_PASSWORD" : "Mot de passe"
@@ -184,28 +184,28 @@
         "ACTION_DELETE"               : "@:APP.ACTION_DELETE",
         "ACTION_SAVE"                 : "@:APP.ACTION_SAVE",
 
-        "DIALOG_HEADER_CONFIRM_DELETE" : "Supprimer Connexion",
+        "DIALOG_HEADER_CONFIRM_DELETE" : "Supprimer la connexion",
         "DIALOG_HEADER_ERROR"          : "Erreur",
 
-        "FIELD_HEADER_LOCATION" : "Lieu:",
-        "FIELD_HEADER_NAME"     : "Nom:",
-        "FIELD_HEADER_PROTOCOL" : "Protocole:",
+        "FIELD_HEADER_LOCATION" : "Localisation :",
+        "FIELD_HEADER_NAME"     : "Nom :",
+        "FIELD_HEADER_PROTOCOL" : "Protocole :",
 
         "FORMAT_HISTORY_START" : "@:APP.FORMAT_DATE_TIME_PRECISE",
 
         "INFO_CONNECTION_DURATION_UNKNOWN" : "--",
         "INFO_CONNECTION_ACTIVE_NOW"       : "Active",
-        "INFO_CONNECTION_NOT_USED"         : "Cette connexion n'a jamais été utilisée.",
+        "INFO_CONNECTION_NOT_USED"         : "Cette connexion n’a jamais été utilisée.",
 
-        "SECTION_HEADER_EDIT_CONNECTION" : "Modifier Connexion",
-        "SECTION_HEADER_HISTORY"         : "Historique d'utilisation",
+        "SECTION_HEADER_EDIT_CONNECTION" : "Modifier la connexion",
+        "SECTION_HEADER_HISTORY"         : "Historique d’utilisation",
         "SECTION_HEADER_PARAMETERS"      : "Paramètres",
 
         "TABLE_HEADER_HISTORY_USERNAME" : "Identifiant",
         "TABLE_HEADER_HISTORY_START"    : "Ouverture",
         "TABLE_HEADER_HISTORY_DURATION" : "Durée",
 
-        "TEXT_CONFIRM_DELETE"   : "Les connexions ne pourront être restaurées une fois supprimées. Êtes-vous certains de vouloir supprimer cette connexion ?",
+        "TEXT_CONFIRM_DELETE"   : "Les connexions ne pourront être restaurées une fois supprimées. Êtes‐vous certain de vouloir supprimer cette connexion ?",
         "TEXT_HISTORY_DURATION" : "@:APP.TEXT_HISTORY_DURATION"
 
     },
@@ -217,19 +217,19 @@
         "ACTION_DELETE"        : "@:APP.ACTION_DELETE",
         "ACTION_SAVE"          : "@:APP.ACTION_SAVE",
 
-        "DIALOG_HEADER_CONFIRM_DELETE" : "Supprimer Groupe de Connexion",
+        "DIALOG_HEADER_CONFIRM_DELETE" : "Suppression d’un groupe de connexions",
         "DIALOG_HEADER_ERROR"          : "Erreur",
 
-        "FIELD_HEADER_LOCATION" : "Lieu:",
-        "FIELD_HEADER_NAME"     : "Nom:",
-        "FIELD_HEADER_TYPE"     : "Type:",
+        "FIELD_HEADER_LOCATION" : "Localisation :",
+        "FIELD_HEADER_NAME"     : "Nom :",
+        "FIELD_HEADER_TYPE"     : "Type :",
 
         "NAME_TYPE_BALANCING"       : "Répartition",
-        "NAME_TYPE_ORGANIZATIONAL"  : "Organizationel",
+        "NAME_TYPE_ORGANIZATIONAL"  : "Organisationnel",
 
-        "SECTION_HEADER_EDIT_CONNECTION_GROUP" : "Modifier Groupe de Connexion",
+        "SECTION_HEADER_EDIT_CONNECTION_GROUP" : "Modification d’un groupe de connexions",
 
-        "TEXT_CONFIRM_DELETE" : "Les groupes de connexions ne pourront être restaurés une fois supprimés. Êtes-vous certains de vouloir supprimer ce groupe de connexion ?"
+        "TEXT_CONFIRM_DELETE" : "Les groupes de connexions ne pourront être restaurés une fois supprimés. Êtes‐vous certain de vouloir supprimer ce groupe de connexions ?"
 
     },
 
@@ -237,134 +237,133 @@
 
         "ACTION_ACKNOWLEDGE"   : "@:APP.ACTION_ACKNOWLEDGE",
         "ACTION_CANCEL"        : "@:APP.ACTION_CANCEL",
-        "ACTION_CLONE"         : "@:APP.ACTION_CLONE",
         "ACTION_DELETE"        : "@:APP.ACTION_DELETE",
         "ACTION_SAVE"          : "@:APP.ACTION_SAVE",
 
-        "DIALOG_HEADER_CONFIRM_DELETE"  : "Supprimer Utilisateur",
+        "DIALOG_HEADER_CONFIRM_DELETE"  : "Suppression d’utilisateur",
         "DIALOG_HEADER_ERROR"           : "Erreur",
 
         "ERROR_PASSWORD_MISMATCH" : "@:APP.ERROR_PASSWORD_MISMATCH",
 
-        "FIELD_HEADER_ADMINISTER_SYSTEM"             : "Administer system:",
-        "FIELD_HEADER_CHANGE_OWN_PASSWORD"           : "Modifier son propre mot de passe:",
-        "FIELD_HEADER_CREATE_NEW_USERS"              : "Créer nouveaux utilisateurs:",
-        "FIELD_HEADER_CREATE_NEW_CONNECTIONS"        : "Créer nouvelles connexions:",
-        "FIELD_HEADER_CREATE_NEW_CONNECTION_GROUPS"  : "Créer nouveaux groupes de connexion:",
+        "FIELD_HEADER_ADMINISTER_SYSTEM"             : "Administrer le système :",
+        "FIELD_HEADER_CHANGE_OWN_PASSWORD"           : "Modifier son propre mot de passe :",
+        "FIELD_HEADER_CREATE_NEW_USERS"              : "Créer nouveaux utilisateurs :",
+        "FIELD_HEADER_CREATE_NEW_CONNECTIONS"        : "Créer nouvelles connexions :",
+        "FIELD_HEADER_CREATE_NEW_CONNECTION_GROUPS"  : "Créer nouveaux groupes de connexion :",
         "FIELD_HEADER_PASSWORD"                      : "@:APP.FIELD_HEADER_PASSWORD",
         "FIELD_HEADER_PASSWORD_AGAIN"                : "@:APP.FIELD_HEADER_PASSWORD_AGAIN",
-        "FIELD_HEADER_USERNAME"                      : "Identifiant:",
+        "FIELD_HEADER_USERNAME"                      : "Identifiant :",
         
         "FIELD_PLACEHOLDER_FILTER" : "@:APP.FIELD_PLACEHOLDER_FILTER",
 
-        "INFO_READ_ONLY" : "Désolé, mais ce compte ne peut pas être édité.",
+        "INFO_READ_ONLY" : "Désolé, mais ce compte utilisateur ne peut être modifié.",
 
         "SECTION_HEADER_CONNECTIONS" : "Connexions",
-        "SECTION_HEADER_EDIT_USER"   : "Modifier Utilisateur",
+        "SECTION_HEADER_EDIT_USER"   : "Modifier l’utilisateur",
         "SECTION_HEADER_PERMISSIONS" : "Permissions",
 
-        "TEXT_CONFIRM_DELETE" : "Les utilisateurs ne pourront être restaurés une fois supprimés. Êtes-vous certains de vouloir supprimer cet utilisateur?"
+        "TEXT_CONFIRM_DELETE" : "Les utilisateurs ne pourront être restaurés une fois supprimés. Êtes‐vous certain de vouloir supprimer cet utilisateur ?"
 
     },
     
     "PROTOCOL_RDP" : {
 
-        "FIELD_HEADER_CLIENT_NAME"     : "Nom du Client:",
-        "FIELD_HEADER_COLOR_DEPTH"     : "Qualité couleur:",
-        "FIELD_HEADER_CONSOLE"         : "Console Administrateur:",
-        "FIELD_HEADER_CONSOLE_AUDIO"   : "Support son en console:",
-        "FIELD_HEADER_CREATE_DRIVE_PATH" : "Créer automatiquement un lecteur:",
-        "FIELD_HEADER_DISABLE_AUDIO"   : "Désactiver son:",
-        "FIELD_HEADER_DISABLE_AUTH"    : "Désactiver authentification:",
-        "FIELD_HEADER_DOMAIN"          : "Nom du domaine:",
-        "FIELD_HEADER_DPI"             : "Résolution (ppp):",
-        "FIELD_HEADER_DRIVE_PATH"      : "Chemin du lecteur:",
-        "FIELD_HEADER_ENABLE_DESKTOP_COMPOSITION" : "Activer la composition du bureau (Aero):",
-        "FIELD_HEADER_ENABLE_DRIVE"    : "Activer lecteur réseau:",
-        "FIELD_HEADER_ENABLE_FONT_SMOOTHING" : "Enable font smoothing (ClearType):",
-        "FIELD_HEADER_ENABLE_FULL_WINDOW_DRAG" : "Activer pleine fenêtre de glisser:",
-        "FIELD_HEADER_ENABLE_MENU_ANIMATIONS" : "Activer les animations de menu:",
-        "FIELD_HEADER_ENABLE_PRINTING" : "Activer imprimante:",
-        "FIELD_HEADER_ENABLE_SFTP"     : "Activer SFTP:",
-        "FIELD_HEADER_ENABLE_THEMING"  : "Activer thématisation:",
-        "FIELD_HEADER_ENABLE_WALLPAPER" : "Activer fond d'écran:",
-        "FIELD_HEADER_HEIGHT"          : "Hauteur:",
-        "FIELD_HEADER_HOSTNAME"        : "Nom d'hôte:",
-        "FIELD_HEADER_IGNORE_CERT"     : "Ignorer le certificat du serveur:",
-        "FIELD_HEADER_INITIAL_PROGRAM" : "Programme de démarrage:",
-        "FIELD_HEADER_PASSWORD"        : "Mot de passe:",
-        "FIELD_HEADER_PORT"            : "Port:",
-        "FIELD_HEADER_PRECONNECTION_BLOB" : "Pré-connexion BLOB (VM ID):",
-        "FIELD_HEADER_PRECONNECTION_ID"   : "Source RDP ID:",
-        "FIELD_HEADER_REMOTE_APP_ARGS" : "Paramètres:",
-        "FIELD_HEADER_REMOTE_APP_DIR"  : "Répertoire de travail:",
-        "FIELD_HEADER_REMOTE_APP"      : "Programme:",
-        "FIELD_HEADER_SECURITY"        : "Mode de Sécurité:",
-        "FIELD_HEADER_SERVER_LAYOUT"   : "Agencement clavier:",
-        "FIELD_HEADER_SFTP_DIRECTORY"   : "Répertoire d'upload par défaut:",
-        "FIELD_HEADER_SFTP_HOSTNAME"    : "Nom d'hôte:",
-        "FIELD_HEADER_SFTP_PASSPHRASE"  : "Phrase secrète:",
-        "FIELD_HEADER_SFTP_PASSWORD"    : "Mot de passe:",
-        "FIELD_HEADER_SFTP_PORT"        : "Port:",
-        "FIELD_HEADER_SFTP_PRIVATE_KEY" : "Clé privée:",
-        "FIELD_HEADER_SFTP_USERNAME"    : "Identifiant:",
-        "FIELD_HEADER_STATIC_CHANNELS" : "Static channel names:",
-        "FIELD_HEADER_USERNAME"        : "Identifiant:",
-        "FIELD_HEADER_WIDTH"           : "Largeur:",
+        "FIELD_HEADER_CLIENT_NAME"     : "Nom du client :",
+        "FIELD_HEADER_COLOR_DEPTH"     : "Profondeur de couleurs :",
+        "FIELD_HEADER_CONSOLE"         : "Console administrateur :",
+        "FIELD_HEADER_CONSOLE_AUDIO"   : "Prise en charge du son en console :",
+        "FIELD_HEADER_CREATE_DRIVE_PATH" : "Création automatique du lecteur :",
+        "FIELD_HEADER_DISABLE_AUDIO"   : "Désactiver le son :",
+        "FIELD_HEADER_DISABLE_AUTH"    : "Désactiver l’authentification :",
+        "FIELD_HEADER_DOMAIN"          : "Nom du domaine :",
+        "FIELD_HEADER_DPI"             : "Résolution (ppp) :",
+        "FIELD_HEADER_DRIVE_PATH"      : "Chemin du lecteur :",
+        "FIELD_HEADER_ENABLE_DESKTOP_COMPOSITION" : "Activer la composition du bureau (Aéro) :",
+        "FIELD_HEADER_ENABLE_DRIVE"    : "Activer le lecteur réseau :",
+        "FIELD_HEADER_ENABLE_FONT_SMOOTHING" : "Activer le lissage des polices (ClearType) :",
+        "FIELD_HEADER_ENABLE_FULL_WINDOW_DRAG" : "Redimensionnement de fenêtre par glissement :",
+        "FIELD_HEADER_ENABLE_MENU_ANIMATIONS" : "Activer les animations des menus :",
+        "FIELD_HEADER_ENABLE_PRINTING" : "Activer l’impression :",
+        "FIELD_HEADER_ENABLE_SFTP"     : "Activer SFTP :",
+        "FIELD_HEADER_ENABLE_THEMING"  : "Activer la thématisation :",
+        "FIELD_HEADER_ENABLE_WALLPAPER" : "Activer le fond d’écran :",
+        "FIELD_HEADER_HEIGHT"          : "Hauteur :",
+        "FIELD_HEADER_HOSTNAME"        : "Nom d’hôte :",
+        "FIELD_HEADER_IGNORE_CERT"     : "Ignorer le certificat du serveur :",
+        "FIELD_HEADER_INITIAL_PROGRAM" : "Programme de démarrage :",
+        "FIELD_HEADER_PASSWORD"        : "Mot de passe :",
+        "FIELD_HEADER_PORT"            : "Port :",
+        "FIELD_HEADER_PRECONNECTION_BLOB" : "Identifant de pré‐connexion de MV :",
+        "FIELD_HEADER_PRECONNECTION_ID"   : "Identifiant de source RDP :",
+        "FIELD_HEADER_REMOTE_APP_ARGS" : "Paramètres :",
+        "FIELD_HEADER_REMOTE_APP_DIR"  : "Répertoire de travail :",
+        "FIELD_HEADER_REMOTE_APP"      : "Programme :",
+        "FIELD_HEADER_SECURITY"        : "Mode de Sécurité :",
+        "FIELD_HEADER_SERVER_LAYOUT"   : "Agencement clavier :",
+        "FIELD_HEADER_SFTP_DIRECTORY"   : "Répertoire de téléversement par défaut :",
+        "FIELD_HEADER_SFTP_HOSTNAME"    : "Nom d’hôte :",
+        "FIELD_HEADER_SFTP_PASSPHRASE"  : "Phrase de passe :",
+        "FIELD_HEADER_SFTP_PASSWORD"    : "Mot de passe :",
+        "FIELD_HEADER_SFTP_PORT"        : "Port :",
+        "FIELD_HEADER_SFTP_PRIVATE_KEY" : "Clef privée :",
+        "FIELD_HEADER_SFTP_USERNAME"    : "Identifiant :",
+        "FIELD_HEADER_STATIC_CHANNELS" : "Noms des canaux statiques :",
+        "FIELD_HEADER_USERNAME"        : "Identifiant :",
+        "FIELD_HEADER_WIDTH"           : "Largeur :",
 
-        "FIELD_OPTION_COLOR_DEPTH_16"    : "Faibles couleurs (16-bit)",
-        "FIELD_OPTION_COLOR_DEPTH_24"    : "Vraies couleurs (24-bit)",
-        "FIELD_OPTION_COLOR_DEPTH_32"    : "Vraies couleurs (32-bit)",
-        "FIELD_OPTION_COLOR_DEPTH_8"     : "256 couleurs",
+        "FIELD_OPTION_COLOR_DEPTH_8"     : "256 couleurs (8 bits)",
+        "FIELD_OPTION_COLOR_DEPTH_16"    : "hautes couleurs (16 bits)",
+        "FIELD_OPTION_COLOR_DEPTH_24"    : "vraies couleurs (24 bits)",
+        "FIELD_OPTION_COLOR_DEPTH_32"    : "vraies couleurs (32 bits)",
         "FIELD_OPTION_COLOR_DEPTH_EMPTY" : "",
 
-        "FIELD_OPTION_SECURITY_ANY"   : "Aucune",
+        "FIELD_OPTION_SECURITY_ANY"   : "toute méthode",
         "FIELD_OPTION_SECURITY_EMPTY" : "",
         "FIELD_OPTION_SECURITY_NLA"   : "NLA (Network Level Authentication)",
-        "FIELD_OPTION_SECURITY_RDP"   : "Chiffrement RDP",
-        "FIELD_OPTION_SECURITY_TLS"   : "Chiffrement TLS",
+        "FIELD_OPTION_SECURITY_RDP"   : "chiffrement RDP",
+        "FIELD_OPTION_SECURITY_TLS"   : "chiffrement TLS",
 
-        "FIELD_OPTION_SERVER_LAYOUT_DE_DE_QWERTZ" : "German (Qwertz)",
+        "FIELD_OPTION_SERVER_LAYOUT_DE_DE_QWERTZ" : "allemand (QWERTZ)",
         "FIELD_OPTION_SERVER_LAYOUT_EMPTY"        : "",
-        "FIELD_OPTION_SERVER_LAYOUT_EN_US_QWERTY" : "US English (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_EN_US_QWERTY" : "états‐unien (QWERTY)",
         "FIELD_OPTION_SERVER_LAYOUT_FAILSAFE"     : "Unicode",
-        "FIELD_OPTION_SERVER_LAYOUT_FR_FR_AZERTY" : "French (Azerty)",
-        "FIELD_OPTION_SERVER_LAYOUT_IT_IT_QWERTY" : "Italian (Qwerty)",
-        "FIELD_OPTION_SERVER_LAYOUT_SV_SE_QWERTY" : "Swedish (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_FR_FR_AZERTY" : "français (AZERTY)",
+        "FIELD_OPTION_SERVER_LAYOUT_IT_IT_QWERTY" : "italien (QWERTY)",
+        "FIELD_OPTION_SERVER_LAYOUT_SV_SE_QWERTY" : "suédois (QWERTY)",
 
         "NAME" : "RDP",
 
         "SECTION_HEADER_AUTHENTICATION"     : "Authentification",
         "SECTION_HEADER_BASIC_PARAMETERS"   : "Paramètres de base",
-        "SECTION_HEADER_DEVICE_REDIRECTION" : "Redirection Périphérique",
+        "SECTION_HEADER_DEVICE_REDIRECTION" : "Redirection de périphériques",
         "SECTION_HEADER_DISPLAY"            : "Affichage",
         "SECTION_HEADER_NETWORK"            : "Réseau",
         "SECTION_HEADER_PERFORMANCE"        : "Performance",
-        "SECTION_HEADER_PRECONNECTION_PDU"  : "Pré-connexion PDU / Hyper-V",
-        "SECTION_HEADER_REMOTEAPP"          : "RemoteApp",
+        "SECTION_HEADER_PRECONNECTION_PDU"  : "Pré‐connexion PDU / Hyper-V",
+        "SECTION_HEADER_REMOTEAPP"          : "Applications distantes",
         "SECTION_HEADER_SFTP"               : "SFTP"
 
     },
 
     "PROTOCOL_SSH" : {
 
-        "FIELD_HEADER_COLOR_SCHEME" : "Palette de couleurs:",
-        "FIELD_HEADER_COMMAND"     : "Exécuter une commande:",
-        "FIELD_HEADER_FONT_NAME"   : "Nom police:",
-        "FIELD_HEADER_FONT_SIZE"   : "Taille police:",
-        "FIELD_HEADER_ENABLE_SFTP" : "Activer SFTP:",
-        "FIELD_HEADER_HOSTNAME"    : "Nom d'hôte:",
-        "FIELD_HEADER_USERNAME"    : "Identifiant:",
-        "FIELD_HEADER_PASSWORD"    : "Mot de passe:",
-        "FIELD_HEADER_PASSPHRASE"  : "Phrase secrète:",
-        "FIELD_HEADER_PORT"        : "Port:",
-        "FIELD_HEADER_PRIVATE_KEY" : "Clé privée:",
+        "FIELD_HEADER_COLOR_SCHEME" : "Modèle de couleurs :",
+        "FIELD_HEADER_COMMAND"     : "Commande à exécuter :",
+        "FIELD_HEADER_FONT_NAME"   : "Nom de police :",
+        "FIELD_HEADER_FONT_SIZE"   : "Taille de police :",
+        "FIELD_HEADER_ENABLE_SFTP" : "Activer SFTP :",
+        "FIELD_HEADER_HOSTNAME"    : "Nom d’hôte :",
+        "FIELD_HEADER_USERNAME"    : "Identifiant :",
+        "FIELD_HEADER_PASSWORD"    : "Mot de passe :",
+        "FIELD_HEADER_PASSPHRASE"  : "Phrase de passe :",
+        "FIELD_HEADER_PORT"        : "Port :",
+        "FIELD_HEADER_PRIVATE_KEY" : "Clef privée :",
 
-        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Noir sur blanc",
+        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "noir sur fond blanc",
         "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
-        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Gris sur noir",
-        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Vert sur noir",
-        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "Blanc sur noir",
+        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "gris sur fond noir",
+        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "vert sur fond noir",
+        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "blanc sur fond noir",
 
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",
@@ -387,27 +386,27 @@
         "SECTION_HEADER_AUTHENTICATION" : "Authentification",
         "SECTION_HEADER_DISPLAY"        : "Affichage",
         "SECTION_HEADER_NETWORK"        : "Réseau",
-        "SECTION_HEADER_SESSION"        : "Session / Environnement",
+        "SECTION_HEADER_SESSION"        : "Session et environnement",
         "SECTION_HEADER_SFTP"           : "SFTP"
 
     },
 
     "PROTOCOL_TELNET" : {
 
-        "FIELD_HEADER_COLOR_SCHEME"   : "Palette de couleurs:",
-        "FIELD_HEADER_FONT_NAME"      : "Nom police:",
-        "FIELD_HEADER_FONT_SIZE"      : "Taille police:",
-        "FIELD_HEADER_HOSTNAME"       : "Nom d'hôte:",
-        "FIELD_HEADER_USERNAME"       : "Identifiant:",
-        "FIELD_HEADER_PASSWORD"       : "Mot de passe:",
-        "FIELD_HEADER_PASSWORD_REGEX" : "Expression régulière Mot de passe:",
-        "FIELD_HEADER_PORT"           : "Port:",
+        "FIELD_HEADER_COLOR_SCHEME"   : "Modèle de couleurs :",
+        "FIELD_HEADER_FONT_NAME"      : "Nom de police :",
+        "FIELD_HEADER_FONT_SIZE"      : "Taille de police :",
+        "FIELD_HEADER_HOSTNAME"       : "Nom d’hôte :",
+        "FIELD_HEADER_USERNAME"       : "Identifiant :",
+        "FIELD_HEADER_PASSWORD"       : "Mot de passe :",
+        "FIELD_HEADER_PASSWORD_REGEX" : "Expression rationnelle du mot de passe :",
+        "FIELD_HEADER_PORT"           : "Port :",
 
-        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Noir sur blanc",
+        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "noir sur fond blanc",
         "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
-        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Gris sur noir",
-        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Vert sur noir",
-        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "Blanc sur noir",
+        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "gris sur fond noir",
+        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "vert sur fond noir",
+        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "blanc sur fond noir",
 
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",
@@ -435,40 +434,40 @@
 
     "PROTOCOL_VNC" : {
 
-        "FIELD_HEADER_AUDIO_SERVERNAME" : "Serveur de son:",
-        "FIELD_HEADER_CLIPBOARD_ENCODING" : "Encodage:",
-        "FIELD_HEADER_COLOR_DEPTH"      : "Qualité couleur:",
-        "FIELD_HEADER_CURSOR"           : "Curseur:",
-        "FIELD_HEADER_DEST_HOST"        : "Hôte distant:",
-        "FIELD_HEADER_DEST_PORT"        : "Port distant:",
-        "FIELD_HEADER_ENABLE_AUDIO"     : "Activer son:",
-        "FIELD_HEADER_ENABLE_SFTP"      : "Activer SFTP:",
-        "FIELD_HEADER_HOSTNAME"         : "Nom d'hôte:",
-        "FIELD_HEADER_PASSWORD"         : "Mot de passe:",
-        "FIELD_HEADER_PORT"             : "Port:",
-        "FIELD_HEADER_READ_ONLY"        : "Lecture seule:",
-        "FIELD_HEADER_SFTP_DIRECTORY"   : "Répertoire d'upload par défaut:",
-        "FIELD_HEADER_SFTP_HOSTNAME"    : "Nom d'hôte:",
-        "FIELD_HEADER_SFTP_PASSPHRASE"  : "Phrase secrète:",
-        "FIELD_HEADER_SFTP_PASSWORD"    : "Mot de passe:",
-        "FIELD_HEADER_SFTP_PORT"        : "Port:",
-        "FIELD_HEADER_SFTP_PRIVATE_KEY" : "Clé privée:",
-        "FIELD_HEADER_SFTP_USERNAME"    : "Identifiant:",
-        "FIELD_HEADER_SWAP_RED_BLUE"    : "Swap red/blue components:",
+        "FIELD_HEADER_AUDIO_SERVERNAME" : "Serveur de son :",
+        "FIELD_HEADER_CLIPBOARD_ENCODING" : "Encodage de caractères :",
+        "FIELD_HEADER_COLOR_DEPTH"      : "Profondeur de couleurs :",
+        "FIELD_HEADER_CURSOR"           : "Curseur :",
+        "FIELD_HEADER_DEST_HOST"        : "Hôte distant :",
+        "FIELD_HEADER_DEST_PORT"        : "Port distant :",
+        "FIELD_HEADER_ENABLE_AUDIO"     : "Activer son :",
+        "FIELD_HEADER_ENABLE_SFTP"      : "Activer SFTP :",
+        "FIELD_HEADER_HOSTNAME"         : "Nom d’hôte :",
+        "FIELD_HEADER_PASSWORD"         : "Mot de passe :",
+        "FIELD_HEADER_PORT"             : "Port :",
+        "FIELD_HEADER_READ_ONLY"        : "Lecture seule :",
+        "FIELD_HEADER_SFTP_DIRECTORY"   : "Répertoire de téléversement par défaut :",
+        "FIELD_HEADER_SFTP_HOSTNAME"    : "Nom d’hôte :",
+        "FIELD_HEADER_SFTP_PASSPHRASE"  : "Phrase de passe :",
+        "FIELD_HEADER_SFTP_PASSWORD"    : "Mot de passe :",
+        "FIELD_HEADER_SFTP_PORT"        : "Port :",
+        "FIELD_HEADER_SFTP_PRIVATE_KEY" : "Clef privée :",
+        "FIELD_HEADER_SFTP_USERNAME"    : "Identifiant :",
+        "FIELD_HEADER_SWAP_RED_BLUE"    : "Intervertir le rouge et le bleu :",
 
-        "FIELD_OPTION_COLOR_DEPTH_8"     : "256 couleurs",
-        "FIELD_OPTION_COLOR_DEPTH_16"    : "Faibles couleurs (16-bit)",
-        "FIELD_OPTION_COLOR_DEPTH_24"    : "Vraies couleurs (24-bit)",
-        "FIELD_OPTION_COLOR_DEPTH_32"    : "Vraies couleurs (32-bit)",
+        "FIELD_OPTION_COLOR_DEPTH_8"     : "256 couleurs (8 bits)",
+        "FIELD_OPTION_COLOR_DEPTH_16"    : "hautes couleurs (16 bits)",
+        "FIELD_OPTION_COLOR_DEPTH_24"    : "vraies couleurs (24 bits)",
+        "FIELD_OPTION_COLOR_DEPTH_32"    : "vraies couleurs (32 bits)",
         "FIELD_OPTION_COLOR_DEPTH_EMPTY" : "",
 
         "FIELD_OPTION_CURSOR_EMPTY"  : "",
-        "FIELD_OPTION_CURSOR_LOCAL"  : "Local",
-        "FIELD_OPTION_CURSOR_REMOTE" : "Distant",
+        "FIELD_OPTION_CURSOR_LOCAL"  : "local",
+        "FIELD_OPTION_CURSOR_REMOTE" : "distant",
 
         "FIELD_OPTION_CLIPBOARD_ENCODING_CP1252"    : "CP1252",
         "FIELD_OPTION_CLIPBOARD_ENCODING_EMPTY"     : "",
-        "FIELD_OPTION_CLIPBOARD_ENCODING_ISO8859_1" : "ISO 8859-1",
+        "FIELD_OPTION_CLIPBOARD_ENCODING_ISO8859_1" : "ISO-8859-1",
         "FIELD_OPTION_CLIPBOARD_ENCODING_UTF_8"     : "UTF-8",
         "FIELD_OPTION_CLIPBOARD_ENCODING_UTF_16"    : "UTF-16",
 
@@ -490,6 +489,28 @@
 
     },
 
+    "SETTINGS_CONNECTION_HISTORY" : {
+
+        "ACTION_SEARCH" : "@:APP.ACTION_SEARCH",
+
+        "FIELD_PLACEHOLDER_FILTER" : "@:APP.FIELD_PLACEHOLDER_FILTER",
+
+        "FORMAT_DATE" : "@:APP.FORMAT_DATE_TIME_PRECISE",
+
+        "HELP_CONNECTION_HISTORY" : "L’historique des anciennes connexions est listé ici et peut être trié en cliquant sur les en‐têtes des colonnes. Pour rechercher un enregistrement particulier, tapez une chaîne de caractères et cliquez sur « Rechercher ». Seuls les enregistrements contenant cette chaîne de caractères seront listés.",
+
+        "INFO_CONNECTION_DURATION_UNKNOWN" : "--",
+        "INFO_NO_HISTORY"                  : "Aucun enregistrement correspondant",
+
+        "TABLE_HEADER_SESSION_CONNECTION_NAME" : "Nom de connexion",
+        "TABLE_HEADER_SESSION_DURATION"        : "Durée",
+        "TABLE_HEADER_SESSION_STARTDATE"       : "Ouverte depuis",
+        "TABLE_HEADER_SESSION_USERNAME"        : "Identifiant",
+
+        "TEXT_HISTORY_DURATION" : "@:APP.TEXT_HISTORY_DURATION"
+
+    },
+
     "SETTINGS_CONNECTIONS" : {
 
         "ACTION_ACKNOWLEDGE"          : "@:APP.ACTION_ACKNOWLEDGE",
@@ -500,33 +521,11 @@
 
         "FIELD_PLACEHOLDER_FILTER" : "@:APP.FIELD_PLACEHOLDER_FILTER",
 
-        "HELP_CONNECTIONS"   : "Cliquer ou appuyer sur une connexion en dessous pour la gérer. Selon vos permissions, les connexions peuvent être ajoutées, supprimées, leur propriétés (protocole, nom d'hôte, port, etc) changées.",
+        "HELP_CONNECTIONS"   : "Cliquez ou appuyez sur une connexion ci‐dessous pour la gérer. Selon vos permissions, des connexions peuvent être ajoutées ou supprimées, et leurs propriétés (protocole, nom d’hôte, port, etc.) changées.",
         
         "INFO_ACTIVE_USER_COUNT" : "@:APP.INFO_ACTIVE_USER_COUNT",
 
         "SECTION_HEADER_CONNECTIONS"     : "Connexions"
-
-    },
-
-    "SETTINGS_CONNECTION_HISTORY" : {
-
-        "ACTION_SEARCH" : "@:APP.ACTION_SEARCH",
-
-        "FIELD_PLACEHOLDER_FILTER" : "@:APP.FIELD_PLACEHOLDER_FILTER",
-
-        "FORMAT_DATE" : "@:APP.FORMAT_DATE_TIME_PRECISE",
-
-        "HELP_CONNECTION_HISTORY" : "L'historique des dernières connexions est listé ici et peut être trié en cliquant sur l'en-tête des colonnes. Pour rechercher des enregistrements spécifiques, entrez un filtre et cliquez sur \"Rechercher\". Seuls les enregistrements correspondants au filtre renseigné seront listés.",
-
-        "INFO_CONNECTION_DURATION_UNKNOWN" : "--",
-        "INFO_NO_HISTORY"                  : "Aucun enregistrement correspondant",
-
-        "TABLE_HEADER_SESSION_CONNECTION_NAME" : "Nom de connexion",
-        "TABLE_HEADER_SESSION_DURATION"        : "Durée",
-        "TABLE_HEADER_SESSION_STARTDATE"       : "Ouvert depuis",
-        "TABLE_HEADER_SESSION_USERNAME"        : "Identifiant",
-
-        "TEXT_HISTORY_DURATION" : "@:APP.TEXT_HISTORY_DURATION"
 
     },
 
@@ -541,47 +540,47 @@
         "ERROR_PASSWORD_BLANK"    : "Votre mot de passe ne peut être vide.",
         "ERROR_PASSWORD_MISMATCH" : "@:APP.ERROR_PASSWORD_MISMATCH",
 
-        "FIELD_HEADER_LANGUAGE"           : "Langue affichée:",
-        "FIELD_HEADER_PASSWORD"           : "Mot de passe:",
-        "FIELD_HEADER_PASSWORD_OLD"       : "Mot de passe actuel:",
-        "FIELD_HEADER_PASSWORD_NEW"       : "Nouveau mot de passe:",
-        "FIELD_HEADER_PASSWORD_NEW_AGAIN" : "Confirmer nouveau mot de passe:",
-        "FIELD_HEADER_USERNAME"           : "Identifiant:",
+        "FIELD_HEADER_LANGUAGE"           : "Langue affichée :",
+        "FIELD_HEADER_PASSWORD"           : "Mot de passe :",
+        "FIELD_HEADER_PASSWORD_OLD"       : "Mot de passe actuel :",
+        "FIELD_HEADER_PASSWORD_NEW"       : "Nouveau mot de passe :",
+        "FIELD_HEADER_PASSWORD_NEW_AGAIN" : "Confirmez le mot de passe :",
+        "FIELD_HEADER_USERNAME"           : "Identifiant :",
         
-        "HELP_DEFAULT_INPUT_METHOD" : "La méthode de saisie par défaut détermine comme les événements clavier sont reçus par Guacamole. Modifier ces paramètres peut être nécessaire pour l'utilisateur des smartphone/tablette. Ces paramètres peuvent être écrasés pour chaque connexion dans le menu de Guacamole.",
-        "HELP_DEFAULT_MOUSE_MODE"   : "Le mode d'émulation de la souris détermine comment la souris distante se comportera dans les nouvelles connexions. Ce paramètre peut être définit dans chaque connexion dans le menu de Guacamole.", 
+        "HELP_DEFAULT_INPUT_METHOD" : "La méthode de saisie par défaut détermine comment les événements clavier sont reçus par Guacamole. Modifier ces paramètres peut être nécessaire pour une utilisation via un téléphone intelligent ou une tablette. Ces paramètres peuvent être écrasés pour chaque connexion dans le menu de Guacamole.",
+        "HELP_DEFAULT_MOUSE_MODE"   : "Le mode d’émulation de la souris détermine comment la souris distante se comportera pour les nouvelles connexions. Ce paramètre peut être défini dans chaque connexion dans le menu de Guacamole.",
         "HELP_INPUT_METHOD_NONE"    : "@:CLIENT.HELP_INPUT_METHOD_NONE",
         "HELP_INPUT_METHOD_OSK"     : "@:CLIENT.HELP_INPUT_METHOD_OSK",
         "HELP_INPUT_METHOD_TEXT"    : "@:CLIENT.HELP_INPUT_METHOD_TEXT",
-        "HELP_LANGUAGE"             : "Selectionner une langue différente pour changer tout le texte dans Guacamole. Les choix dépendent des langues qui sont installées.", 
+        "HELP_LANGUAGE"             : "Sélectionnez une langue spécifique pour l’interface de Guacamole. Les choix dépendent des langues qui sont installées.",
         "HELP_MOUSE_MODE_ABSOLUTE"  : "@:CLIENT.HELP_MOUSE_MODE_ABSOLUTE",
         "HELP_MOUSE_MODE_RELATIVE"  : "@:CLIENT.HELP_MOUSE_MODE_RELATIVE",
-        "HELP_UPDATE_PASSWORD"      : "Si vous souhaitez changer votre mot de passe, entrer vos mot de passe actuel et le nouveau mot de passe en dessous puis cliquer sur \"Mettre à jour Mot de passe\". Le changement prendra effet immédiatement.",
+        "HELP_UPDATE_PASSWORD"      : "Si vous souhaitez changer votre mot de passe, entrez votre mot de passe actuel et le nouveau mot de passe en dessous puis cliquer sur « Modifier le mot de passe ». Le changement prendra effet immédiatement.",
 
-        "INFO_PASSWORD_CHANGED" : "Mot de passe changé.",
+        "INFO_PASSWORD_CHANGED" : "Mot de passe modifié.",
 
         "NAME_INPUT_METHOD_NONE" : "@:CLIENT.NAME_INPUT_METHOD_NONE",
         "NAME_INPUT_METHOD_OSK"  : "@:CLIENT.NAME_INPUT_METHOD_OSK",
         "NAME_INPUT_METHOD_TEXT" : "@:CLIENT.NAME_INPUT_METHOD_TEXT",
 
-        "SECTION_HEADER_DEFAULT_INPUT_METHOD" : "Méthode de saisie par défaut", 
-        "SECTION_HEADER_DEFAULT_MOUSE_MODE"   : "Mode émulation souris par défaut", 
-        "SECTION_HEADER_UPDATE_PASSWORD"      : "Modifier Mot de passe"
+        "SECTION_HEADER_DEFAULT_INPUT_METHOD" : "Méthode de saisie par défaut",
+        "SECTION_HEADER_DEFAULT_MOUSE_MODE"   : "Mode d’émulation de la souris par défaut",
+        "SECTION_HEADER_UPDATE_PASSWORD"      : "Modifier le mot de passe"
 
     },
 
     "SETTINGS_USERS" : {
 
         "ACTION_ACKNOWLEDGE"   : "@:APP.ACTION_ACKNOWLEDGE",
-        "ACTION_NEW_USER"      : "Nouvel Utilisateur",
+        "ACTION_NEW_USER"      : "Nouvel utilisateur",
 
         "DIALOG_HEADER_ERROR"           : "Erreur",
 
         "FIELD_PLACEHOLDER_FILTER" : "@:APP.FIELD_PLACEHOLDER_FILTER",
 
-        "HELP_USERS" : "Cliquer ou appuyer sur un utilisateur en dessous pour le gérer. Selon vos permissions, les utilisateurs peuvent être ajoutés, supprimés, leur mot de passe changé.",
+        "HELP_USERS" : "Cliquez ou appuyez sur un utilisateur ci‐dessous pour le gérer. Selon vos permissions, les utilisateurs peuvent être ajoutés ou supprimés et leurs mots de passe changés.",
 
-        "SECTION_HEADER_USERS"       : "Utilisateur"
+        "SECTION_HEADER_USERS"       : "Utilisateurs"
 
     },
     
@@ -589,27 +588,27 @@
         
         "ACTION_ACKNOWLEDGE" : "@:APP.ACTION_ACKNOWLEDGE",
         "ACTION_CANCEL"      : "@:APP.ACTION_CANCEL",
-        "ACTION_DELETE"      : "Fermer Sessions",
+        "ACTION_DELETE"      : "Clore les sessions",
         
-        "DIALOG_HEADER_CONFIRM_DELETE" : "Fermer Sessions",
+        "DIALOG_HEADER_CONFIRM_DELETE" : "Clore les sessions",
         "DIALOG_HEADER_ERROR"          : "Erreur",
         
         "FIELD_PLACEHOLDER_FILTER" : "@:APP.FIELD_PLACEHOLDER_FILTER",
         
         "FORMAT_STARTDATE" : "@:APP.FORMAT_DATE_TIME_PRECISE",
 
-        "HELP_SESSIONS" : "Toutes les connexions actives Guacamole sont listées ici. Si vous souhaitez en fermer une ou plusieurs, sélectionner les et cliquer sur \"Fermer Sessions\". La fermeture d'une session déconnectera immédiatement l'utilisateur.", 
+        "HELP_SESSIONS" : "Toutes les connexions actives dans Guacamole sont listées ici. Si vous souhaitez en fermer une ou plusieurs, sélectionnez‐les et cliquez sur « Clore les sessions ». La clôture d’une session déconnectera immédiatement l’utilisateur.",
         
-        "INFO_NO_SESSIONS" : "Pas de session ouverte",
+        "INFO_NO_SESSIONS" : "Aucune session ouverte",
 
-        "SECTION_HEADER_SESSIONS" : "Sessions Ouvertes",
+        "SECTION_HEADER_SESSIONS" : "Sessions ouvertes",
         
         "TABLE_HEADER_SESSION_USERNAME"        : "Identifiant",
-        "TABLE_HEADER_SESSION_STARTDATE"       : "Ouvert depuis",
+        "TABLE_HEADER_SESSION_STARTDATE"       : "Ouverte depuis",
         "TABLE_HEADER_SESSION_REMOTEHOST"      : "Hôte distant",
         "TABLE_HEADER_SESSION_CONNECTION_NAME" : "Nom de connexion",
         
-        "TEXT_CONFIRM_DELETE" : "Êtes-vous certains de vouloir fermer toutes les connexions sélectionnées ? Les utilisateurs utilisant ces sessions seront immédiatement déconnectés." 
+        "TEXT_CONFIRM_DELETE" : "Êtes‐vous certain de vouloir clore toutes les connexions sélectionnées ? Les utilisateurs de ces sessions seront immédiatement déconnectés."
 
     },
 


### PR DESCRIPTION
This is an update to the French translation. Fixes are:
- replacement of wrong simple quotes with true apostrophes
- compliance with French typographic rules (use of non-breaking spaces and thin spaces when needed...)
- missing translations (notably for the SQL extension)
- various typos
- disabling an escape function used by the translation function that was wrongly displaying the HTML entity name of non-breaking spaces (i.e. “&amp;nbsp;”) instead of the character itself.

An updated version of the French AZERTY keyboard is also included with two new modifiers (Alt Gr and Alt Gr-Shift) and adjusted key sizes and key symbols.

TODO: the on-screen keyboard is using some rare UTF-8 characters which contains glyphs that are missing with current font. So a fix is still needed, but anyway it is usable yet.