### PR TITLE
GLEN-126: Continue including ngCookies module for compatibility's sake.

### DIFF
--- a/guacamole/pom.xml
+++ b/guacamole/pom.xml
@@ -343,6 +343,12 @@
         </dependency>
         <dependency>
             <groupId>org.webjars.bower</groupId>
+            <artifactId>angular-cookies</artifactId>
+            <version>1.3.16</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bower</groupId>
             <artifactId>angular-route</artifactId>
             <version>1.3.16</version>
             <scope>runtime</scope>

--- a/guacamole/src/main/webapp/index.html
+++ b/guacamole/src/main/webapp/index.html
@@ -62,6 +62,7 @@
 
         <!-- AngularJS -->
         <script type="text/javascript" src="webjars/angular/1.3.16/angular.min.js"></script>
+        <script type="text/javascript" src="webjars/angular-cookies/1.3.16/angular-cookies.min.js"></script>
         <script type="text/javascript" src="webjars/angular-route/1.3.16/angular-route.min.js"></script>
         <script type="text/javascript" src="webjars/angular-touch/1.3.16/angular-touch.min.js"></script>
 


### PR DESCRIPTION
Commit b64091d66e01f98e4cf9b65036cccb196cfe4ad9 partly results in an unstable upgrade due to the behavior of cached copies of `app.js`. As cached JavaScript may still point to the "ngCookies" module, the webapp may fail to load with injection errors. The cache busting `?v=${project.version}` is of no help here, since the version number doesn't change during GLEN minor updates.

This change partly reverts that commit, restoring the "ngCookies" module. The module is unused by current JS, but this at least allows it to continue being available if Guacamole has been cached.