### PR TITLE
GLEN-262: Backport standardization on single history retrieval mechanism.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ConnectionRecordMapper.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ConnectionRecordMapper.java
@@ -62,8 +62,12 @@ public interface ConnectionRecordMapper {
      * the data they are associated with is is readable by any particular user.
      * This should only be called on behalf of a system administrator. If
      * records are needed by a non-administrative user who must have explicit
-     * read rights, use searchReadable() instead.
+     * read rights, use {@link searchReadable()} instead.
      *
+     * @param identifier
+     *     The optional connection identifier to which records should be limited,
+     *     or null if all records should be retrieved.
+     * 
      * @param terms
      *     The search terms that must match the returned records.
      *
@@ -77,7 +81,8 @@ public interface ConnectionRecordMapper {
      * @return
      *     The results of the search performed with the given parameters.
      */
-    List<ConnectionRecordModel> search(@Param("terms") Collection<ConnectionRecordSearchTerm> terms,
+    List<ConnectionRecordModel> search(@Param("identifier") String identifier,
+            @Param("terms") Collection<ConnectionRecordSearchTerm> terms,
             @Param("sortPredicates") List<ConnectionRecordSortPredicate> sortPredicates,
             @Param("limit") int limit);
 
@@ -86,8 +91,13 @@ public interface ConnectionRecordMapper {
      * the given terms, sorted by the given predicates. Only records that are
      * associated with data explicitly readable by the given user will be
      * returned. If records are needed by a system administrator (who, by
-     * definition, does not need explicit read rights), use search() instead.
+     * definition, does not need explicit read rights), use {@link search()}
+     * instead.
      *
+     * @param identifier
+     *     The optional connection identifier for which records should be
+     *     retrieved, or null if all readable records should be retrieved.
+     * 
      * @param user
      *    The user whose permissions should determine whether a record is
      *    returned.
@@ -105,7 +115,8 @@ public interface ConnectionRecordMapper {
      * @return
      *     The results of the search performed with the given parameters.
      */
-    List<ConnectionRecordModel> searchReadable(@Param("user") UserModel user,
+    List<ConnectionRecordModel> searchReadable(@Param("identifier") String identifier,
+            @Param("user") UserModel user,
             @Param("terms") Collection<ConnectionRecordSearchTerm> terms,
             @Param("sortPredicates") List<ConnectionRecordSortPredicate> sortPredicates,
             @Param("limit") int limit);

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ConnectionRecordSet.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ConnectionRecordSet.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Set;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.jdbc.base.RestrictedObject;
+import org.apache.guacamole.auth.jdbc.user.ModeledAuthenticatedUser;
 import org.apache.guacamole.net.auth.ConnectionRecord;
 
 /**
@@ -45,6 +46,13 @@ public class ConnectionRecordSet extends RestrictedObject
     @Inject
     private ConnectionService connectionService;
     
+    /**
+     * The identifier of the connection to which this record set should be
+     * limited, if any. If null, the set should contain all records readable
+     * by the user making the request.
+     */
+    private String identifier = null;
+
     /**
      * The set of strings that each must occur somewhere within the returned 
      * connection records, whether within the associated username, the name of 
@@ -68,11 +76,29 @@ public class ConnectionRecordSet extends RestrictedObject
      */
     private final List<ConnectionRecordSortPredicate> connectionRecordSortPredicates =
             new ArrayList<ConnectionRecordSortPredicate>();
+   
+    /**
+     * Initializes this object, associating it with the current authenticated
+     * user and connection identifier.
+     *
+     * @param currentUser
+     *     The user that created or retrieved this object.
+     * 
+     * @param identifier
+     *     The connection identifier to which this record set should be limited,
+     *     or null if the record set should contain all records readable by the
+     *     currentUser.
+     */
+    protected void init(ModeledAuthenticatedUser currentUser, String identifier) {
+        super.init(currentUser);
+        this.identifier = identifier;
+    }
     
     @Override
     public Collection<ConnectionRecord> asCollection()
             throws GuacamoleException {
-        return connectionService.retrieveHistory(getCurrentUser(),
+        // Retrieve history from database
+        return connectionService.retrieveHistory(identifier, getCurrentUser(),
                 requiredContents, connectionRecordSortPredicates, limit);
     }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/apache/guacamole/auth/jdbc/connection/ConnectionRecordMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/org/apache/guacamole/auth/jdbc/connection/ConnectionRecordMapper.xml
@@ -100,28 +100,35 @@
         LEFT JOIN guacamole_user       ON guacamole_connection_history.user_id       = guacamole_user.user_id
 
         <!-- Search terms -->
-        <foreach collection="terms" item="term"
-                 open="WHERE " separator=" AND ">
-            (
+        <where>
+            
+            <if test="identifier != null">
+                guacamole_connection_history.connection_id = #{identifier,jdbcType=VARCHAR}
+            </if>
+            
+            <foreach collection="terms" item="term" open=" AND " separator=" AND ">
+                (
 
-                guacamole_connection_history.user_id IN (
-                    SELECT user_id
-                    FROM guacamole_user
-                    WHERE POSITION(#{term.term,jdbcType=VARCHAR} IN username) > 0
+                    guacamole_connection_history.user_id IN (
+                        SELECT user_id
+                        FROM guacamole_user
+                        WHERE POSITION(#{term.term,jdbcType=VARCHAR} IN username) > 0
+                    )
+
+                    OR guacamole_connection_history.connection_id IN (
+                        SELECT connection_id
+                        FROM guacamole_connection
+                        WHERE POSITION(#{term.term,jdbcType=VARCHAR} IN connection_name) > 0
+                    )
+
+                    <if test="term.startDate != null and term.endDate != null">
+                        OR start_date BETWEEN #{term.startDate,jdbcType=TIMESTAMP} AND #{term.endDate,jdbcType=TIMESTAMP}
+                    </if>
+
                 )
-
-                OR guacamole_connection_history.connection_id IN (
-                    SELECT connection_id
-                    FROM guacamole_connection
-                    WHERE POSITION(#{term.term,jdbcType=VARCHAR} IN connection_name) > 0
-                )
-
-                <if test="term.startDate != null and term.endDate != null">
-                    OR start_date BETWEEN #{term.startDate,jdbcType=TIMESTAMP} AND #{term.endDate,jdbcType=TIMESTAMP}
-                </if>
-
-            )
-        </foreach>
+            </foreach>
+            
+        </where>
 
         <!-- Bind sort property enum values for sake of readability -->
         <bind name="START_DATE"      value="@org.apache.guacamole.net.auth.ConnectionRecordSet$SortableProperty@START_DATE"/>
@@ -169,28 +176,35 @@
             AND guacamole_user_permission.permission = 'READ'
 
         <!-- Search terms -->
-        <foreach collection="terms" item="term"
-                 open="WHERE " separator=" AND ">
-            (
+        <where>
+            
+            <if test="identifier != null">
+                guacamole_connection_history.connection_id = #{identifier,jdbcType=VARCHAR}
+            </if>
+            
+            <foreach collection="terms" item="term" open=" AND " separator=" AND ">
+                (
 
-                guacamole_connection_history.user_id IN (
-                    SELECT user_id
-                    FROM guacamole_user
-                    WHERE POSITION(#{term.term,jdbcType=VARCHAR} IN username) > 0
+                    guacamole_connection_history.user_id IN (
+                        SELECT user_id
+                        FROM guacamole_user
+                        WHERE POSITION(#{term.term,jdbcType=VARCHAR} IN username) > 0
+                    )
+
+                    OR guacamole_connection_history.connection_id IN (
+                        SELECT connection_id
+                        FROM guacamole_connection
+                        WHERE POSITION(#{term.term,jdbcType=VARCHAR} IN connection_name) > 0
+                    )
+
+                    <if test="term.startDate != null and term.endDate != null">
+                        OR start_date BETWEEN #{term.startDate,jdbcType=TIMESTAMP} AND #{term.endDate,jdbcType=TIMESTAMP}
+                    </if>
+
                 )
-
-                OR guacamole_connection_history.connection_id IN (
-                    SELECT connection_id
-                    FROM guacamole_connection
-                    WHERE POSITION(#{term.term,jdbcType=VARCHAR} IN connection_name) > 0
-                )
-
-                <if test="term.startDate != null and term.endDate != null">
-                    OR start_date BETWEEN #{term.startDate,jdbcType=TIMESTAMP} AND #{term.endDate,jdbcType=TIMESTAMP}
-                </if>
-
-            )
-        </foreach>
+            </foreach>
+        
+        </where>
 
         <!-- Bind sort property enum values for sake of readability -->
         <bind name="START_DATE"      value="@org.apache.guacamole.net.auth.ConnectionRecordSet$SortableProperty@START_DATE"/>

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/connection/ConnectionRecordMapper.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/org/apache/guacamole/auth/jdbc/connection/ConnectionRecordMapper.xml
@@ -98,28 +98,35 @@
         FROM guacamole_connection_history
 
         <!-- Search terms -->
-        <foreach collection="terms" item="term"
-                 open="WHERE " separator=" AND ">
-            (
+        <where>
+            
+            <if test="identifier != null">
+                guacamole_connection_history.connection_id = #{identifier,jdbcType=INTEGER}::integer
+            </if>
+            
+            <foreach collection="terms" item="term" open=" AND " separator=" AND ">
+                (
 
-                guacamole_connection_history.user_id IN (
-                    SELECT user_id
-                    FROM guacamole_user
-                    WHERE POSITION(#{term.term,jdbcType=VARCHAR} IN username) > 0
+                    guacamole_connection_history.user_id IN (
+                        SELECT user_id
+                        FROM guacamole_user
+                        WHERE POSITION(#{term.term,jdbcType=VARCHAR} IN username) > 0
+                    )
+
+                    OR guacamole_connection_history.connection_id IN (
+                        SELECT connection_id
+                        FROM guacamole_connection
+                        WHERE POSITION(#{term.term,jdbcType=VARCHAR} IN connection_name) > 0
+                    )
+
+                    <if test="term.startDate != null and term.endDate != null">
+                        OR start_date BETWEEN #{term.startDate,jdbcType=TIMESTAMP} AND #{term.endDate,jdbcType=TIMESTAMP}
+                    </if>
+
                 )
-
-                OR guacamole_connection_history.connection_id IN (
-                    SELECT connection_id
-                    FROM guacamole_connection
-                    WHERE POSITION(#{term.term,jdbcType=VARCHAR} IN connection_name) > 0
-                )
-
-                <if test="term.startDate != null and term.endDate != null">
-                    OR start_date BETWEEN #{term.startDate,jdbcType=TIMESTAMP} AND #{term.endDate,jdbcType=TIMESTAMP}
-                </if>
-
-            )
-        </foreach>
+            </foreach>
+            
+        </where>
 
         <!-- Bind sort property enum values for sake of readability -->
         <bind name="START_DATE"      value="@org.apache.guacamole.net.auth.ConnectionRecordSet$SortableProperty@START_DATE"/>
@@ -167,28 +174,35 @@
             AND guacamole_user_permission.permission = 'READ'
 
         <!-- Search terms -->
-        <foreach collection="terms" item="term"
-                 open="WHERE " separator=" AND ">
-            (
+        <where>
+            
+            <if test="identifier != null">
+                guacamole_connection_history.connection_id = #{identifier,jdbcType=INTEGER}::integer
+            </if>
+            
+            <foreach collection="terms" item="term" open=" AND " separator=" AND ">
+                (
 
-                guacamole_connection_history.user_id IN (
-                    SELECT user_id
-                    FROM guacamole_user
-                    WHERE POSITION(#{term.term,jdbcType=VARCHAR} IN username) > 0
+                    guacamole_connection_history.user_id IN (
+                        SELECT user_id
+                        FROM guacamole_user
+                        WHERE POSITION(#{term.term,jdbcType=VARCHAR} IN username) > 0
+                    )
+
+                    OR guacamole_connection_history.connection_id IN (
+                        SELECT connection_id
+                        FROM guacamole_connection
+                        WHERE POSITION(#{term.term,jdbcType=VARCHAR} IN connection_name) > 0
+                    )
+
+                    <if test="term.startDate != null and term.endDate != null">
+                        OR start_date BETWEEN #{term.startDate,jdbcType=TIMESTAMP} AND #{term.endDate,jdbcType=TIMESTAMP}
+                    </if>
+
                 )
+            </foreach>
 
-                OR guacamole_connection_history.connection_id IN (
-                    SELECT connection_id
-                    FROM guacamole_connection
-                    WHERE POSITION(#{term.term,jdbcType=VARCHAR} IN connection_name) > 0
-                )
-
-                <if test="term.startDate != null and term.endDate != null">
-                    OR start_date BETWEEN #{term.startDate,jdbcType=TIMESTAMP} AND #{term.endDate,jdbcType=TIMESTAMP}
-                </if>
-
-            )
-        </foreach>
+        </where>
 
         <!-- Bind sort property enum values for sake of readability -->
         <bind name="START_DATE"      value="@org.apache.guacamole.net.auth.ConnectionRecordSet$SortableProperty@START_DATE"/>


### PR DESCRIPTION
From [GLEN-262](https://jira.glyptodon.com/browse/GLEN-262):

> The database backends supported by Guacamole provide two ways of querying the connection history: a flexible, searchable query, and a query that simply retrieves all history records. As the latter is equivalent to the former with zero search criteria, upstream has combined these mechanisms for the sake of consistency and maintainability via [GUACAMOLE-1123](https://issues.apache.org/jira/browse/GUACAMOLE-1123). We should backport the same.

These changes are already on the `glyptodon/2.x` branch due to merge of all upstream 1.3.0 changes, but they need manual backporting for 1.x to maintain compatibility with 0.9.12-incubating.