### PR TITLE
GLEN-241: Correct handling of translated error messages in 1.x.

### DIFF
--- a/extensions/guacamole-auth-duo/src/main/java/org/apache/guacamole/auth/duo/UserVerificationService.java
+++ b/extensions/guacamole-auth-duo/src/main/java/org/apache/guacamole/auth/duo/UserVerificationService.java
@@ -22,16 +22,16 @@ package org.apache.guacamole.auth.duo;
 import com.google.inject.Inject;
 import java.util.Collections;
 import javax.servlet.http.HttpServletRequest;
-import org.apache.guacamole.GuacamoleClientException;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.duo.api.DuoService;
 import org.apache.guacamole.auth.duo.conf.ConfigurationService;
 import org.apache.guacamole.auth.duo.form.DuoSignedResponseField;
 import org.apache.guacamole.form.Field;
+import org.apache.guacamole.language.TranslatableGuacamoleClientException;
+import org.apache.guacamole.language.TranslatableGuacamoleInsufficientCredentialsException;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.Credentials;
 import org.apache.guacamole.net.auth.credentials.CredentialsInfo;
-import org.apache.guacamole.net.auth.credentials.GuacamoleInsufficientCredentialsException;
 
 /**
  * Service for verifying the identity of a user against Duo.
@@ -95,14 +95,18 @@ public class UserVerificationService {
                         Collections.singletonList(signedResponseField));
 
             // Request additional credentials
-            throw new GuacamoleInsufficientCredentialsException(
-                    "LOGIN.INFO_DUO_AUTH_REQUIRED", expectedCredentials);
+            throw new TranslatableGuacamoleInsufficientCredentialsException(
+                    "Verification using Duo is required before authentication "
+                    + "can continue.", "LOGIN.INFO_DUO_AUTH_REQUIRED",
+                    expectedCredentials);
 
         }
 
         // If signed response does not verify this user's identity, abort auth
         if (!duoService.isValidSignedResponse(authenticatedUser, signedResponse))
-            throw new GuacamoleClientException("LOGIN.INFO_DUO_VALIDATION_CODE_INCORRECT");
+            throw new TranslatableGuacamoleClientException("Provided Duo "
+                    + "validation code is incorrect.",
+                    "LOGIN.INFO_DUO_VALIDATION_CODE_INCORRECT");
 
     }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderService.java
@@ -21,7 +21,6 @@ package org.apache.guacamole.auth.jdbc;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
-import org.apache.guacamole.GuacamoleClientException;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.jdbc.security.PasswordPolicyService;
 import org.apache.guacamole.auth.jdbc.sharing.user.SharedAuthenticatedUser;
@@ -29,6 +28,7 @@ import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.auth.jdbc.user.ModeledUser;
 import org.apache.guacamole.auth.jdbc.user.ModeledUserContext;
 import org.apache.guacamole.auth.jdbc.user.UserService;
+import org.apache.guacamole.language.TranslatableGuacamoleClientException;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Credentials;
@@ -105,11 +105,15 @@ public class JDBCAuthenticationProviderService implements AuthenticationProvider
 
                 // Verify user account is still valid as of today
                 if (!user.isAccountValid())
-                    throw new GuacamoleClientException("LOGIN.ERROR_NOT_VALID");
+                    throw new TranslatableGuacamoleClientException("User "
+                            + "account is no longer valid.",
+                            "LOGIN.ERROR_NOT_VALID");
 
                 // Verify user account is allowed to be used at the current time
                 if (!user.isAccountAccessible())
-                    throw new GuacamoleClientException("LOGIN.ERROR_NOT_ACCESSIBLE");
+                    throw new TranslatableGuacamoleClientException("User "
+                            + "account may not be used at this time.",
+                            "LOGIN.ERROR_NOT_ACCESSIBLE");
 
             }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserService.java
@@ -38,11 +38,12 @@ import org.apache.guacamole.auth.jdbc.security.PasswordEncryptionService;
 import org.apache.guacamole.auth.jdbc.security.PasswordPolicyService;
 import org.apache.guacamole.form.Field;
 import org.apache.guacamole.form.PasswordField;
+import org.apache.guacamole.language.TranslatableGuacamoleClientException;
+import org.apache.guacamole.language.TranslatableGuacamoleInsufficientCredentialsException;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.User;
 import org.apache.guacamole.net.auth.credentials.CredentialsInfo;
-import org.apache.guacamole.net.auth.credentials.GuacamoleInsufficientCredentialsException;
 import org.apache.guacamole.net.auth.permission.ObjectPermission;
 import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
 import org.apache.guacamole.net.auth.permission.SystemPermission;
@@ -436,20 +437,25 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
         // Require new password if account is expired
         if (newPassword == null || confirmNewPassword == null) {
             logger.info("The password of user \"{}\" has expired and must be reset.", username);
-            throw new GuacamoleInsufficientCredentialsException("LOGIN.INFO_PASSWORD_EXPIRED", EXPIRED_PASSWORD);
+            throw new TranslatableGuacamoleInsufficientCredentialsException("Password has expired",
+                    "LOGIN.INFO_PASSWORD_EXPIRED", EXPIRED_PASSWORD);
         }
 
         // New password must be different from old password
         if (newPassword.equals(credentials.getPassword()))
-            throw new GuacamoleClientException("LOGIN.ERROR_PASSWORD_SAME");
+            throw new TranslatableGuacamoleClientException("New passwords may "
+                    + "not be identical to the current password if password "
+                    + "reset is required.", "LOGIN.ERROR_PASSWORD_SAME");
 
         // New password must not be blank
         if (newPassword.isEmpty())
-            throw new GuacamoleClientException("LOGIN.ERROR_PASSWORD_BLANK");
+            throw new TranslatableGuacamoleClientException("Passwords may not "
+                    + "be blank.", "LOGIN.ERROR_PASSWORD_BLANK");
 
         // Confirm that the password was entered correctly twice
         if (!newPassword.equals(confirmNewPassword))
-            throw new GuacamoleClientException("LOGIN.ERROR_PASSWORD_MISMATCH");
+            throw new TranslatableGuacamoleClientException("New password does "
+                    + "not match.", "LOGIN.ERROR_PASSWORD_MISMATCH");
 
         // Verify new password does not violate defined policies
         passwordPolicyService.verifyPassword(username, newPassword);

--- a/guacamole-ext/src/main/java/org/apache/guacamole/language/TranslatableGuacamoleClientException.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/language/TranslatableGuacamoleClientException.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.language;
+
+import org.apache.guacamole.GuacamoleClientException;
+
+/**
+ * A {@link GuacamoleClientException} whose associated message is translatable
+ * and can be passed through an arbitrary translation service, producing a
+ * human-readable message in the user's native language.
+ */
+public class TranslatableGuacamoleClientException extends GuacamoleClientException implements Translatable {
+
+    /**
+     * A translatable, human-readable description of the exception that
+     * occurred.
+     */
+    private final TranslatableMessage translatableMessage;
+
+    /**
+     * Creates a new TranslatableGuacamoleClientException with the given
+     * message and cause. The message must be provided in both non-translatable
+     * (readable as-written) and translatable forms.
+     *
+     * @param message
+     *     A human-readable description of the exception that occurred. This
+     *     message should be readable on its own and as-written, without
+     *     requiring a translation service.
+     *
+     * @param translatableMessage
+     *     A translatable, human-readable description of the exception that
+     *     occurred.
+     *
+     * @param cause
+     *     The cause of this exception.
+     */
+    public TranslatableGuacamoleClientException(String message, TranslatableMessage translatableMessage, Throwable cause) {
+        super(message, cause);
+        this.translatableMessage = translatableMessage;
+    }
+
+    /**
+     * Creates a new TranslatableGuacamoleClientException with the given
+     * message. The message must be provided in both non-translatable (readable
+     * as-written) and translatable forms.
+     *
+     * @param message
+     *     A human-readable description of the exception that occurred. This
+     *     message should be readable on its own and as-written, without
+     *     requiring a translation service.
+     *
+     * @param translatableMessage
+     *     A translatable, human-readable description of the exception that
+     *     occurred.
+     */
+    public TranslatableGuacamoleClientException(String message, TranslatableMessage translatableMessage) {
+        super(message);
+        this.translatableMessage = translatableMessage;
+    }
+
+    /**
+     * Creates a new TranslatableGuacamoleClientException with the given
+     * message and cause. The message must be provided in both non-translatable
+     * (readable as-written) and translatable forms.
+     *
+     * @param message
+     *     A human-readable description of the exception that occurred. This
+     *     message should be readable on its own and as-written, without
+     *     requiring a translation service.
+     *
+     * @param key
+     *     The arbitrary key which can be used to look up the message to be
+     *     displayed in the user's native language.
+     *
+     * @param cause
+     *     The cause of this exception.
+     */
+    public TranslatableGuacamoleClientException(String message, String key, Throwable cause) {
+        this(message, new TranslatableMessage(key), cause);
+    }
+
+    /**
+     * Creates a new TranslatableGuacamoleClientException with the given
+     * message. The message must be provided in both non-translatable (readable
+     * as-written) and translatable forms.
+     *
+     * @param message
+     *     A human-readable description of the exception that occurred. This
+     *     message should be readable on its own and as-written, without
+     *     requiring a translation service.
+     *
+     * @param key
+     *     The arbitrary key which can be used to look up the message to be
+     *     displayed in the user's native language.
+     */
+    public TranslatableGuacamoleClientException(String message, String key) {
+        this(message, new TranslatableMessage(key));
+    }
+
+    @Override
+    public TranslatableMessage getTranslatableMessage() {
+        return translatableMessage;
+    }
+
+}

