### PR TITLE
GLEN-119: Remove use of deprecated navigator.getUserMedia()

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/AudioRecorder.js
+++ b/guacamole-common-js/src/main/webapp/modules/AudioRecorder.js
@@ -181,16 +181,20 @@ Guacamole.RawAudioRecorder = function RawAudioRecorder(stream, mimetype) {
      */
     var context = Guacamole.AudioContextFactory.getAudioContext();
 
-    /**
-     * A function which directly invokes the browser's implementation of
-     * navigator.getUserMedia() with all provided parameters.
-     *
-     * @type Function
-     */
-    var getUserMedia = (navigator.getUserMedia
-            || navigator.webkitGetUserMedia
-            || navigator.mozGetUserMedia
-            || navigator.msGetUserMedia).bind(navigator);
+    // Some browsers do not implement navigator.mediaDevices - this
+    // shims in this functionality to ensure code compatibility.
+    if (!navigator.mediaDevices)
+        navigator.mediaDevices = {};
+
+    // Browsers that either do not implement navigator.mediaDevices
+    // at all or do not implement it completely need the getUserMedia
+    // method defined.  This shims in this function by detecting
+    // one of the supported legacy methods.
+    if (!navigator.mediaDevices.getUserMedia)
+        navigator.mediaDevices.getUserMedia = (navigator.getUserMedia
+                || navigator.webkitGetUserMedia
+                || navigator.mozGetUserMedia
+                || navigator.msGetUserMedia).bind(navigator);
 
     /**
      * Guacamole.ArrayBufferWriter wrapped around the audio output stream
@@ -419,7 +423,7 @@ Guacamole.RawAudioRecorder = function RawAudioRecorder(stream, mimetype) {
     var beginAudioCapture = function beginAudioCapture() {
 
         // Attempt to retrieve an audio input stream from the browser
-        getUserMedia({ 'audio' : true }, function streamReceived(stream) {
+        navigator.mediaDevices.getUserMedia({ 'audio' : true }, function streamReceived(stream) {
 
             // Create processing node which receives appropriately-sized audio buffers
             processor = context.createScriptProcessor(BUFFER_SIZE, format.channels, format.channels);


### PR DESCRIPTION
From upstream [GUACAMOLE-237](https://issues.apache.org/jira/browse/GUACAMOLE-237):

> [`navigator.getUserMedia()` has been deprecated within Firefox](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getUserMedia), replaced by [`navigator.mediaDevices.getUserMedia()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia). See: https://www.w3.org/TR/mediacapture-streams/

Though not deprecated in the standard per se, it's clear that `navigator.getUserMedia()` is legacy. As Mozilla has marked it as deprecated within Firefox, this change will need to be made eventually to ensure forward compatibility.
{quote}