### PR TITLE
GLEN-169: Backport connection switching fixes to 1.x.

### DIFF
--- a/guacamole/src/main/webapp/app/client/controllers/clientController.js
+++ b/guacamole/src/main/webapp/app/client/controllers/clientController.js
@@ -267,9 +267,12 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
     })(guacClientManager.getManagedClients());
 
     /**
-     * Map of data source identifier to the root connection group of that data
-     * source, or null if the connection group hierarchy has not yet been
-     * loaded.
+     * The root connection groups of the connection hierarchy that should be
+     * presented to the user for selecting a different connection, as a map of
+     * data source identifier to the root connection group of that data
+     * source. This will be null if the connection group hierarchy has not yet
+     * been loaded or if the hierarchy is inapplicable due to only one
+     * connection or balancing group being available.
      *
      * @type Object.<String, ConnectionGroup>
      */
@@ -300,7 +303,13 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
         ConnectionGroup.ROOT_IDENTIFIER
     )
     .then(function rootGroupsRetrieved(rootConnectionGroups) {
-        $scope.rootConnectionGroups = rootConnectionGroups;
+
+        // Store retrieved groups only if there are multiple connections or
+        // balancing groups available
+        var clientPages = userPageService.getClientPages(rootConnectionGroups);
+        if (clientPages.length > 1)
+            $scope.rootConnectionGroups = rootConnectionGroups;
+
     });
 
     /**

--- a/guacamole/src/main/webapp/app/client/styles/connection-select-menu.css
+++ b/guacamole/src/main/webapp/app/client/styles/connection-select-menu.css
@@ -35,6 +35,8 @@
     font-size: 0.8em;
     right: auto;
     left: 0;
+    max-width: 100vw;
+    width: 400px;
 }
 
 .connection-select-menu .menu-dropdown .menu-contents .filter input {
@@ -45,4 +47,11 @@
 .connection-select-menu .menu-dropdown .menu-contents .filter {
     margin-bottom: 0.5em;
     padding: 0;
+}
+
+.connection-select-menu .menu-dropdown .menu-contents .group-list .caption {
+    display: inline-block;
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }

--- a/guacamole/src/main/webapp/app/client/styles/connection-select-menu.css
+++ b/guacamole/src/main/webapp/app/client/styles/connection-select-menu.css
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#guac-menu .header h2.connection-select-menu {
+    overflow: visible;
+}
+
+.connection-select-menu {
+    padding: 0;
+    min-width: 0;
+}
+
+.connection-select-menu .menu-dropdown {
+    border: none;
+}
+
+.connection-select-menu .menu-dropdown .menu-contents {
+    font-weight: normal;
+    font-size: 0.8em;
+    right: auto;
+    left: 0;
+}
+
+.connection-select-menu .menu-dropdown .menu-contents .filter input {
+    border-bottom: 1px solid rgba(0,0,0,0.125);
+    border-left: none;
+}
+
+.connection-select-menu .menu-dropdown .menu-contents .filter {
+    margin-bottom: 0.5em;
+    padding: 0;
+}

--- a/guacamole/src/main/webapp/app/client/styles/guac-menu.css
+++ b/guacamole/src/main/webapp/app/client/styles/guac-menu.css
@@ -66,26 +66,10 @@
 }
 
 #guac-menu .header h2 {
-    padding: 0;
-}
-
-#guac-menu .header h2 .menu-dropdown {
-    border: none;
-}
-
-#guac-menu .header h2 .menu-contents {
-    font-weight: normal;
-    font-size: 0.8em;
-}
-
-#guac-menu .header .filter input {
-    border-bottom: 1px solid rgba(0,0,0,0.125);
-    border-left: none;
-}
-
-#guac-menu .header .filter {
-    margin-bottom: 0.5em;
-    padding: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    width: 100%;
+    text-overflow: ellipsis;
 }
 
 #guac-menu #mouse-settings .choice {

--- a/guacamole/src/main/webapp/app/client/templates/client.html
+++ b/guacamole/src/main/webapp/app/client/templates/client.html
@@ -48,7 +48,7 @@
             <!-- Stationary header -->
             <div class="header">
                 <h2 ng-hide="rootConnectionGroups">{{client.name}}</h2>
-                <h2 ng-show="rootConnectionGroups">
+                <h2 class="connection-select-menu" ng-show="rootConnectionGroups">
                     <guac-menu menu-title="client.name">
                         <div class="all-connections">
                             <guac-group-list-filter connection-groups="rootConnectionGroups"

--- a/guacamole/src/main/webapp/app/client/templates/client.html
+++ b/guacamole/src/main/webapp/app/client/templates/client.html
@@ -49,7 +49,7 @@
             <div class="header">
                 <h2 ng-hide="rootConnectionGroups">{{client.name}}</h2>
                 <h2 class="connection-select-menu" ng-show="rootConnectionGroups">
-                    <guac-menu menu-title="client.name">
+                    <guac-menu menu-title="client.name" interactive="true">
                         <div class="all-connections">
                             <guac-group-list-filter connection-groups="rootConnectionGroups"
                                 filtered-connection-groups="filteredRootConnectionGroups"

--- a/guacamole/src/main/webapp/app/home/templates/connectionGroup.html
+++ b/guacamole/src/main/webapp/app/home/templates/connectionGroup.html
@@ -1,4 +1,4 @@
 <span class="home-connection-group name">
-    <a ng-show="item.balancing" ng-href="#/client/{{ getClientIdentifier() }}">{{item.name}}</a>
+    <a ng-show="item.balancing" ng-href="#/client/{{ item.getClientIdentifier() }}">{{item.name}}</a>
     <span ng-show="!item.balancing">{{item.name}}</span>
 </span>

--- a/guacamole/src/main/webapp/app/navigation/directives/guacMenu.js
+++ b/guacamole/src/main/webapp/app/navigation/directives/guacMenu.js
@@ -34,7 +34,16 @@ angular.module('navigation').directive('guacMenu', [function guacMenu() {
              *
              * @type String
              */
