### PR TITLE
GLEN-171: Update visible tiled connections only when actually changing.

### DIFF
--- a/guacamole/src/main/frontend/src/app/client/controllers/clientController.js
+++ b/guacamole/src/main/frontend/src/app/client/controllers/clientController.js
@@ -284,6 +284,10 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
      */
     const setAttachedGroup = function setAttachedGroup(managedClientGroup) {
 
+        // Do nothing if group is not actually changing
+        if ($scope.clientGroup === managedClientGroup)
+            return;
+
         if ($scope.clientGroup) {
 
             // Remove all disconnected clients from management (the user has


### PR DESCRIPTION
As with previous behavior, a disconnected/failed connections should only be removed from management when they are no longer present in the current view. Only when the user has fully navigated away from the current view should any disconnected/failed connections associated with that view be removed.