--- a/guacamole-ext/src/main/java/org/apache/guacamole/language/TranslatableGuacamoleInsufficientCredentialsException.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/language/TranslatableGuacamoleInsufficientCredentialsException.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.language;
+
+import org.apache.guacamole.net.auth.credentials.CredentialsInfo;
+import org.apache.guacamole.net.auth.credentials.GuacamoleInsufficientCredentialsException;
+
+/**
+ * A {@link GuacamoleInsufficientCredentialsException} whose associated message
+ * is translatable and can be passed through an arbitrary translation service,
+ * producing a human-readable message in the user's native language.
+ */
+public class TranslatableGuacamoleInsufficientCredentialsException
+        extends GuacamoleInsufficientCredentialsException implements Translatable {
+
+    /**
+     * A translatable, human-readable description of the exception that
+     * occurred.
+     */
+    private final TranslatableMessage translatableMessage;
+
+    /**
+     * Creates a new TranslatableGuacamoleInsufficientCredentialsException with
+     * the given message, cause, and associated credential information. The
+     * message must be provided in both non-translatable (readable as-written)
+     * and translatable forms.
+     *
+     * @param message
+     *     A human-readable description of the exception that occurred. This
+     *     message should be readable on its own and as-written, without
+     *     requiring a translation service.
+     *
+     * @param translatableMessage
+     *     A translatable, human-readable description of the exception that
+     *     occurred.
+     *
+     * @param cause
+     *     The cause of this exception.
+     *
+     * @param credentialsInfo
+     *     Information describing the form of valid credentials.
+     */
+    public TranslatableGuacamoleInsufficientCredentialsException(String message,
+            TranslatableMessage translatableMessage, Throwable cause, CredentialsInfo credentialsInfo) {
+        super(message, cause, credentialsInfo);
+        this.translatableMessage = translatableMessage;
+    }
+
+    /**
+     * Creates a new TranslatableGuacamoleInsufficientCredentialsException with
+     * the given message, and associated credential information. The message
+     * must be provided in both non-translatable (readable as-written) and
+     * translatable forms.
+     *
+     * @param message
+     *     A human-readable description of the exception that occurred. This
+     *     message should be readable on its own and as-written, without
+     *     requiring a translation service.
+     *
+     * @param translatableMessage
+     *     A translatable, human-readable description of the exception that
+     *     occurred.
+     *
+     * @param credentialsInfo
+     *     Information describing the form of valid credentials.
+     */
+    public TranslatableGuacamoleInsufficientCredentialsException(String message,
+            TranslatableMessage translatableMessage, CredentialsInfo credentialsInfo) {
+        super(message, credentialsInfo);
+        this.translatableMessage = translatableMessage;
+    }
+
+    /**
+     * Creates a new TranslatableGuacamoleInsufficientCredentialsException with
+     * the given message, cause, and associated credential information. The
+     * message must be provided in both non-translatable (readable as-written)
+     * and translatable forms.
+     *
+     * @param message
+     *     A human-readable description of the exception that occurred. This
+     *     message should be readable on its own and as-written, without
+     *     requiring a translation service.
+     *
+     * @param key
+     *     The arbitrary key which can be used to look up the message to be
+     *     displayed in the user's native language.
+     *
+     * @param cause
+     *     The cause of this exception.
+     *
+     * @param credentialsInfo
+     *     Information describing the form of valid credentials.
+     */
+    public TranslatableGuacamoleInsufficientCredentialsException(String message,
+            String key, Throwable cause, CredentialsInfo credentialsInfo) {
+        this(message, new TranslatableMessage(key), cause, credentialsInfo);
+    }
+
+    /**
+     * Creates a new TranslatableGuacamoleInsufficientCredentialsException with
+     * the given message, and associated credential information. The message
+     * must be provided in both non-translatable (readable as-written) and
+     * translatable forms.
+     *
+     * @param message
+     *     A human-readable description of the exception that occurred. This
+     *     message should be readable on its own and as-written, without
+     *     requiring a translation service.
+     *
+     * @param key
+     *     The arbitrary key which can be used to look up the message to be
+     *     displayed in the user's native language.
+     *
+     * @param credentialsInfo
+     *     Information describing the form of valid credentials.
+     */
+    public TranslatableGuacamoleInsufficientCredentialsException(String message,
+            String key, CredentialsInfo credentialsInfo) {
+        this(message, new TranslatableMessage(key), credentialsInfo);
+    }
+
+    @Override
+    public TranslatableMessage getTranslatableMessage() {
+        return translatableMessage;
+    }
+
+}


### PR DESCRIPTION
This change backports the fix for the incorrect handling of extension errors which resulted in translated error messages being rendered as raw translation keys. See:

https://jira.glyptodon.com/browse/GLEN-241

As GLEN 1.x maintains strict compatibility with 0.9.12-incubating, and only `TranslatableGuacamoleClientException` and `TranslatableGuacamoleInsufficientCredentialsException` are required by these changes, only those exceptions are backported here.