### PR TITLE
GLEN-102: Address IE-related clipboard issues

### DIFF
--- a/guacamole/src/main/webapp/app/clipboard/styles/clipboard.css
+++ b/guacamole/src/main/webapp/app/clipboard/styles/clipboard.css
@@ -52,10 +52,10 @@
 
 .clipboard-service-target {
     position: fixed;
-    left: -1px;
-    right: -1px;
-    width: 1px;
-    height: 1px;
+    left: -1em;
+    right: -1em;
+    width: 1em;
+    height: 1em;
     white-space: pre;
     overflow: hidden;
 }

--- a/guacamole/src/main/webapp/app/index/controllers/indexController.js
+++ b/guacamole/src/main/webapp/app/index/controllers/indexController.js
@@ -137,8 +137,8 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
 
     // Attempt to read the clipboard if it may have changed
     $window.addEventListener('load',  checkClipboard, true);
-    $window.addEventListener('copy',  checkClipboard, true);
-    $window.addEventListener('cut',   checkClipboard, true);
+    $window.addEventListener('copy',  checkClipboard);
+    $window.addEventListener('cut',   checkClipboard);
     $window.addEventListener('focus', function focusGained(e) {
 
         // Only recheck clipboard if it's the window itself that gained focus


### PR DESCRIPTION
This change backports the changes from upstream [GUACAMOLE-128](https://issues.apache.org/jira/browse/GUACAMOLE-128) and [GUACAMOLE-310](https://issues.apache.org/jira/browse/GUACAMOLE-310), both of which deal with clipboard failures due to IE behavior.

GUACAMOLE-310 additionally addresses incorrect stripping of newline characters when the "Clipboard Permission Manager" extension is used under Chrome.