### PR TITLE
GLEN-120: Backport upstream fixes for generally IE-specific issues

### DIFF
--- a/guacamole/src/main/webapp/app/rest/services/tunnelService.js
+++ b/guacamole/src/main/webapp/app/rest/services/tunnelService.js
@@ -189,8 +189,14 @@ angular.module('rest').factory('tunnelService', ['$injector',
      */
     service.downloadStream = function downloadStream(tunnel, stream, mimetype, filename) {
 
+        // Work-around for IE missing window.location.origin
+        if (!$window.location.origin)
+            var streamOrigin = $window.location.protocol + '//' + $window.location.hostname + ($window.location.port ? (':' + $window.location.port) : '');
+        else
+            var streamOrigin = $window.location.origin;
+
         // Build download URL
-        var url = $window.location.origin
+        var url = streamOrigin
                 + $window.location.pathname
                 + 'api/session/tunnels/' + encodeURIComponent(tunnel)
                 + '/streams/' + encodeURIComponent(stream.index)
@@ -267,8 +273,14 @@ angular.module('rest').factory('tunnelService', ['$injector',
 
         var deferred = $q.defer();
 
+        // Work-around for IE missing window.location.origin
+        if (!$window.location.origin)
+            var streamOrigin = $window.location.protocol + '//' + $window.location.hostname + ($window.location.port ? (':' + $window.location.port) : '');
+        else
+            var streamOrigin = $window.location.origin;
+
         // Build upload URL
-        var url = $window.location.origin
+        var url = streamOrigin
                 + $window.location.pathname
                 + 'api/session/tunnels/' + encodeURIComponent(tunnel)
                 + '/streams/' + encodeURIComponent(stream.index)

--- a/guacamole/src/main/webapp/app/rest/services/tunnelService.js
+++ b/guacamole/src/main/webapp/app/rest/services/tunnelService.js
@@ -230,7 +230,9 @@ angular.module('rest').factory('tunnelService', ['$injector',
         // ends, in the browser does NOT fire the "load" event for downloads
         stream.onend = function downloadComplete() {
             $window.setTimeout(function cleanupIframe() {
-                document.body.removeChild(iframe);
+                if (iframe.parentElement) {
+                    document.body.removeChild(iframe);
+                }
             }, DOWNLOAD_CLEANUP_WAIT);
         };
 

--- a/guacamole/src/main/webapp/app/rest/types/UserCredentials.js
+++ b/guacamole/src/main/webapp/app/rest/types/UserCredentials.js
@@ -114,8 +114,14 @@ angular.module('rest').factory('UserCredentials', ['$injector', function defineU
      */
     UserCredentials.getLink = function getLink(userCredentials) {
 
+        // Work-around for IE missing window.location.origin
+        if (!$window.location.origin)
+            var linkOrigin = $window.location.protocol + '//' + $window.location.hostname + ($window.location.port ? (':' + $window.location.port) : '');
+        else
+            var linkOrigin = $window.location.origin;
+
         // Build base link
-        var link = $window.location.origin
+        var link = linkOrigin
                  + $window.location.pathname
                  + '#/';
 

--- a/guacamole/src/main/webapp/index.html
+++ b/guacamole/src/main/webapp/index.html
@@ -19,7 +19,8 @@
 -->
 <html ng-app="index" ng-controller="indexController">
     <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+        <meta http-equiv="x-ua-compatible" content="IE=edge"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densitydpi=medium-dpi"/>
         <meta name="mobile-web-app-capable" content="yes"/>
         <meta name="apple-mobile-web-app-capable" content="yes"/>


### PR DESCRIPTION
Relevant issues:

* [GUACAMOLE-316](https://issues.apache.org/jira/browse/GUACAMOLE-316) - "IE Compatibility mode doesn't work"
* [GUACAMOLE-347](https://issues.apache.org/jira/browse/GUACAMOLE-347) - "IE may lack window.location.origin"
* [GUACAMOLE-348](https://issues.apache.org/jira/browse/GUACAMOLE-348) - "Stream download iframe may not exist in DOM at time of removal"