### PR TITLE
GLEN-125: Backport fix for MySQL/PostgreSQL "disabled" flag

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderService.java
@@ -87,15 +87,21 @@ public class JDBCAuthenticationProviderService implements AuthenticationProvider
     public ModeledUserContext getUserContext(AuthenticationProvider authenticationProvider,
             AuthenticatedUser authenticatedUser) throws GuacamoleException {
 
+        // Always allow but provide no data for users authenticated via our own
+        // connection sharing links
+        if (authenticatedUser instanceof SharedAuthenticatedUser)
+            return null;
+
+        // Set semantic flags based on context
+        boolean databaseCredentialsUsed = (authenticatedUser instanceof ModeledAuthenticatedUser);
+        boolean databaseRestrictionsApplicable = (databaseCredentialsUsed || environment.isUserRequired());
+
         // Retrieve user account for already-authenticated user
         ModeledUser user = userService.retrieveUser(authenticationProvider, authenticatedUser);
         if (user != null && !user.isDisabled()) {
 
-            // Account restrictions specific to this extension apply if this
-            // extension authenticated the user OR if an account from this
-            // extension is explicitly required
-            if (authenticatedUser instanceof ModeledAuthenticatedUser
-                    || environment.isUserRequired()) {
+            // Enforce applicable account restrictions
+            if (databaseRestrictionsApplicable) {
 
                 // Verify user account is still valid as of today
                 if (!user.isAccountValid())
@@ -105,32 +111,33 @@ public class JDBCAuthenticationProviderService implements AuthenticationProvider
                 if (!user.isAccountAccessible())
                     throw new GuacamoleClientException("LOGIN.ERROR_NOT_ACCESSIBLE");
 
-                // Update password if password is expired
-                if (user.isExpired() || passwordPolicyService.isPasswordExpired(user))
-                    userService.resetExpiredPassword(user, authenticatedUser.getCredentials());
-
             }
 
-            // Link to user context
+            // Update password if password is expired AND the password was
+            // actually involved in the authentication process
+            if (databaseCredentialsUsed) {
+                if (user.isExpired() || passwordPolicyService.isPasswordExpired(user))
+                    userService.resetExpiredPassword(user, authenticatedUser.getCredentials());
+            }
+
+            // Return all data associated with the authenticated user
             ModeledUserContext context = userContextProvider.get();
             context.init(user.getCurrentUser());
             return context;
 
         }
 
-        // Do not invalidate the authentication result of users who were
-        // authenticated via our own connection sharing links
-        if (authenticatedUser instanceof SharedAuthenticatedUser)
-            return null;
+        // Veto authentication result only if database-specific account
+        // restrictions apply in this situation
+        if (databaseRestrictionsApplicable)
+            throw new GuacamoleInvalidCredentialsException("Invalid login",
+                    CredentialsInfo.USERNAME_PASSWORD);
 
-        // Simply return no data if a database user account is not required
-        if (!environment.isUserRequired())
-            return null;
-
-        // Otherwise, invalidate the authentication result, as database user
-        // accounts are absolutely required
-        throw new GuacamoleInvalidCredentialsException("Invalid login",
-                CredentialsInfo.USERNAME_PASSWORD);
+        // There is no data to be returned for the user, either because they do
+        // not exist or because restrictions prevent their data from being
+        // retrieved, but no restrictions apply which should prevent the user
+        // from authenticating entirely
+        return null;
 
     }
 


### PR DESCRIPTION
From [GLEN-125](https://glyptodon.org/jira/browse/GLEN-125):

> The user account "disabled" flag implemented by the MySQL and PostgreSQL support is intended to disable access to that account, behaving as if the account is entirely absent. With the changes made by upstream [GUACAMOLE-284](https://issues.apache.org/jira/browse/GUACAMOLE-284) (backported via [GLEN-37](https://glyptodon.org/jira/browse/GLEN-37)), this behavior is broken, and disabled users are able to log in. Such users are denied access to absolutely everything (they are given a blank home screen), but authentication still succeeds.

This has been fixed upstream via [GUACAMOLE-529](https://issues.apache.org/jira/browse/GUACAMOLE-529), which is the source of the changes backported here.