### PR TITLE
GLEN-168: Correct IE-specific regression in handling of login fields in 1.x.

### DIFF
--- a/guacamole/src/main/webapp/app/form/templates/form.html
+++ b/guacamole/src/main/webapp/app/form/templates/form.html
@@ -9,7 +9,7 @@
         <div class="fields">
             <guac-form-field ng-repeat="field in form.fields" namespace="namespace"
                              ng-if="isVisible(field)"
-                             disabled="disabled"
+                             data-disabled="disabled"
                              field="field" model="values[field.name]"></guac-form-field>
         </div>
 

--- a/guacamole/src/main/webapp/app/login/templates/login.html
+++ b/guacamole/src/main/webapp/app/login/templates/login.html
@@ -27,7 +27,7 @@
                         namespace="'LOGIN'"
                         content="remainingFields"
                         model="enteredValues"
-                        disabled="submitted"></guac-form>
+                        data-disabled="submitted"></guac-form>
                 </div>
 
                 <!-- Login/continue button -->


### PR DESCRIPTION
If an element has an attribute named `disabled`, all input fields that are descendants of that element are disabled by IE regardless of the type of element the `disabled` attribute is on, even if the element is unknown. This resulted in a regression where the entire login form was disabled due to both `<guac-form-field>` and `<guac-form>` directives having an attribute named "disabled".

This has since been resolved by using the alternative `data-disabled` form.