### PR TITLE
GLEN-142: Retrieve HTTP status code from GuacamoleException via its associated GuacamoleStatus.

### DIFF
--- a/guacamole/src/main/java/org/apache/guacamole/rest/RESTExceptionMapper.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/RESTExceptionMapper.java
@@ -93,7 +93,7 @@ public class RESTExceptionMapper implements ExceptionMapper<Throwable> {
         // Translate GuacamoleException subclasses to HTTP error codes 
         if (t instanceof GuacamoleException)
             return Response
-                    .status(((GuacamoleException) t).getHttpStatusCode())
+                    .status(((GuacamoleException) t).getStatus().getHttpStatusCode())
                     .entity(new APIError((GuacamoleException) t))
                     .type(MediaType.APPLICATION_JSON)
                     .build();


### PR DESCRIPTION
The build of guacamole-client for Glyptodon Enterprise is currently failing due to the changes merged via #371. This is because the backported changes (from [GUACAMOLE-566](https://issues.apache.org/jira/browse/GUACAMOLE-566)) were made in context of [GUACAMOLE-504](https://issues.apache.org/jira/browse/GUACAMOLE-504) which added a new function to `GuacamoleException` for directly retrieving the HTTP status code. That API change to `GuacamoleException` came after 0.9.12-incubating and thus is not available within GLEN 1.x.

Internally, the default implementation of the missing function is simply:

    public int getHttpStatusCode() {
        return getStatus().getHttpStatusCode();
    }

so doing essentially the same here should satisfy the needs behind [GLEN-142](https://jira.glyptodon.org/browse/GLEN-142) while remaining minimally divergent from upstream.