### PR TITLE
GLEN-123: Allow protocol support to change page title

### DIFF
--- a/guacamole/src/main/webapp/app/client/controllers/clientController.js
+++ b/guacamole/src/main/webapp/app/client/controllers/clientController.js
@@ -530,9 +530,9 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
 
     });
 
-    // Update page title when client name is received
-    $scope.$watch('client.name', function clientNameChanged(name) {
-        $scope.page.title = name;
+    // Update page title when client title changes
+    $scope.$watch('client.title', function clientTitleChanged(title) {
+        $scope.page.title = title;
     });
 
     /**

--- a/guacamole/src/main/webapp/app/client/types/ManagedClient.js
+++ b/guacamole/src/main/webapp/app/client/types/ManagedClient.js
@@ -108,6 +108,14 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
         this.name = template.name;
 
         /**
+         * The title which should be displayed as the page title for this
+         * client.
+         *
+         * @type String
+         */
+        this.title = template.title;
+
+        /**
          * The most recently-generated thumbnail for this connection, as
          * stored within the local connection history. If no thumbnail is
          * stored, this will be null.
@@ -470,6 +478,13 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
 
         };
 
+        // Update title when a "name" instruction is received
+        client.onname = function clientNameReceived(name) {
+            $rootScope.$apply(function updateClientTitle() {
+                managedClient.title = name;
+            });
+        };
+
         // Handle any received files
         client.onfile = function clientFileReceived(stream, mimetype, filename) {
             tunnelService.downloadStream(tunnel.uuid, stream, mimetype, filename);
@@ -498,7 +513,7 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
         if (clientIdentifier.type === ClientIdentifier.Types.CONNECTION) {
             connectionService.getConnection(clientIdentifier.dataSource, clientIdentifier.id)
             .success(function connectionRetrieved(connection) {
-                managedClient.name = connection.name;
+                managedClient.name = managedClient.title = connection.name;
             });
         }
         
@@ -506,7 +521,7 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
         else if (clientIdentifier.type === ClientIdentifier.Types.CONNECTION_GROUP) {
             connectionGroupService.getConnectionGroup(clientIdentifier.dataSource, clientIdentifier.id)
             .success(function connectionGroupRetrieved(group) {
-                managedClient.name = group.name;
+                managedClient.name = managedClient.title = group.name;
             });
         }
 


### PR DESCRIPTION
This change forms the client-side basis of support for changing the window title in response to terminal codes received via SSH and telnet. The server-side changes, being against the guacamole-server repository, will come via a separate PR.

Relevant upstream issue: https://issues.apache.org/jira/browse/GUACAMOLE-265 ("Support OSC 0 for changing SSH/telnet window title")