### PR TITLE
GLEN-237: Backport corrections for Czech translation to 1.x.

### DIFF
--- a/guacamole/src/main/webapp/translations/cs.json
+++ b/guacamole/src/main/webapp/translations/cs.json
@@ -1,8 +1,9 @@
 {
-
+    
     "NAME" : "Čeština",
 
     "APP" : {
+
 
         "ACTION_ACKNOWLEDGE"        : "OK",
         "ACTION_CANCEL"             : "Zrušit",
@@ -32,18 +33,19 @@
         "ERROR_PAGE_UNAVAILABLE"  : "Došlo k chybě a tuto akci nelze dokončit. Pokud problém přetrvává, informujte prosím správce systému nebo zkontrolujte systémové protokoly.",
         "ERROR_PASSWORD_BLANK"    : "Heslo nesmí být prázdné.",
         "ERROR_PASSWORD_MISMATCH" : "Hesla nesouhlasí.",
-
+        
         "FIELD_HEADER_PASSWORD"       : "Heslo:",
         "FIELD_HEADER_PASSWORD_AGAIN" : "Heslo znovu:",
 
-        "FIELD_PLACEHOLDER_FILTER"    : "Filtr",
+        "FIELD_PLACEHOLDER_FILTER" : "Filtr",
 
         "FORMAT_DATE_TIME_PRECISE" : "yyyy-MM-dd HH:mm:ss",
 
-        "INFO_ACTIVE_USER_COUNT" : "V současné době používá {USERS} {USERS, plural, one{user} other{users}}.",
+        "INFO_ACTIVE_USER_COUNT" : "V současné době používá {USERS} {USERS, plural, one{uživatel} other{uživatelů}}.",
 
-        "TEXT_ANONYMOUS_USER"   : "Anonym",
-        "TEXT_HISTORY_DURATION" : "{VALUE} {UNIT, select, second{{VALUE, plural, one{second} other{seconds}}} minute{{VALUE, plural, one{minute} other{minutes}}} hour{{VALUE, plural, one{hour} other{hours}}} day{{VALUE, plural, one{day} other{days}}} other{}}"
+        "TEXT_ANONYMOUS_USER"   : "Neznámý uživatel",
+        "TEXT_HISTORY_DURATION" : "{VALUE} {UNIT, select, second{{VALUE, plural, one{sekundu} other{sekund}}} minute{{VALUE, plural, one{minutu} other{minut}}} hour{{VALUE, plural, one{hodinu} other{hodin}}} day{{VALUE, plural, one{den} other{dnů}}} other{}}",
+        "TEXT_UNTRANSLATED" : "{MESSAGE}"
 
     },
 
@@ -112,7 +114,7 @@
         "HELP_MOUSE_MODE"          : "Určuje, jak se bude vzdálená myš chovat s ohledem na dotyky.",
         "HELP_MOUSE_MODE_ABSOLUTE" : "Tap to click. Kliknutí nastane v místě dotyku.",
         "HELP_MOUSE_MODE_RELATIVE" : "Přetažením myši posuňte ukazatel myši a klepněte na tlačítko. Kliknutí nastane v místě ukazatele.",
-        "HELP_SHARE_LINK"          : "Aktuální připojení je sdíleno a může k němu přistupovat kdokoli s následujícím {LINKS, plural, one{link} other{links}}:",
+        "HELP_SHARE_LINK"          : "Aktuální připojení je sdíleno a může k němu přistupovat kdokoli s následujícím {LINKS, plural, one{odkazem} other{odkazy}}:",
 
         "INFO_CONNECTION_SHARED" : "Toto připojení je nyní sdíleno.",
         "INFO_NO_FILE_TRANSFERS" : "Žádné přenosy souborů.",
@@ -140,10 +142,26 @@
         "TEXT_CLIENT_STATUS_DISCONNECTED" : "Byl jste odpojen.",
         "TEXT_CLIENT_STATUS_UNSTABLE"     : "Síťové spojení ke  Guacamole serveru se zdá nestabilní.",
         "TEXT_CLIENT_STATUS_WAITING"      : "Připojen ke Guacamole. Čekání na odpověď...",
-        "TEXT_RECONNECT_COUNTDOWN"        : "Znovu připojuji  {REMAINING} {REMAINING, plural, one{second} other{seconds}}...",
+        "TEXT_RECONNECT_COUNTDOWN"        : "Znovu připojuji  {REMAINING} {REMAINING, plural, one{sekundu} other{sekund}}...",
         "TEXT_FILE_TRANSFER_PROGRESS"     : "{PROGRESS} {UNIT, select, b{B} kb{KB} mb{MB} gb{GB} other{}}",
 
         "URL_OSK_LAYOUT" : "layouts/en-us-qwerty.json"
+
+    },
+
+    "COLOR_SCHEME" : {
+
+        "ACTION_CANCEL"       : "@:APP.ACTION_CANCEL",
+        "ACTION_HIDE_DETAILS" : "Skrýt",
+        "ACTION_SAVE"         : "@:APP.ACTION_SAVE",
+        "ACTION_SHOW_DETAILS" : "Zobrazit",
+
+        "FIELD_HEADER_BACKGROUND" : "Pozadí",
+        "FIELD_HEADER_FOREGROUND" : "Popředí",
+
+        "FIELD_OPTION_CUSTOM" : "Vlastní...",
+
+        "SECTION_HEADER_DETAILS" : "Detaily:"
 
     },
 
