### PR TITLE
GLEN-301: Correct version number suffixes of newly-reorganized projects.

### DIFF
--- a/extensions/guacamole-auth-cas/pom.xml
+++ b/extensions/guacamole-auth-cas/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-GLEN-2.4</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/extensions/guacamole-auth-duo/pom.xml
+++ b/extensions/guacamole-auth-duo/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-GLEN-2.4</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/extensions/guacamole-auth-header/pom.xml
+++ b/extensions/guacamole-auth-header/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-GLEN-2.4</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/extensions/guacamole-auth-jdbc/pom.xml
+++ b/extensions/guacamole-auth-jdbc/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-GLEN-2.4</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/extensions/guacamole-auth-json/pom.xml
+++ b/extensions/guacamole-auth-json/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-GLEN-2.4</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/extensions/guacamole-auth-ldap/pom.xml
+++ b/extensions/guacamole-auth-ldap/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-GLEN-2.4</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/extensions/guacamole-auth-openid/pom.xml
+++ b/extensions/guacamole-auth-openid/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-GLEN-2.4</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/extensions/guacamole-auth-quickconnect/pom.xml
+++ b/extensions/guacamole-auth-quickconnect/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-GLEN-2.4</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/extensions/guacamole-auth-radius/pom.xml
+++ b/extensions/guacamole-auth-radius/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-GLEN-2.4</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/extensions/guacamole-auth-saml/pom.xml
+++ b/extensions/guacamole-auth-saml/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-GLEN-2.4</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/extensions/guacamole-auth-totp/pom.xml
+++ b/extensions/guacamole-auth-totp/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-GLEN-2.4</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -26,14 +26,14 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>extensions</artifactId>
     <packaging>pom</packaging>
-    <version>1.3.0</version>
+    <version>1.3.0-GLEN-2.4</version>
     <name>extensions</name>
     <url>http://guacamole.apache.org/</url>
 
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-client</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-GLEN-2.4</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/guacamole-common-js/pom.xml
+++ b/guacamole-common-js/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-client</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-GLEN-2.4</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/guacamole-common/pom.xml
+++ b/guacamole-common/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-client</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-GLEN-2.4</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/guacamole-ext/pom.xml
+++ b/guacamole-ext/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-client</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-GLEN-2.4</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/guacamole/pom.xml
+++ b/guacamole/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-client</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-GLEN-2.4</version>
         <relativePath>../</relativePath>
     </parent>
 


### PR DESCRIPTION
The guacamole-client package build is currently failing due to parent POMs not properly resolving. This is because the parent POMs have not been updated to have the expected version suffixes, and thus can't be located at build time. This change adds the required suffixes.