### PR TITLE
GLEN-235: Add RDP parameter value and translation string for Hyper-V / VMConnect security mode.

### DIFF
--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
@@ -34,7 +34,7 @@
                 {
                     "name"    : "security",
                     "type"    : "ENUM",
-                    "options" : [ "", "rdp", "tls", "nla", "any" ]
+                    "options" : [ "", "rdp", "tls", "nla", "vmconnect", "any" ]
                 },
                 {
                     "name"    : "disable-auth",

--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -534,6 +534,7 @@
         "FIELD_OPTION_SECURITY_NLA"   : "NLA (Network Level Authentication)",
         "FIELD_OPTION_SECURITY_RDP"   : "RDP encryption",
         "FIELD_OPTION_SECURITY_TLS"   : "TLS encryption",
+        "FIELD_OPTION_SECURITY_VMCONNECT" : "Hyper-V / VMConnect",
 
         "FIELD_OPTION_SERVER_LAYOUT_DE_CH_QWERTZ" : "Swiss German (Qwertz)",
         "FIELD_OPTION_SERVER_LAYOUT_DE_DE_QWERTZ" : "German (Qwertz)",


### PR DESCRIPTION
After the migration to FreeRDP 2.0.0, support for connecting directly to the console of a Hyper-V 
 VM broke. This was addressed upstream via the addition of a new VMConnect-specific security mode, which is part of the changes proposed for backport in glyptodon/guacamole-server#189.

This change consists only of the parameter value and translation string for this new security mode.