### PR TITLE
GLEN-167: Backport fix for IE11 caching behavior to GLEN 2.x.

### DIFF
--- a/guacamole/src/main/webapp/app/index/config/httpDefaults.js
+++ b/guacamole/src/main/webapp/app/index/config/httpDefaults.js
@@ -18,14 +18,19 @@
  */
 
 /**
- * The config block for setting up the HTTP PATCH method.
+ * Defaults for the AngularJS $http service.
  */
-angular.module('index').config(['$httpProvider', 
-        function indexHttpPatchConfig($httpProvider) {
-    
+angular.module('index').config(['$httpProvider', function httpDefaults($httpProvider) {
+
+    // Do not cache the responses of GET requests
+    $httpProvider.defaults.headers.get = {
+        'Cache-Control' : 'no-cache',
+        'Pragma' : 'no-cache'
+    };
+
+    // Use "application/json" content type by default for PATCH requests
     $httpProvider.defaults.headers.patch = {
-        'Content-Type': 'application/json'
-    }
+        'Content-Type' : 'application/json'
+    };
+
 }]);
-
-


### PR DESCRIPTION
As noted on #383, these changes reconfigure the `$http` service such that it sends additional headers to request that the browser not cache the response for GET requests, including IE.