@@ -153,7 +171,7 @@
 
     "FORM" : {
 
-        "FIELD_PLACEHOLDER_DATE" : "YYYY-MM-dd",
+        "FIELD_PLACEHOLDER_DATE" : "YYYY-MM-DD",
         "FIELD_PLACEHOLDER_TIME" : "HH:MM:SS",
 
         "HELP_SHOW_PASSWORD" : "Klikněte pro zobrazní hesla",
@@ -168,7 +186,7 @@
         "INFO_ACTIVE_USER_COUNT" : "@:APP.INFO_ACTIVE_USER_COUNT",
 
         "INFO_NO_RECENT_CONNECTIONS" : "Žádná nedávná spojení.",
-
+        
         "PASSWORD_CHANGED" : "Heslo bylo změněno.",
 
         "SECTION_HEADER_ALL_CONNECTIONS"    : "Všechna spojení",
@@ -178,7 +196,7 @@
 
     "LIST" : {
 
-        "TEXT_ANONYMOUS_USER" : "Anonymní"
+        "TEXT_ANONYMOUS_USER" : "Neznámý uživatel"
 
     },
 
@@ -199,11 +217,11 @@
 
     "MANAGE_CONNECTION" : {
 
-        "ACTION_ACKNOWLEDGE" : "@:APP.ACTION_ACKNOWLEDGE",
-        "ACTION_CANCEL"      : "@:APP.ACTION_CANCEL",
-        "ACTION_CLONE"       : "@:APP.ACTION_CLONE",
-        "ACTION_DELETE"      : "@:APP.ACTION_DELETE",
-        "ACTION_SAVE"        : "@:APP.ACTION_SAVE",
+        "ACTION_ACKNOWLEDGE"          : "@:APP.ACTION_ACKNOWLEDGE",
+        "ACTION_CANCEL"               : "@:APP.ACTION_CANCEL",
+        "ACTION_CLONE"                : "@:APP.ACTION_CLONE",
+        "ACTION_DELETE"               : "@:APP.ACTION_DELETE",
+        "ACTION_SAVE"                 : "@:APP.ACTION_SAVE",
 
         "DIALOG_HEADER_CONFIRM_DELETE" : "Smazat spojení",
         "DIALOG_HEADER_ERROR"          : "@:APP.DIALOG_HEADER_ERROR",
@@ -215,7 +233,7 @@
         "FORMAT_HISTORY_START" : "@:APP.FORMAT_DATE_TIME_PRECISE",
 
         "INFO_CONNECTION_DURATION_UNKNOWN" : "--",
-        "INFO_CONNECTION_ACTIVE_NOW"       : "Aktivní nyní",
+        "INFO_CONNECTION_ACTIVE_NOW"       : "Nyní aktivní",
         "INFO_CONNECTION_NOT_USED"         : "Toto spojení ještě nebylo použito.",
 
         "SECTION_HEADER_EDIT_CONNECTION" : "Upravit spojení",
@@ -223,7 +241,7 @@
         "SECTION_HEADER_PARAMETERS"      : "Parametry",
 
         "TABLE_HEADER_HISTORY_USERNAME"   : "Uživatelské jméno",
-        "TABLE_HEADER_HISTORY_START"      : "Čas začátku",
+        "TABLE_HEADER_HISTORY_START"      : "Počáteční čas",
         "TABLE_HEADER_HISTORY_DURATION"   : "Doba",
         "TABLE_HEADER_HISTORY_REMOTEHOST" : "Vzdálený host",
 
@@ -234,11 +252,11 @@
 
     "MANAGE_CONNECTION_GROUP" : {
 
-        "ACTION_ACKNOWLEDGE" : "@:APP.ACTION_ACKNOWLEDGE",
-        "ACTION_CANCEL"      : "@:APP.ACTION_CANCEL",
-        "ACTION_CLONE"       : "@:APP.ACTION_CLONE",
-        "ACTION_DELETE"      : "@:APP.ACTION_DELETE",
-        "ACTION_SAVE"        : "@:APP.ACTION_SAVE",
+        "ACTION_ACKNOWLEDGE"   : "@:APP.ACTION_ACKNOWLEDGE",
+        "ACTION_CANCEL"        : "@:APP.ACTION_CANCEL",
+        "ACTION_CLONE"         : "@:APP.ACTION_CLONE",
+        "ACTION_DELETE"        : "@:APP.ACTION_DELETE",
+        "ACTION_SAVE"          : "@:APP.ACTION_SAVE",
 
         "DIALOG_HEADER_CONFIRM_DELETE" : "Smazat skupinu spojení",
         "DIALOG_HEADER_ERROR"          : "@:APP.DIALOG_HEADER_ERROR",
@@ -247,8 +265,8 @@
         "FIELD_HEADER_NAME"     : "Jméno:",
         "FIELD_HEADER_TYPE"     : "Typ:",
 
-        "NAME_TYPE_BALANCING"      : "Vyvažování:",
-        "NAME_TYPE_ORGANIZATIONAL" : "Organizace:",
+        "NAME_TYPE_BALANCING"      : "Vyvažování",
+        "NAME_TYPE_ORGANIZATIONAL" : "Organizační",
 
         "SECTION_HEADER_EDIT_CONNECTION_GROUP" : "Upravit skupinu spojení",
 
@@ -279,27 +297,27 @@
 
     "MANAGE_USER" : {
 
-        "ACTION_ACKNOWLEDGE" : "@:APP.ACTION_ACKNOWLEDGE",
-        "ACTION_CANCEL"      : "@:APP.ACTION_CANCEL",
-        "ACTION_CLONE"       : "@:APP.ACTION_CLONE",
-        "ACTION_DELETE"      : "@:APP.ACTION_DELETE",
-        "ACTION_SAVE"        : "@:APP.ACTION_SAVE",
+        "ACTION_ACKNOWLEDGE"   : "@:APP.ACTION_ACKNOWLEDGE",
+        "ACTION_CANCEL"        : "@:APP.ACTION_CANCEL",
+        "ACTION_CLONE"         : "@:APP.ACTION_CLONE",
+        "ACTION_DELETE"        : "@:APP.ACTION_DELETE",
+        "ACTION_SAVE"          : "@:APP.ACTION_SAVE",
 
         "DIALOG_HEADER_CONFIRM_DELETE" : "Smazat uživatele",
         "DIALOG_HEADER_ERROR"          : "@:APP.DIALOG_HEADER_ERROR",
 
         "ERROR_PASSWORD_MISMATCH" : "@:APP.ERROR_PASSWORD_MISMATCH",
 
-        "FIELD_HEADER_ADMINISTER_SYSTEM"            : "Spravovat systém:",
-        "FIELD_HEADER_CHANGE_OWN_PASSWORD"          : "Změnit vlastní heslo:",
-        "FIELD_HEADER_CREATE_NEW_USERS"             : "Vytvořit nové uživatele:",
-        "FIELD_HEADER_CREATE_NEW_USER_GROUPS"       : "Vytvořit novou uživatelskou skupinu:",
-        "FIELD_HEADER_CREATE_NEW_CONNECTIONS"       : "Vytvořit nové spojení:",
-        "FIELD_HEADER_CREATE_NEW_CONNECTION_GROUPS" : "Vytvořit nové skupiny připojení:",
-        "FIELD_HEADER_CREATE_NEW_SHARING_PROFILES"  : "Vytvořit nový sdílený profil:",
-        "FIELD_HEADER_PASSWORD"                     : "@:APP.FIELD_HEADER_PASSWORD",
-        "FIELD_HEADER_PASSWORD_AGAIN"               : "@:APP.FIELD_HEADER_PASSWORD_AGAIN",
-        "FIELD_HEADER_USERNAME"                     : "Uživatelské jméno:",
+        "FIELD_HEADER_ADMINISTER_SYSTEM"             : "Spravovat systém:",
+        "FIELD_HEADER_CHANGE_OWN_PASSWORD"           : "Změnit vlastní heslo:",
+        "FIELD_HEADER_CREATE_NEW_USERS"              : "Vytvořit nové uživatele:",
+        "FIELD_HEADER_CREATE_NEW_USER_GROUPS"        : "Vytvořit novou uživatelskou skupinu:",
+        "FIELD_HEADER_CREATE_NEW_CONNECTIONS"        : "Vytvořit nové spojení:",
+        "FIELD_HEADER_CREATE_NEW_CONNECTION_GROUPS"  : "Vytvořit nové skupiny připojení:",
+        "FIELD_HEADER_CREATE_NEW_SHARING_PROFILES"   : "Vytvořit nový sdílený profil:",
+        "FIELD_HEADER_PASSWORD"                      : "@:APP.FIELD_HEADER_PASSWORD",
+        "FIELD_HEADER_PASSWORD_AGAIN"                : "@:APP.FIELD_HEADER_PASSWORD_AGAIN",
+        "FIELD_HEADER_USERNAME"                      : "Uživatelské jméno:",
 
         "FIELD_PLACEHOLDER_FILTER" : "@:APP.FIELD_PLACEHOLDER_FILTER",
 
@@ -321,23 +339,23 @@
 
     "MANAGE_USER_GROUP" : {
 
-        "ACTION_ACKNOWLEDGE" : "@:APP.ACTION_ACKNOWLEDGE",
-        "ACTION_CANCEL"      : "@:APP.ACTION_CANCEL",
-        "ACTION_CLONE"       : "@:APP.ACTION_CLONE",
-        "ACTION_DELETE"      : "@:APP.ACTION_DELETE",
-        "ACTION_SAVE"        : "@:APP.ACTION_SAVE",
+        "ACTION_ACKNOWLEDGE"   : "@:APP.ACTION_ACKNOWLEDGE",
+        "ACTION_CANCEL"        : "@:APP.ACTION_CANCEL",
+        "ACTION_CLONE"         : "@:APP.ACTION_CLONE",
+        "ACTION_DELETE"        : "@:APP.ACTION_DELETE",
+        "ACTION_SAVE"          : "@:APP.ACTION_SAVE",
 
         "DIALOG_HEADER_CONFIRM_DELETE" : "Smazat skupinu",
         "DIALOG_HEADER_ERROR"          : "@:APP.DIALOG_HEADER_ERROR",
 
-        "FIELD_HEADER_ADMINISTER_SYSTEM"            : "@:MANAGE_USER.FIELD_HEADER_ADMINISTER_SYSTEM",
-        "FIELD_HEADER_CHANGE_OWN_PASSWORD"          : "@:MANAGE_USER.FIELD_HEADER_CHANGE_OWN_PASSWORD",
-        "FIELD_HEADER_CREATE_NEW_USERS"             : "@:MANAGE_USER.FIELD_HEADER_CREATE_NEW_USERS",
-        "FIELD_HEADER_CREATE_NEW_USER_GROUPS"       : "@:MANAGE_USER.FIELD_HEADER_CREATE_NEW_USER_GROUPS",
-        "FIELD_HEADER_CREATE_NEW_CONNECTIONS"       : "@:MANAGE_USER.FIELD_HEADER_CREATE_NEW_CONNECTIONS",
-        "FIELD_HEADER_CREATE_NEW_CONNECTION_GROUPS" : "@:MANAGE_USER.FIELD_HEADER_CREATE_NEW_CONNECTION_GROUPS",
-        "FIELD_HEADER_CREATE_NEW_SHARING_PROFILES"  : "@:MANAGE_USER.FIELD_HEADER_CREATE_NEW_SHARING_PROFILES",
-        "FIELD_HEADER_USER_GROUP_NAME"              : "Jméno skupiny:",
+        "FIELD_HEADER_ADMINISTER_SYSTEM"             : "@:MANAGE_USER.FIELD_HEADER_ADMINISTER_SYSTEM",
+        "FIELD_HEADER_CHANGE_OWN_PASSWORD"           : "@:MANAGE_USER.FIELD_HEADER_CHANGE_OWN_PASSWORD",
+        "FIELD_HEADER_CREATE_NEW_USERS"              : "@:MANAGE_USER.FIELD_HEADER_CREATE_NEW_USERS",
+        "FIELD_HEADER_CREATE_NEW_USER_GROUPS"        : "@:MANAGE_USER.FIELD_HEADER_CREATE_NEW_USER_GROUPS",
+        "FIELD_HEADER_CREATE_NEW_CONNECTIONS"        : "@:MANAGE_USER.FIELD_HEADER_CREATE_NEW_CONNECTIONS",
+        "FIELD_HEADER_CREATE_NEW_CONNECTION_GROUPS"  : "@:MANAGE_USER.FIELD_HEADER_CREATE_NEW_CONNECTION_GROUPS",
+        "FIELD_HEADER_CREATE_NEW_SHARING_PROFILES"   : "@:MANAGE_USER.FIELD_HEADER_CREATE_NEW_SHARING_PROFILES",
+        "FIELD_HEADER_USER_GROUP_NAME"               : "Jméno skupiny:",
 
         "FIELD_PLACEHOLDER_FILTER" : "@:APP.FIELD_PLACEHOLDER_FILTER",
 
@@ -358,7 +376,73 @@
         "SECTION_HEADER_PERMISSIONS"         : "@:MANAGE_USER.SECTION_HEADER_PERMISSIONS",
         "SECTION_HEADER_USER_GROUPS"         : "Rodičovské skupiny",
 
-        "TEXT_CONFIRM_DELETE" : "Skupiny nelze obnovit po jejich odstranění. Opravdu chcete tuto skupinu smazat?"
+        "TEXT_CONFIRM_DELETE" : "Skupiny nelze po jejich odstranění obnovit. Chcete opravdu smazat tuto skupinu?"
+
+    },
+
+    "PROTOCOL_KUBERNETES" : {
+
+        "FIELD_HEADER_BACKSPACE"                : "Klávesa Zpět odešle:",
+        "FIELD_HEADER_CA_CERT"                  : "Certifikát certifikační autority:",
+        "FIELD_HEADER_CLIENT_CERT"              : "Klientský certifikát:",
+        "FIELD_HEADER_CLIENT_KEY"               : "Klientský klíč:",
+        "FIELD_HEADER_COLOR_SCHEME"             : "Barevné schéma:",
+        "FIELD_HEADER_CONTAINER"                : "Jméno kontejneru:",
+        "FIELD_HEADER_CREATE_RECORDING_PATH"    : "Automaticky vytvořit cestu k záznamu:",
+        "FIELD_HEADER_CREATE_TYPESCRIPT_PATH"   : "Automaticky vytvořit cestu ke strojopisu:",
+        "FIELD_HEADER_FONT_NAME"                : "Jméno fontu:",
+        "FIELD_HEADER_FONT_SIZE"                : "Velikost fontu:",
+        "FIELD_HEADER_HOSTNAME"                 : "Jméno hostitele:",
+        "FIELD_HEADER_IGNORE_CERT"              : "Ignorovat serverový certifikát:",
+        "FIELD_HEADER_NAMESPACE"                : "Obor názvů:",
+        "FIELD_HEADER_POD"                      : "Jméno podu:",
+        "FIELD_HEADER_PORT"                     : "Port:",
+        "FIELD_HEADER_READ_ONLY"                : "Pouze ke čtení:",
+        "FIELD_HEADER_RECORDING_EXCLUDE_MOUSE"  : "Vyloučit myš:",
+        "FIELD_HEADER_RECORDING_EXCLUDE_OUTPUT" : "Vyloučit grafiku/streamování:",
+        "FIELD_HEADER_RECORDING_INCLUDE_KEYS"   : "Zahrnout události kláves:",
+        "FIELD_HEADER_RECORDING_NAME"           : "Jméno záznamu:",
+        "FIELD_HEADER_RECORDING_PATH"           : "Cesta k záznamu:",
+        "FIELD_HEADER_SCROLLBACK"               : "Maximální délka historie:",
+        "FIELD_HEADER_TYPESCRIPT_NAME"          : "Jméno strojopisu:",
+        "FIELD_HEADER_TYPESCRIPT_PATH"          : "Cesta ke strojopisu:",
+        "FIELD_HEADER_USE_SSL"                  : "Použít SSL/TLS",
+
+        "FIELD_OPTION_BACKSPACE_EMPTY" : "",
+        "FIELD_OPTION_BACKSPACE_8"     : "Zpět (Ctrl-H)",
+        "FIELD_OPTION_BACKSPACE_127"   : "Smazat (Ctrl-?)",
+
+        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Černá na bílé",
+        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
+        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Šedá na černé",
+        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Zelená na černé",
+        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "Bílá na černé",
+
+        "FIELD_OPTION_FONT_SIZE_8"     : "8",
+        "FIELD_OPTION_FONT_SIZE_9"     : "9",
+        "FIELD_OPTION_FONT_SIZE_10"    : "10",
+        "FIELD_OPTION_FONT_SIZE_11"    : "11",
+        "FIELD_OPTION_FONT_SIZE_12"    : "12",
+        "FIELD_OPTION_FONT_SIZE_14"    : "14",
+        "FIELD_OPTION_FONT_SIZE_18"    : "18",
+        "FIELD_OPTION_FONT_SIZE_24"    : "24",
+        "FIELD_OPTION_FONT_SIZE_30"    : "30",
+        "FIELD_OPTION_FONT_SIZE_36"    : "36",
+        "FIELD_OPTION_FONT_SIZE_48"    : "48",
+        "FIELD_OPTION_FONT_SIZE_60"    : "60",
+        "FIELD_OPTION_FONT_SIZE_72"    : "72",
+        "FIELD_OPTION_FONT_SIZE_96"    : "96",
+        "FIELD_OPTION_FONT_SIZE_EMPTY" : "",
+
+        "NAME" : "Kubernetes",
+
+        "SECTION_HEADER_AUTHENTICATION" : "Ověřování",
+        "SECTION_HEADER_BEHAVIOR"       : "Chování terminálu",
+        "SECTION_HEADER_CONTAINER"      : "Kontejner",
+        "SECTION_HEADER_DISPLAY"        : "Zobrazení",
+        "SECTION_HEADER_RECORDING"      : "Záznam obrazovky",
+        "SECTION_HEADER_TYPESCRIPT"     : "Strojopis (textový záznam sezení)",
+        "SECTION_HEADER_NETWORK"        : "Síť"
 
     },
 
@@ -405,21 +489,21 @@
         "FIELD_HEADER_PORT"                       : "Port:",
         "FIELD_HEADER_PRINTER_NAME"               : "Název přesměrované tiskárny:",
         "FIELD_HEADER_PRECONNECTION_BLOB"         : "Preconnection BLOB (VM ID):",
-        "FIELD_HEADER_PRECONNECTION_ID"           : "Zdrojové ID RDP",
+        "FIELD_HEADER_PRECONNECTION_ID"           : "Zdrojové ID RDP:",
         "FIELD_HEADER_READ_ONLY"                  : "Pouze ke čtení:",
         "FIELD_HEADER_RECORDING_EXCLUDE_MOUSE"    : "Vyloučit myš:",
         "FIELD_HEADER_RECORDING_EXCLUDE_OUTPUT"   : "Vyloučit grafiku/strímování:",
         "FIELD_HEADER_RECORDING_INCLUDE_KEYS"     : "Zahrnout klíčové události:",
-        "FIELD_HEADER_RECORDING_NAME"             : "Nahrávané jméno:",
-        "FIELD_HEADER_RECORDING_PATH"             : "Nahrávaná cesta:",
+        "FIELD_HEADER_RECORDING_NAME"             : "Název záznamu:",
+        "FIELD_HEADER_RECORDING_PATH"             : "Cesta pro záznam:",
         "FIELD_HEADER_RESIZE_METHOD"              : "Metoda změny velikosti:",
         "FIELD_HEADER_REMOTE_APP_ARGS"            : "Parametry:",
         "FIELD_HEADER_REMOTE_APP_DIR"             : "Pracovní adresář:",
         "FIELD_HEADER_REMOTE_APP"                 : "Program:",
         "FIELD_HEADER_SECURITY"                   : "Bezpečnostní mód:",
         "FIELD_HEADER_SERVER_LAYOUT"              : "Rozložení klávesnice:",
-        "FIELD_HEADER_SFTP_DIRECTORY"             : "Výchozí složka pro nahrávání:",
-        "FIELD_HEADER_SFTP_HOST_KEY"              : "Veřejný klíč hosta (Base64)",
+        "FIELD_HEADER_SFTP_DIRECTORY"             : "Výchozí složka pro uložení záznamu:",
+        "FIELD_HEADER_SFTP_HOST_KEY"              : "Veřejný klíč hosta (Base64):",
         "FIELD_HEADER_SFTP_HOSTNAME"              : "Jméno hostitele:",
         "FIELD_HEADER_SFTP_SERVER_ALIVE_INTERVAL" : "SFTP keepalive interval:",
         "FIELD_HEADER_SFTP_PASSPHRASE"            : "Přístupová fráze:",
@@ -429,6 +513,7 @@
         "FIELD_HEADER_SFTP_ROOT_DIRECTORY"        : "Souborový prohlížeč kořenové složky:",
         "FIELD_HEADER_SFTP_USERNAME"              : "Uživatelské jméno:",
         "FIELD_HEADER_STATIC_CHANNELS"            : "Názvy statických kanálů:",
+        "FIELD_HEADER_TIMEZONE"                   : "Časová zóna:",
         "FIELD_HEADER_USERNAME"                   : "Uživatelské jméno:",
         "FIELD_HEADER_WIDTH"                      : "Šířka:",
 
@@ -438,9 +523,9 @@
         "FIELD_OPTION_COLOR_DEPTH_8"     : "256 barev",
         "FIELD_OPTION_COLOR_DEPTH_EMPTY" : "",
 
-        "FIELD_OPTION_RESIZE_METHOD_DISPLAY_UPDATE" : "Virtuální kanál „Aktualizace zobrazení“ (RDP 8.1+)",
-        "FIELD_OPTION_RESIZE_METHOD_EMPTY"     : "",
-        "FIELD_OPTION_RESIZE_METHOD_RECONNECT" : "Znovu připojit",
+        "FIELD_OPTION_RESIZE_METHOD_DISPLAY_UPDATE" : "\"Aktualizace zobrazení\" virtuální kanál (RDP 8.1+)",
+        "FIELD_OPTION_RESIZE_METHOD_EMPTY"          : "",
+        "FIELD_OPTION_RESIZE_METHOD_RECONNECT"      : "Znovu připojit",
 
         "FIELD_OPTION_SECURITY_ANY"   : "Jakýkoliv",
         "FIELD_OPTION_SECURITY_EMPTY" : "",
@@ -448,20 +533,24 @@
         "FIELD_OPTION_SECURITY_RDP"   : "Šifrování RDP",
         "FIELD_OPTION_SECURITY_TLS"   : "Šifrování TLS",
 
-        "FIELD_OPTION_SERVER_LAYOUT_DE_DE_QWERTZ" : "Němčina (Qwertz)",
-        "FIELD_OPTION_SERVER_LAYOUT_EMPTY"        : "",
-        "FIELD_OPTION_SERVER_LAYOUT_EN_GB_QWERTY" : "UK Angličtina (Qwerty)",
-        "FIELD_OPTION_SERVER_LAYOUT_EN_US_QWERTY" : "US Angličtina (Qwerty)",
-        "FIELD_OPTION_SERVER_LAYOUT_ES_ES_QWERTY" : "Španělština (Qwerty)",
-        "FIELD_OPTION_SERVER_LAYOUT_FAILSAFE"     : "Unicode",
-        "FIELD_OPTION_SERVER_LAYOUT_FR_CH_QWERTZ" : "Švícarská Francouzština (Qwertz)",
-        "FIELD_OPTION_SERVER_LAYOUT_FR_FR_AZERTY" : "Francouzština (Azerty)",
-        "FIELD_OPTION_SERVER_LAYOUT_IT_IT_QWERTY" : "Italština (Qwerty)",
-        "FIELD_OPTION_SERVER_LAYOUT_JA_JP_QWERTY" : "Japonština (Qwerty)",
-        "FIELD_OPTION_SERVER_LAYOUT_PT_BR_QWERTY" : "Portugalská Brazilština (Qwerty)",
-        "FIELD_OPTION_SERVER_LAYOUT_SV_SE_QWERTY" : "Švédština (Qwerty)",
-        "FIELD_OPTION_SERVER_LAYOUT_DA_DK_QWERTY" : "Dánština (Qwerty)",
-        "FIELD_OPTION_SERVER_LAYOUT_TR_TR_QWERTY" : "Turečtina (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_DE_CH_QWERTZ"    : "Švícarská Němčina (Qwertz)",
+        "FIELD_OPTION_SERVER_LAYOUT_DE_DE_QWERTZ"    : "Němčina (Qwertz)",
+        "FIELD_OPTION_SERVER_LAYOUT_EMPTY"           : "",
+        "FIELD_OPTION_SERVER_LAYOUT_EN_GB_QWERTY"    : "UK Angličtina (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_EN_US_QWERTY"    : "US Angličtina (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_ES_ES_QWERTY"    : "Španělština (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_ES_LATAM_QWERTY" : "Standardní Angličtina (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_FAILSAFE"        : "Unicode",
+        "FIELD_OPTION_SERVER_LAYOUT_FR_BE_AZERTY"    : "Belgická Francouzština (Azerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_FR_CH_QWERTZ"    : "Švícarská Francouzština (Qwertz)",
+        "FIELD_OPTION_SERVER_LAYOUT_FR_FR_AZERTY"    : "Francouzština (Azerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_HU_HU_QWERTZ"    : "Maďarština (Qwertz)",
+        "FIELD_OPTION_SERVER_LAYOUT_IT_IT_QWERTY"    : "Italština (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_JA_JP_QWERTY"    : "Japonština (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_PT_BR_QWERTY"    : "Portugalská Brazilština (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_SV_SE_QWERTY"    : "Švédština (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_DA_DK_QWERTY"    : "Dánština (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_TR_TR_QWERTY"    : "Turečtina (Qwerty)",
 
         "NAME" : "RDP",
 
@@ -475,7 +564,7 @@
         "SECTION_HEADER_NETWORK"            : "Síť",
         "SECTION_HEADER_PERFORMANCE"        : "Výkon",
         "SECTION_HEADER_PRECONNECTION_PDU"  : "Preconnection PDU / Hyper-V",
-        "SECTION_HEADER_RECORDING"          : "Nahrávání obrazovky",
+        "SECTION_HEADER_RECORDING"          : "Záznam obrazovky",
         "SECTION_HEADER_REMOTEAPP"          : "RemoteApp",
         "SECTION_HEADER_SFTP"               : "SFTP"
 
@@ -483,38 +572,42 @@
 
     "PROTOCOL_SSH" : {
 
-        "FIELD_HEADER_BACKSPACE"                : "Backspace, poslat klávesy:",
-        "FIELD_HEADER_COLOR_SCHEME"             : "Barva",
+        "FIELD_HEADER_BACKSPACE"                : "Klávesa Zpět odešle:",
+        "FIELD_HEADER_COLOR_SCHEME"             : "Barva:",
         "FIELD_HEADER_COMMAND"                  : "Provést příkaz:",
-        "FIELD_HEADER_CREATE_RECORDING_PATH"    : "Automaticky vytvořit cestu k nahrávání:",
+        "FIELD_HEADER_CREATE_RECORDING_PATH"    : "Automaticky vytvořit cestu pro uložení záznamu:",
         "FIELD_HEADER_CREATE_TYPESCRIPT_PATH"   : "Automaticky vytvořit cestu ke strojopisu:",
         "FIELD_HEADER_DISABLE_COPY"             : "Zakázat kopírování ze vzdáleného terminálu:",
         "FIELD_HEADER_DISABLE_PASTE"            : "Zakázat vkládání z klienta:",
-        "FIELD_HEADER_FONT_NAME"                : "Typ fontu",
+        "FIELD_HEADER_FONT_NAME"                : "Typ fontu:",
         "FIELD_HEADER_FONT_SIZE"                : "Velikost písma:",
         "FIELD_HEADER_ENABLE_SFTP"              : "Povolit SFTP:",
         "FIELD_HEADER_HOST_KEY"                 : "Veřejný klíč hosta (Base64):",
         "FIELD_HEADER_HOSTNAME"                 : "Jméno hostitele:",
+        "FIELD_HEADER_LOCALE"                   : "Jazyk/Lokalizace ($LANG):",
         "FIELD_HEADER_USERNAME"                 : "Uživatelské jméno:",
         "FIELD_HEADER_PASSWORD"                 : "Heslo:",
         "FIELD_HEADER_PASSPHRASE"               : "Přístupová fráze:",
         "FIELD_HEADER_PORT"                     : "Port:",
         "FIELD_HEADER_PRIVATE_KEY"              : "Privátní klíč:",
+        "FIELD_HEADER_SCROLLBACK"               : "Maximální délka historie:",
         "FIELD_HEADER_READ_ONLY"                : "Pouze ke čtení:",
         "FIELD_HEADER_RECORDING_EXCLUDE_MOUSE"  : "Vynechat myš:",
         "FIELD_HEADER_RECORDING_EXCLUDE_OUTPUT" : "Vynechat grafiku/streamování:",
-        "FIELD_HEADER_RECORDING_INCLUDE_KEYS"   : "Zahrnout události kláves",
-        "FIELD_HEADER_RECORDING_NAME"           : "Nahrávané jméno:",
-        "FIELD_HEADER_RECORDING_PATH"           : "Nahrávaná cesta:",
+        "FIELD_HEADER_RECORDING_INCLUDE_KEYS"   : "Zahrnout události kláves:",
+        "FIELD_HEADER_RECORDING_NAME"           : "Název záznamu:",
+        "FIELD_HEADER_RECORDING_PATH"           : "Cesta pro záznam:",
         "FIELD_HEADER_SERVER_ALIVE_INTERVAL"    : "Serverový keepalive interval:",
         "FIELD_HEADER_SFTP_ROOT_DIRECTORY"      : "Souborový prohlížeč kořenové složky:",
         "FIELD_HEADER_TERMINAL_TYPE"            : "Typ terminálu:",
+        "FIELD_HEADER_TIMEZONE"                 : "Časová zóna ($TZ):",
         "FIELD_HEADER_TYPESCRIPT_NAME"          : "Jméno strojopisu:",
         "FIELD_HEADER_TYPESCRIPT_PATH"          : "Cesta ke strojopisu:",
 
-        "FIELD_OPTION_BACKSPACE_EMPTY"          : "",
-        "FIELD_OPTION_BACKSPACE_8"              : "Backspace (Ctrl-H)",
-        "FIELD_OPTION_BACKSPACE_127"            : "Delete (Ctrl-?)",
+        "FIELD_OPTION_BACKSPACE_EMPTY" : "",
+        "FIELD_OPTION_BACKSPACE_8"     : "Zpět (Ctrl-H)",
+        "FIELD_OPTION_BACKSPACE_127"   : "Smazat (Ctrl-?)",
+
         "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Černá na bílé",
         "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
         "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Šedá na černé",
@@ -552,19 +645,19 @@
         "SECTION_HEADER_CLIPBOARD"      : "Schránka",
         "SECTION_HEADER_DISPLAY"        : "Zobrazení",
         "SECTION_HEADER_NETWORK"        : "Síť",
-        "SECTION_HEADER_RECORDING"      : "Nahrávání obrazovky",
+        "SECTION_HEADER_RECORDING"      : "Záznam obrazovky",
         "SECTION_HEADER_SESSION"        : "Sezení / prostředí",
-        "SECTION_HEADER_TYPESCRIPT"     : "Strojopis (textové nahrávání sezení)",
+        "SECTION_HEADER_TYPESCRIPT"     : "Strojopis (textový záznam sezení)",
         "SECTION_HEADER_SFTP"           : "SFTP"
 
     },
 
     "PROTOCOL_TELNET" : {
 
-        "FIELD_HEADER_BACKSPACE"                : "Backspace, poslat klávesy:",
+        "FIELD_HEADER_BACKSPACE"                : "Klávesa Zpět odešle:",
         "FIELD_HEADER_COLOR_SCHEME"             : "Barevné schéma:",
-        "FIELD_HEADER_CREATE_RECORDING_PATH"    : "Automaticky vytvořit cestu k nahrávání:",
-        "FIELD_HEADER_CREATE_TYPESCRIPT_PATH"   : "Automaticky vytvořit cestu k typescriptu:",
+        "FIELD_HEADER_CREATE_RECORDING_PATH"    : "Automaticky vytvořit cestu pro uložení záznamu:",
+        "FIELD_HEADER_CREATE_TYPESCRIPT_PATH"   : "Automaticky vytvořit cestu ke strojopisu:",
         "FIELD_HEADER_DISABLE_COPY"             : "Zakázat kopírování z terminálu:",
         "FIELD_HEADER_DISABLE_PASTE"            : "Zakázat vkládání z klienta:",
         "FIELD_HEADER_FONT_NAME"                : "Jméno fontu:",
@@ -579,17 +672,18 @@
         "FIELD_HEADER_PORT"                     : "Port:",
         "FIELD_HEADER_READ_ONLY"                : "Pouze ke čtení:",
         "FIELD_HEADER_RECORDING_EXCLUDE_MOUSE"  : "Vyloučit myš:",
-        "FIELD_HEADER_RECORDING_EXCLUDE_OUTPUT" : "Vyloučit grafiku/strímování:",
+        "FIELD_HEADER_RECORDING_EXCLUDE_OUTPUT" : "Vyloučit grafiku/streamování:",
         "FIELD_HEADER_RECORDING_INCLUDE_KEYS"   : "Zahrnout klíčové události:",
-        "FIELD_HEADER_RECORDING_NAME"           : "Nahrávané jméno:",
-        "FIELD_HEADER_RECORDING_PATH"           : "Nahrávaná cesta:",
+        "FIELD_HEADER_RECORDING_NAME"           : "Název záznamu:",
+        "FIELD_HEADER_RECORDING_PATH"           : "Cesta pro záznam:",
+        "FIELD_HEADER_SCROLLBACK"               : "Maximální délka historie:",
         "FIELD_HEADER_TERMINAL_TYPE"            : "Typ terminálu:",
         "FIELD_HEADER_TYPESCRIPT_NAME"          : "Jméno strojopisu:",
         "FIELD_HEADER_TYPESCRIPT_PATH"          : "Cesta ke strojopisu:",
 
         "FIELD_OPTION_BACKSPACE_EMPTY" : "",
-        "FIELD_OPTION_BACKSPACE_8"     : "Backspace (Ctrl-H)",
-        "FIELD_OPTION_BACKSPACE_127"   : "Delete (Ctrl-?)",
+        "FIELD_OPTION_BACKSPACE_8"     : "Zpět (Ctrl-H)",
+        "FIELD_OPTION_BACKSPACE_127"   : "Smazat (Ctrl-?)",
 
         "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Černá na bílé",
         "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
@@ -627,24 +721,24 @@
         "SECTION_HEADER_BEHAVIOR"       : "Chování terminálu",
         "SECTION_HEADER_CLIPBOARD"      : "Schránka",
         "SECTION_HEADER_DISPLAY"        : "Zobrazení",
-        "SECTION_HEADER_RECORDING"      : "Nahrávání obrazovky",
-        "SECTION_HEADER_TYPESCRIPT"     : "Strojopis (textové nahrávání sezení)",
+        "SECTION_HEADER_RECORDING"      : "Záznam obrazovky",
+        "SECTION_HEADER_TYPESCRIPT"     : "Strojopis (textový záznam sezení)",
         "SECTION_HEADER_NETWORK"        : "Síť"
 
     },
 
     "PROTOCOL_VNC" : {
 
-        "FIELD_HEADER_AUDIO_SERVERNAME"           : "Název zvukového serveru",
+        "FIELD_HEADER_AUDIO_SERVERNAME"           : "Název zvukového serveru:",
         "FIELD_HEADER_CLIPBOARD_ENCODING"         : "Kódovávání:",
         "FIELD_HEADER_COLOR_DEPTH"                : "Hloubka barev:",
-        "FIELD_HEADER_CREATE_RECORDING_PATH"      : "Automaticky vytvořit cestu k nahrávání:",
+        "FIELD_HEADER_CREATE_RECORDING_PATH"      : "Automaticky vytvořit cestu pro uložení záznamu:",
         "FIELD_HEADER_CURSOR"                     : "Kurzor:",
         "FIELD_HEADER_DEST_HOST"                  : "Cílový host:",
         "FIELD_HEADER_DEST_PORT"                  : "Vzdálený port:",
         "FIELD_HEADER_DISABLE_COPY"               : "Zakázat kopírování ze vzdálené plochy:",
         "FIELD_HEADER_DISABLE_PASTE"              : "Zakázat vkládání z klienta:",
-        "FIELD_HEADER_ENABLE_AUDIO"               : "Zapnout audio",
+        "FIELD_HEADER_ENABLE_AUDIO"               : "Zapnout audio:",
         "FIELD_HEADER_ENABLE_SFTP"                : "Povolit SFTP:",
         "FIELD_HEADER_HOSTNAME"                   : "Jméno hostitele:",
         "FIELD_HEADER_PASSWORD"                   : "Heslo:",
@@ -652,11 +746,11 @@
         "FIELD_HEADER_READ_ONLY"                  : "Pouze čtení:",
         "FIELD_HEADER_RECORDING_EXCLUDE_MOUSE"    : "Vynechat myš:",
         "FIELD_HEADER_RECORDING_EXCLUDE_OUTPUT"   : "Vynechat grafiku/stremování:",
-        "FIELD_HEADER_RECORDING_INCLUDE_KEYS"     : "Zahrnout události kláves",
-        "FIELD_HEADER_RECORDING_NAME"             : "Nahrávané jméno:",
-        "FIELD_HEADER_RECORDING_PATH"             : "Nahrávaná cesta:",
-        "FIELD_HEADER_SFTP_DIRECTORY"             : "Výchozí složka pro nahrávání:",
-        "FIELD_HEADER_SFTP_HOST_KEY"              : "Veřejný klíč hosta (Base64)",
+        "FIELD_HEADER_RECORDING_INCLUDE_KEYS"     : "Zahrnout události kláves:",
+        "FIELD_HEADER_RECORDING_NAME"             : "Název záznamu:",
+        "FIELD_HEADER_RECORDING_PATH"             : "Cesta pro záznam:",
+        "FIELD_HEADER_SFTP_DIRECTORY"             : "Výchozí složka pro uložení záznamu:",
+        "FIELD_HEADER_SFTP_HOST_KEY"              : "Veřejný klíč hosta (Base64):",
         "FIELD_HEADER_SFTP_HOSTNAME"              : "Jméno hostitele:",
         "FIELD_HEADER_SFTP_SERVER_ALIVE_INTERVAL" : "SFTP keepalive interval:",
         "FIELD_HEADER_SFTP_PASSPHRASE"            : "Přístupová fráze:",
@@ -690,7 +784,7 @@
         "SECTION_HEADER_CLIPBOARD"      : "Schránka",
         "SECTION_HEADER_DISPLAY"        : "Zobrazení",
         "SECTION_HEADER_NETWORK"        : "Síť",
-        "SECTION_HEADER_RECORDING"      : "Nahrávání obrazovky",
+        "SECTION_HEADER_RECORDING"      : "Záznam obrazovky",
         "SECTION_HEADER_REPEATER"       : "VNC opakovač",
         "SECTION_HEADER_SFTP"           : "SFTP"
 
@@ -740,7 +834,7 @@
         "FIELD_PLACEHOLDER_FILTER" : "@:APP.FIELD_PLACEHOLDER_FILTER",
 
         "HELP_CONNECTIONS" : "Toto připojení můžete spravovat klepnutím nebo klepnutím na níže uvedené připojení. V závislosti na vaší úrovni přístupu lze přidávat a mazat připojení a měnit jejich vlastnosti (protokol, název hostitele, port atd.).",
-
+        
         "INFO_ACTIVE_USER_COUNT" : "@:APP.INFO_ACTIVE_USER_COUNT",
 
         "SECTION_HEADER_CONNECTIONS" : "Připojení"
@@ -749,11 +843,11 @@
 
     "SETTINGS_PREFERENCES" : {
 
-        "ACTION_ACKNOWLEDGE"     : "@:APP.ACTION_ACKNOWLEDGE",
-        "ACTION_CANCEL"          : "@:APP.ACTION_CANCEL",
-        "ACTION_UPDATE_PASSWORD" : "@:APP.ACTION_UPDATE_PASSWORD",
+        "ACTION_ACKNOWLEDGE"        : "@:APP.ACTION_ACKNOWLEDGE",
+        "ACTION_CANCEL"             : "@:APP.ACTION_CANCEL",
+        "ACTION_UPDATE_PASSWORD"    : "@:APP.ACTION_UPDATE_PASSWORD",
 
-        "DIALOG_HEADER_ERROR" : "@:APP.DIALOG_HEADER_ERROR",
+        "DIALOG_HEADER_ERROR"    : "@:APP.DIALOG_HEADER_ERROR",
 
         "ERROR_PASSWORD_BLANK"    : "@:APP.ERROR_PASSWORD_BLANK",
         "ERROR_PASSWORD_MISMATCH" : "@:APP.ERROR_PASSWORD_MISMATCH",
@@ -763,14 +857,15 @@
         "FIELD_HEADER_PASSWORD_OLD"       : "Aktuální heslo:",
         "FIELD_HEADER_PASSWORD_NEW"       : "Nové heslo:",
         "FIELD_HEADER_PASSWORD_NEW_AGAIN" : "Potvrďte nové heslo:",
+        "FIELD_HEADER_TIMEZONE"           : "Časové pásmo:",
         "FIELD_HEADER_USERNAME"           : "Uživatelské jméno:",
-
+        
         "HELP_DEFAULT_INPUT_METHOD" : "Výchozí metoda vstupu určuje, jak Guacamole přijímá události klávesnice. Změna tohoto nastavení může být nezbytná při používání mobilního zařízení nebo při psaní přes IME. Toto nastavení může být přepsáno na základě připojení v rámci nabídky Guacamole.",
         "HELP_DEFAULT_MOUSE_MODE"   : "Výchozí režim emulace myši určuje, jak se bude vzdálená myš chovat v nových spojeních s ohledem na dotyky. Toto nastavení může být přepsáno na základě připojení v rámci nabídky Guacamole.",
         "HELP_INPUT_METHOD_NONE"    : "@:CLIENT.HELP_INPUT_METHOD_NONE",
         "HELP_INPUT_METHOD_OSK"     : "@:CLIENT.HELP_INPUT_METHOD_OSK",
         "HELP_INPUT_METHOD_TEXT"    : "@:CLIENT.HELP_INPUT_METHOD_TEXT",
-        "HELP_LANGUAGE"             : "Chcete-li změnit jazyk celého textu v Guacamole, vyberte níže uvedený jazyk. Dostupné volby budou záviset na nainstalovaných jazycích.",
+        "HELP_LOCALE"               : "Níže uvedené možnosti se vztahují k místu uživatele a ovlivní způsob zobrazení různých částí rozhraní.",
         "HELP_MOUSE_MODE_ABSOLUTE"  : "@:CLIENT.HELP_MOUSE_MODE_ABSOLUTE",
         "HELP_MOUSE_MODE_RELATIVE"  : "@:CLIENT.HELP_MOUSE_MODE_RELATIVE",
         "HELP_UPDATE_PASSWORD"      : "Pokud chcete změnit heslo, zadejte své aktuální heslo a níže požadované nové heslo a klikněte na tlačítko „Aktualizovat heslo“. Změna se projeví okamžitě.",
@@ -789,7 +884,7 @@
 
     "SETTINGS_USERS" : {
 
-        "ACTION_ACKNOWLEDGE" : "@:APP.ACTION_ACKNOWLEDGE",
+        "ACTION_ACKNOWLEDGE"   : "@:APP.ACTION_ACKNOWLEDGE",
         "ACTION_NEW_USER"    : "Nový uživatel",
 
         "DIALOG_HEADER_ERROR" : "@:APP.DIALOG_HEADER_ERROR",
@@ -803,7 +898,7 @@
         "SECTION_HEADER_USERS" : "Uživatel",
 
         "TABLE_HEADER_FULL_NAME"    : "Celé jméno",
-        "TABLE_HEADER_LAST_ACTIVE"  : "Poslední aktivní",
+        "TABLE_HEADER_LAST_ACTIVE"  : "Naposledy aktivní",
         "TABLE_HEADER_ORGANIZATION" : "Organizace",
         "TABLE_HEADER_USERNAME"     : "Uživatelské jméno"
 
@@ -829,30 +924,30 @@
     },
 
     "SETTINGS_SESSIONS" : {
-
+        
         "ACTION_ACKNOWLEDGE" : "@:APP.ACTION_ACKNOWLEDGE",
         "ACTION_CANCEL"      : "@:APP.ACTION_CANCEL",
         "ACTION_DELETE"      : "Ukončit sezení",
-
+        
         "DIALOG_HEADER_CONFIRM_DELETE" : "Ukončit sezení",
         "DIALOG_HEADER_ERROR"          : "@:APP.DIALOG_HEADER_ERROR",
-
+        
         "FIELD_PLACEHOLDER_FILTER" : "@:APP.FIELD_PLACEHOLDER_FILTER",
-
+        
         "FORMAT_STARTDATE" : "@:APP.FORMAT_DATE_TIME_PRECISE",
 
         "HELP_SESSIONS" : "Tato stránka bude naplněna aktuálně aktivními připojeními. Uvedená připojení a schopnost zabít tato připojení závisí na úrovni přístupu. Pokud chcete zabít jednu nebo více relací, zaškrtněte políčko vedle těchto relací a klepněte na tlačítko \"Zabít relace\". Zabití relace okamžitě odpojí uživatele od přidruženého připojení.",
-
+        
         "INFO_NO_SESSIONS" : "Žádné aktivní sezení",
 
         "SECTION_HEADER_SESSIONS" : "Aktivní sezení",
-
+        
         "TABLE_HEADER_SESSION_CONNECTION_NAME" : "Název připojení",
         "TABLE_HEADER_SESSION_REMOTEHOST"      : "Vzdálený host",
         "TABLE_HEADER_SESSION_STARTDATE"       : "Aktivní od",
-        "TABLE_HEADER_SESSION_USERNAME"        : "Uživatelské jméno:",
-
-        "TEXT_CONFIRM_DELETE" : "Jste si jisti, že chcete ukončit vybrané sezení? Uživatele užívající toto spojení budou okamžitě odpojeni. "
+        "TABLE_HEADER_SESSION_USERNAME"        : "Uživatelské jméno",
+        
+        "TEXT_CONFIRM_DELETE" : "Jste si jisti, že chcete ukončit vybrané připojení? Uživatelé využívající toto připojení budou okamžitě odpojeni."
 
     },
 


### PR DESCRIPTION
As noted in [GLEN-237](https://jira.glyptodon.com/browse/GLEN-237), the recently backported Czech translation was incorrect in that it should have been named `cs.json`, not `cz.json`. The incorrect naming resulted in JavaScript errors which caused the translation to fail to apply.

In addition to the naming, the translation has been updated upstream as part of the same changes. This change backports all of this.