-            menuTitle : '='
+            menuTitle : '=',
+
+            /**
+             * Whether the menu should remain open while the user interacts
+             * with the contents of the menu. By default, the menu will close
+             * if the user clicks within the menu contents.
+             *
+             * @type Boolean
+             */
+            interactive : '='
 
         },
 
@@ -81,21 +90,19 @@ angular.module('navigation').directive('guacMenu', [function guacMenu() {
                 $scope.menuShown = !$scope.menuShown;
             };
 
-            // Close menu when use clicks anywhere else
-            document.body.addEventListener('click', function clickOutsideMenu() {
+            // Close menu when user clicks anywhere outside this specific menu
+            document.body.addEventListener('click', function clickOutsideMenu(e) {
                 $scope.$apply(function closeMenu() {
-                    $scope.menuShown = false;
+                    if (e.target !== element && !element.contains(e.target))
+                        $scope.menuShown = false;
                 });
             }, false);
 
-            // Prevent click within menu from triggering the outside-menu handler
-            element.addEventListener('click', function clickInsideMenu(e) {
-                e.stopPropagation();
-            }, false);
-
-            // Prevent click within menu contents from toggling menu visibility
+            // Prevent clicks within menu contents from toggling menu visibility
+            // if the menu contents are intended to be interactive
             contents.addEventListener('click', function clickInsideMenuContents(e) {
-                e.stopPropagation();
+                if ($scope.interactive)
+                    e.stopPropagation();
             }, false);
 
         }] // end controller

--- a/guacamole/src/main/webapp/app/navigation/services/userPageService.js
+++ b/guacamole/src/main/webapp/app/navigation/services/userPageService.js
@@ -66,7 +66,6 @@ angular.module('navigation').factory('userPageService', ['$injector',
      */
     var generateHomePage = function generateHomePage(rootGroups, permissions) {
 
-        var homePage = null;
         var settingsPages = generateSettingsPages(permissions);
 
         // If user has access to settings pages, return home page and skip
@@ -76,67 +75,87 @@ angular.module('navigation').factory('userPageService', ['$injector',
         if (settingsPages.length > 1)
             return SYSTEM_HOME_PAGE;
 
+        // If exactly one connection or balancing group is available, use
+        // that as the home page
+        var clientPages = service.getClientPages(rootGroups);
+        return (clientPages.length === 1) ? clientPages[0] : SYSTEM_HOME_PAGE;
+
+    };
+
+    /**
+     * Adds to the given array all pages that the current user may use to
+     * access connections or balancing groups that are descendants of the given
+     * connection group.
+     *
+     * @param {PageDefinition[]} clientPages
+     *     The array that pages should be added to.
+     *
+     * @param {String} dataSource
+     *     The data source containing the given connection group.
+     *
+     * @param {ConnectionGroup} connectionGroup
+     *     The connection group ancestor of the connection or balancing group
+     *     descendants whose pages should be added to the given array.
+     */
+    var addClientPages = function addClientPages(clientPages, dataSource, connectionGroup) {
+
+        // Add pages for all child connections
+        angular.forEach(connectionGroup.childConnections, function addConnectionPage(connection) {
+            clientPages.push(new PageDefinition({
+                name : connection.name,
+                url  : '/client/' + ClientIdentifier.toString({
+                    dataSource : dataSource,
+                    type       : ClientIdentifier.Types.CONNECTION,
+                    id         : connection.identifier
+                })
+            }));
+        });
+
+        // Add pages for all child balancing groups, as well as the connectable
+        // descendants of all balancing groups of any type
+        angular.forEach(connectionGroup.childConnectionGroups, function addConnectionGroupPage(connectionGroup) {
+
+            if (connectionGroup.type === ConnectionGroup.Type.BALANCING) {
+                clientPages.push(new PageDefinition({
+                    name : connectionGroup.name,
+                    url  : '/client/' + ClientIdentifier.toString({
+                        dataSource : dataSource,
+                        type       : ClientIdentifier.Types.CONNECTION_GROUP,
+                        id         : connectionGroup.identifier
+                    })
+                }));
+            }
+
+            addClientPages(clientPages, dataSource, connectionGroup);
+
+        });
+
+    };
+
+    /**
+     * Returns a full list of all pages that the current user may use to access
+     * a connection or balancing group, regardless of the depth of those
+     * connections/groups within the connection hierarchy.
+     *
+     * @param {Object.<String, ConnectionGroup>} rootGroups
+     *     A map of all root connection groups visible to the current user,
+     *     where each key is the identifier of the corresponding data source.
+     *
+     * @returns {PageDefinition[]}
+     *     A list of all pages that the current user may use to access a
+     *     connection or balancing group.
+     */
+    service.getClientPages = function getClientPages(rootGroups) {
+
+        var clientPages = [];
+
         // Determine whether a connection or balancing group should serve as
         // the home page
         for (var dataSource in rootGroups) {
+            addClientPages(clientPages, dataSource, rootGroups[dataSource]);
+        }
 
-            // Get corresponding root group
-            var rootGroup = rootGroups[dataSource];
-
-            // Get children
-            var connections      = rootGroup.childConnections      || [];
-            var connectionGroups = rootGroup.childConnectionGroups || [];
-
-            // Calculate total number of root-level objects
-            var totalRootObjects = connections.length + connectionGroups.length;
-
-            // If exactly one connection or balancing group is available, use
-            // that as the home page
-            if (homePage === null && totalRootObjects === 1) {
-
-                var connection      = connections[0];
-                var connectionGroup = connectionGroups[0];
-
-                // Only one connection present, use as home page
-                if (connection) {
-                    homePage = new PageDefinition({
-                        name : connection.name,
-                        url  : '/client/' + ClientIdentifier.toString({
-                            dataSource : dataSource,
-                            type       : ClientIdentifier.Types.CONNECTION,
-                            id         : connection.identifier
-                        })
-                    });
-                }
-
-                // Only one balancing group present, use as home page
-                if (connectionGroup
-                        && connectionGroup.type === ConnectionGroup.Type.BALANCING
-                        && _.isEmpty(connectionGroup.childConnections)
-                        && _.isEmpty(connectionGroup.childConnectionGroups)) {
-                    homePage = new PageDefinition({
-                        name : connectionGroup.name,
-                        url  : '/client/' + ClientIdentifier.toString({
-                            dataSource : dataSource,
-                            type       : ClientIdentifier.Types.CONNECTION_GROUP,
-                            id         : connectionGroup.identifier
-                        })
-                    });
-                }
-
-            }
-
-            // Otherwise, a connection or balancing group cannot serve as the
-            // home page
-            else if (totalRootObjects >= 1) {
-                homePage = null;
-                break;
-            }
-
-        } // end for each data source
-
-        // Use default home page if no other is available
-        return homePage || SYSTEM_HOME_PAGE;
+        return clientPages;
 
     };
 

--- a/guacamole/src/main/webapp/app/navigation/styles/menu.css
+++ b/guacamole/src/main/webapp/app/navigation/styles/menu.css
@@ -68,6 +68,11 @@
     padding: 0.5em;
     padding-right: 2em;
 
+    white-space: nowrap;
+    overflow: hidden;
+    width: 100%;
+    text-overflow: ellipsis;
+
     -ms-flex: 0 0 auto;
     -moz-box-flex: 0;
     -webkit-box-flex: 0;


### PR DESCRIPTION
This change backports upstream changes from [GUACAMOLE-723](https://issues.apache.org/jira/browse/GUACAMOLE-723) and [GUACAMOLE-822](https://issues.apache.org/jira/browse/GUACAMOLE-822) to correct the following issues noticed after the connection switching feature was backported to 1.x:

* The "Share" menu no longer closes when an option is clicked.
* The portion of the Guacamole menu containing the connection name can considerably overlap other parts of the header when the connection name is long.
* The drop down of the new connection selection menu is aligned relative to its right edge, causing the menu to overflow off the left side of the screen if the relevant part of the header is smaller than the width of the drop down.
* The connection selection menu continues to render as a drop down, even if there are no other connections available.
* Links to balancing groups from the home screen no longer work (they are missing the client identifier)